### PR TITLE
Add compile options for example applications and tests

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,6 +2,9 @@ cmake_minimum_required(VERSION 3.20)
 
 project(Open1722 VERSION 0.1)
 
+option(BUILD_TESTS "Build tests" ON)
+option(BUILD_EXAMPLES "Build tests" ON)
+
 set(CMAKE_C_STANDARD 99)
 set(CMAKE_C_STANDARD_REQUIRED TRUE)
 
@@ -38,95 +41,102 @@ target_include_directories(open1722 PRIVATE
 
 #### Examples #################################################################
 
-# Common library accross all examples
-add_library(open1722examples STATIC "examples/common/common.c")
-target_include_directories(open1722examples PRIVATE "examples" "include")
+if (BUILD_EXAMPLES)
+    # Common library accross all examples
+    add_library(open1722examples STATIC "examples/common/common.c")
+    target_include_directories(open1722examples PRIVATE "examples" "include")
 
-# AAF listener app
-add_executable(aaf-listener "examples/aaf/aaf-listener.c")
-target_include_directories(aaf-listener PRIVATE "examples" "include")
-target_link_libraries(aaf-listener open1722 open1722examples)
+    # AAF listener app
+    add_executable(aaf-listener "examples/aaf/aaf-listener.c")
+    target_include_directories(aaf-listener PRIVATE "examples" "include")
+    target_link_libraries(aaf-listener open1722 open1722examples)
 
-# AAF talker app
-add_executable(aaf-talker "examples/aaf/aaf-talker.c")
-target_include_directories(aaf-talker PRIVATE "examples" "include")
-target_link_libraries(aaf-talker open1722 open1722examples)
+    # AAF talker app
+    add_executable(aaf-talker "examples/aaf/aaf-talker.c")
+    target_include_directories(aaf-talker PRIVATE "examples" "include")
+    target_link_libraries(aaf-talker open1722 open1722examples)
 
-# CAN talker app
-add_executable(acf-can-talker "examples/acf-can/acf-can-talker.c" "examples/acf-can/acf-can-common.c")
-target_include_directories(acf-can-talker PRIVATE "examples" "include")
-target_link_libraries(acf-can-talker open1722 open1722examples)
+    # CAN talker app
+    add_executable(acf-can-talker "examples/acf-can/acf-can-talker.c" "examples/acf-can/acf-can-common.c")
+    target_include_directories(acf-can-talker PRIVATE "examples" "include")
+    target_link_libraries(acf-can-talker open1722 open1722examples)
 
-# CAN listener app
-add_executable(acf-can-listener "examples/acf-can/acf-can-listener.c" "examples/acf-can/acf-can-common.c")
-target_include_directories(acf-can-listener PRIVATE "examples" "include")
-target_link_libraries(acf-can-listener open1722 open1722examples)
+    # CAN listener app
+    add_executable(acf-can-listener "examples/acf-can/acf-can-listener.c" "examples/acf-can/acf-can-common.c")
+    target_include_directories(acf-can-listener PRIVATE "examples" "include")
+    target_link_libraries(acf-can-listener open1722 open1722examples)
 
-# CRF talker app
-add_executable(crf-talker "examples/crf/crf-talker.c")
-target_include_directories(crf-talker PRIVATE "examples" "include")
-target_link_libraries(crf-talker open1722 open1722examples m)
+    # CRF talker app
+    add_executable(crf-talker "examples/crf/crf-talker.c")
+    target_include_directories(crf-talker PRIVATE "examples" "include")
+    target_link_libraries(crf-talker open1722 open1722examples m)
 
-# CRF listener app
-add_executable(crf-listener "examples/crf/crf-listener.c")
-target_include_directories(crf-listener PRIVATE "examples" "include")
-target_link_libraries(crf-listener open1722 open1722examples m)
+    # CRF listener app
+    add_executable(crf-listener "examples/crf/crf-listener.c")
+    target_include_directories(crf-listener PRIVATE "examples" "include")
+    target_link_libraries(crf-listener open1722 open1722examples m)
 
-# CVF talker app
-add_executable(cvf-talker "examples/cvf/cvf-talker.c")
-target_include_directories(cvf-talker PRIVATE "examples" "include")
-target_link_libraries(cvf-talker open1722 open1722examples)
+    # CVF talker app
+    add_executable(cvf-talker "examples/cvf/cvf-talker.c")
+    target_include_directories(cvf-talker PRIVATE "examples" "include")
+    target_link_libraries(cvf-talker open1722 open1722examples)
 
-# CVF listener app
-add_executable(cvf-listener "examples/cvf/cvf-listener.c")
-target_include_directories(cvf-listener PRIVATE "examples" "include")
-target_link_libraries(cvf-listener open1722 open1722examples)
+    # CVF listener app
+    add_executable(cvf-listener "examples/cvf/cvf-listener.c")
+    target_include_directories(cvf-listener PRIVATE "examples" "include")
+    target_link_libraries(cvf-listener open1722 open1722examples)
 
-# Hello-world talker app
-add_executable(hello-world-talker "examples/hello-world/hello-world-talker.c")
-target_include_directories(hello-world-talker PRIVATE "examples" "include")
-target_link_libraries(hello-world-talker open1722 open1722examples)
+    # Hello-world talker app
+    add_executable(hello-world-talker "examples/hello-world/hello-world-talker.c")
+    target_include_directories(hello-world-talker PRIVATE "examples" "include")
+    target_link_libraries(hello-world-talker open1722 open1722examples)
 
-# Hello-world listener app
-add_executable(hello-world-listener "examples/hello-world/hello-world-listener.c")
-target_include_directories(hello-world-listener PRIVATE "examples" "include")
-target_link_libraries(hello-world-listener open1722 open1722examples)
+    # Hello-world listener app
+    add_executable(hello-world-listener "examples/hello-world/hello-world-listener.c")
+    target_include_directories(hello-world-listener PRIVATE "examples" "include")
+    target_link_libraries(hello-world-listener open1722 open1722examples)
+endif()
 
 #### Tests ####################################################################
 
-enable_testing()
+if (BUILD_TESTS)
+    enable_testing()
 
-# find_package(cmocka 1.1.0 REQUIRED)
+    # find_package(cmocka 1.1.0 REQUIRED)
 
-list(APPEND TEST_TARGETS test-aaf)
-list(APPEND TEST_TARGETS test-avtp)
-list(APPEND TEST_TARGETS test-can)
-list(APPEND TEST_TARGETS test-crf)
-list(APPEND TEST_TARGETS test-cvf)
-list(APPEND TEST_TARGETS test-rvf)
-# list(APPEND TEST_TARGETS test-stream)
+    list(APPEND TEST_TARGETS test-aaf)
+    list(APPEND TEST_TARGETS test-avtp)
+    list(APPEND TEST_TARGETS test-can)
+    list(APPEND TEST_TARGETS test-crf)
+    list(APPEND TEST_TARGETS test-cvf)
+    list(APPEND TEST_TARGETS test-rvf)
+    # list(APPEND TEST_TARGETS test-stream)
 
-foreach(TEST_TARGET IN LISTS TEST_TARGETS)
-    add_executable(${TEST_TARGET} "unit/${TEST_TARGET}.c")
-    target_include_directories(${TEST_TARGET} PRIVATE "include")
-    target_link_libraries(${TEST_TARGET} open1722 cmocka m)
-    add_test(NAME ${TEST_TARGET} COMMAND "${PROJECT_BINARY_DIR}/${TEST_TARGET}")
-endforeach()
+    foreach(TEST_TARGET IN LISTS TEST_TARGETS)
+        add_executable(${TEST_TARGET} "unit/${TEST_TARGET}.c")
+        target_include_directories(${TEST_TARGET} PRIVATE "include")
+        target_link_libraries(${TEST_TARGET} open1722 cmocka m)
+        add_test(NAME ${TEST_TARGET} COMMAND "${PROJECT_BINARY_DIR}/${TEST_TARGET}")
+    endforeach()
+endif()
 
 #### Install ##################################################################
 
 install(TARGETS open1722 EXPORT Open1722Targets DESTINATION lib)
-install(TARGETS
-    aaf-listener
-    aaf-talker
-    acf-can-listener
-    acf-can-talker
-    crf-listener
-    crf-talker
-    cvf-listener
-    cvf-talker
-    DESTINATION bin)
 install(DIRECTORY "include/" DESTINATION include)
+
+if (BUILD_EXAMPLES)
+    install(TARGETS
+        aaf-listener
+        aaf-talker
+        acf-can-listener
+        acf-can-talker
+        crf-listener
+        crf-talker
+        cvf-listener
+        cvf-talker
+        DESTINATION bin)
+endif()
 
 #### Export Configuration #####################################################
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,15 +2,16 @@ cmake_minimum_required(VERSION 3.20)
 
 project(Open1722 VERSION 0.1)
 
-option(BUILD_TESTS "Build tests" ON)
-option(BUILD_EXAMPLES "Build tests" ON)
+option(OPEN1722_BUILD_TESTS "Build tests" OFF)
+option(OPEN1722_BUILD_EXAMPLES "Build tests" OFF)
+option(BUILD_SHARED_LIBS "Build using shared libraries" ON)
 
 set(CMAKE_C_STANDARD 99)
 set(CMAKE_C_STANDARD_REQUIRED TRUE)
 
 #### Libraries ################################################################
 
-add_library(open1722 SHARED
+set(SOURCES
     "src/avtp/CommonHeader.c"
     "src/avtp/Crf.c"
     "src/avtp/Rvf.c"
@@ -32,7 +33,15 @@ add_library(open1722 SHARED
     "src/avtp/cvf/Cvf.c"
     "src/avtp/cvf/H264.c"
     "src/avtp/cvf/Jpeg2000.c"
-    "src/avtp/cvf/Mjpeg.c")
+    "src/avtp/cvf/Mjpeg.c"
+)
+
+if(BUILD_SHARED_LIBS)
+    add_library(open1722 SHARED ${SOURCES})
+else()
+    add_library(open1722 STATIC ${SOURCES})
+endif()
+
 set_target_properties(open1722 PROPERTIES VERSION ${PROJECT_VERSION})
 
 target_include_directories(open1722 PRIVATE
@@ -41,7 +50,7 @@ target_include_directories(open1722 PRIVATE
 
 #### Examples #################################################################
 
-if (BUILD_EXAMPLES)
+if (OPEN1722_BUILD_EXAMPLES)
     # Common library accross all examples
     add_library(open1722examples STATIC "examples/common/common.c")
     target_include_directories(open1722examples PRIVATE "examples" "include")
@@ -99,7 +108,7 @@ endif()
 
 #### Tests ####################################################################
 
-if (BUILD_TESTS)
+if (OPEN1722_BUILD_TESTS)
     enable_testing()
 
     # find_package(cmocka 1.1.0 REQUIRED)
@@ -125,7 +134,7 @@ endif()
 install(TARGETS open1722 EXPORT Open1722Targets DESTINATION lib)
 install(DIRECTORY "include/" DESTINATION include)
 
-if (BUILD_EXAMPLES)
+if (OPEN1722_BUILD_EXAMPLES)
     install(TARGETS
         aaf-listener
         aaf-talker

--- a/README.md
+++ b/README.md
@@ -61,6 +61,11 @@ $ cmake ..
 $ make
 ```
 
+On default, the example applications and tests are build. It's also possible to disable building examples or tests as shown below. This can be useful to cross-compile Open1722 for microcontrollers.
+```
+$ cmake -DBUILD_TESTS=off -DBUILD_EXAMPLES=off
+```
+
 The build can be cleaned using the following command:
 ```
 $ make clean

--- a/README.md
+++ b/README.md
@@ -53,17 +53,17 @@ Before building Open1722 make sure you have installed the following software :
 
 Alternatively, you can use VS Code to run the provided dev container which takes care of the dependencies.
 
-The first step to build Open1722 is to generate the Makefile and build the project.
+The first step to build Open1722 is to generate the Makefile and build the project (including example applications and tests).
 ```
 $ mkdir build
 $ cd buid
-$ cmake ..
+$ cmake -DOPEN1722_BUILD_TESTS=ON -DOPEN1722_BUILD_EXAMPLES=ON ..
 $ make
 ```
 
-On default, the example applications and tests are build. It's also possible to disable building examples or tests as shown below. This can be useful to cross-compile Open1722 for microcontrollers.
+To build a static library you need to pass the following parameter to CMake
 ```
-$ cmake -DBUILD_TESTS=off -DBUILD_EXAMPLES=off
+$ cmake -DBUILD_SHARED_LIBS=OFF
 ```
 
 The build can be cleaned using the following command:

--- a/build_all.sh
+++ b/build_all.sh
@@ -4,5 +4,5 @@ set -ev
 rm -rf build
 mkdir build
 cd build
-cmake ..
+cmake -DOPEN1722_BUILD_TESTS=ON -DOPEN1722_BUILD_EXAMPLES=ON ..
 make -j`nproc`


### PR DESCRIPTION
Default build is now without example applications and tests. They must be enabled explicitely

```
cmake -DOPEN1722_BUILD_TESTS=ON -DOPEN1722_BUILD_EXAMPLES=ON <open1722-directory>
```

It's now also possible to choose whether to build a static or dynamic library using CMake's `BUILD_SHARED_LIBS` variable. A static library can be build like this:

```
cmake -BUILD_SHARED_LIBS=OFF <open1722-directory>
```

The last CMake command shown (no tests, examples and static lib) can be used to cross-compile for microcontrollers. In a Zephyr project you can simply add the following snippet to the CMakeLists.txt to include Open1722 (make sure to set a valid commit ID or tag)

```
include(FetchContent)
FetchContent_Declare(open1722
    GIT_REPOSITORY git@github.com:COVESA/Open1722.git
    GIT_TAG <tag or commit ID>
FetchContent_MakeAvailable(open1722)
```