### PR TITLE
Fix CVF talker and improve documentation

### DIFF
--- a/examples/cvf/README.md
+++ b/examples/cvf/README.md
@@ -15,7 +15,7 @@ The easiest way to use this example is by combining it with a GStreamer pipeline
 
 ```
 $ cvf-listener <args> | gst-launch-1.0 filesrc location=/dev/stdin \
-  ! decodebin ! videoconvert ! autovideosink
+  ! h264parse ! avdec_h264 ! videoconvert ! autovideosink
 ```
 
 ## CVF Talker

--- a/examples/cvf/cvf-listener.c
+++ b/examples/cvf/cvf-listener.c
@@ -54,7 +54,7 @@
  * display, you can do something like:
  *
  * $ cvf-listener <args> | gst-launch-1.0 filesrc location=/dev/stdin \
- *  ! decodebin ! videoconvert ! autovideosink
+ *    ! h264parse ! avdec_h264 ! videoconvert ! autovideosink
  */
 
 #include <assert.h>

--- a/examples/cvf/cvf-talker.c
+++ b/examples/cvf/cvf-talker.c
@@ -141,6 +141,7 @@ static int init_pdu(Avtp_Cvf_t* cvf)
 {
     Avtp_Cvf_Init(cvf);
     Avtp_Cvf_SetField(cvf, AVTP_CVF_FIELD_FORMAT_SUBTYPE, AVTP_CVF_FORMAT_SUBTYPE_H264);
+    Avtp_Cvf_SetField(cvf, AVTP_CVF_FIELD_FORMAT, AVTP_CVF_FORMAT_RFC);
     Avtp_Cvf_SetField(cvf, AVTP_CVF_FIELD_TV, 1);
     Avtp_Cvf_SetField(cvf, AVTP_CVF_FIELD_STREAM_ID, STREAM_ID);
     Avtp_Cvf_SetField(cvf, AVTP_CVF_FIELD_M, 1);


### PR DESCRIPTION
PR solves following problems:

- CVF format field was not set to correct value causing CVF listener to discard frames
- Example GStreamer pipeline described in README and code documentation for CVF listener did not work as expected
