### PR TITLE
Fix build problems in absence of cmocka

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -96,22 +96,27 @@ target_link_libraries(hello-world-listener open1722 open1722examples)
 
 enable_testing()
 
-# find_package(cmocka 1.1.0 REQUIRED)
+if (UNIT_TESTING)
 
-list(APPEND TEST_TARGETS test-aaf)
-list(APPEND TEST_TARGETS test-avtp)
-list(APPEND TEST_TARGETS test-can)
-list(APPEND TEST_TARGETS test-crf)
-list(APPEND TEST_TARGETS test-cvf)
-list(APPEND TEST_TARGETS test-rvf)
-# list(APPEND TEST_TARGETS test-stream)
+    find_package(cmocka 1.1.0 REQUIRED)
 
-foreach(TEST_TARGET IN LISTS TEST_TARGETS)
-    add_executable(${TEST_TARGET} "unit/${TEST_TARGET}.c")
-    target_include_directories(${TEST_TARGET} PRIVATE "include")
-    target_link_libraries(${TEST_TARGET} open1722 cmocka m)
-    add_test(NAME ${TEST_TARGET} COMMAND "${PROJECT_BINARY_DIR}/${TEST_TARGET}")
-endforeach()
+    if (cmocka_FOUND)
+        list(APPEND TEST_TARGETS test-aaf)
+        list(APPEND TEST_TARGETS test-avtp)
+        list(APPEND TEST_TARGETS test-can)
+        list(APPEND TEST_TARGETS test-crf)
+        list(APPEND TEST_TARGETS test-cvf)
+        list(APPEND TEST_TARGETS test-rvf)
+
+        foreach(TEST_TARGET IN LISTS TEST_TARGETS)
+            add_executable(${TEST_TARGET} "unit/${TEST_TARGET}.c")
+            target_include_directories(${TEST_TARGET} PRIVATE "include")
+            target_link_libraries(${TEST_TARGET} open1722 cmocka m)
+            add_test(NAME ${TEST_TARGET} COMMAND "${PROJECT_BINARY_DIR}/${TEST_TARGET}")
+        endforeach()
+    endif(cmocka_FOUND)
+endif(UNIT_TESTING)
+
 
 #### Install ##################################################################
 

--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ This repository is organized as follows:
 
 Before building Open1722 make sure you have installed the following software :
 * CMake >= 3.20
-* CMocka >= 1.1.0
+* CMocka >= 1.1.0 (For running unit tests. This can be installed on Debian/Ubuntu using ```sudo apt install libcmocka-dev```)
 
 Alternatively, you can use VS Code to run the provided dev container which takes care of the dependencies.
 
@@ -58,6 +58,12 @@ The first step to build Open1722 is to generate the Makefile and build the proje
 $ mkdir build
 $ cd buid
 $ cmake ..
+$ make
+```
+
+To execute available unit tests, set the Cmake variable UNIT_TESTING.
+```
+$ cmake .. -DUNIT_TESTING=on
 $ make
 ```
 

--- a/test_all.sh
+++ b/test_all.sh
@@ -1,7 +1,9 @@
-#!/bin/bash 
-set -ev 
+#!/bin/bash
+set -ev
 
-./build_all.sh
+rm -rf build
+mkdir build
 cd build
+cmake .. -DUNIT_TESTING=on
+make -j`nproc`
 make test
-# ninja coverage-html


### PR DESCRIPTION
Updated CMake build to selectively build unit tests and check for availability of cmocka library.