### PR TITLE
Modified CAN read/write to work with classical CAN

### DIFF
--- a/examples/acf-can/acf-can-common.h
+++ b/examples/acf-can/acf-can-common.h
@@ -29,4 +29,10 @@
 
 #include "avtp/acf/Can.h"
 
+/* CAN CC/FD frame union */
+typedef union {
+	struct can_frame cc;
+	struct canfd_frame fd;
+} frame_t;
+
 int setup_can_socket(const char* can_ifname, Avtp_CanVariant_t can_variant);


### PR DESCRIPTION
Fixed issue with write operation on the CAN socket. The operation expects 16 bytes of data when CAN_RAW_FD_FRAMES socket option is not set and 72 bytes with the flag set. This caused the application to fail without --fd flag as it always tries to write 72 bytes.