### PR TITLE
Fix boolean convenience setters for ACF-CAN

### DIFF
--- a/include/avtp/acf/Can.h
+++ b/include/avtp/acf/Can.h
@@ -119,9 +119,9 @@ void Avtp_Can_SetField(Avtp_Can_t* can_pdu, Avtp_CanFields_t field, uint64_t val
 void Avtp_Can_SetAcfMsgType(Avtp_Can_t* pdu, uint8_t value);
 void Avtp_Can_SetAcfMsgLength(Avtp_Can_t* pdu, uint16_t value);
 void Avtp_Can_SetPad(Avtp_Can_t* pdu, uint8_t value);
-void Avtp_Can_SetMtv(Avtp_Can_t* pdu, uint8_t value);
-void Avtp_Can_SetRtr(Avtp_Can_t* pdu, uint8_t value);
-void Avtp_Can_SetEff(Avtp_Can_t* pdu, uint8_t value);
+void Avtp_Can_SetMtv(Avtp_Can_t* pdu, uint64_t value);
+void Avtp_Can_SetRtr(Avtp_Can_t* pdu, uint32_t value);
+void Avtp_Can_SetEff(Avtp_Can_t* pdu, uint32_t value);
 void Avtp_Can_SetBrs(Avtp_Can_t* pdu, uint8_t value);
 void Avtp_Can_SetFdf(Avtp_Can_t* pdu, uint8_t value);
 void Avtp_Can_SetEsi(Avtp_Can_t* pdu, uint8_t value);

--- a/src/avtp/acf/Can.c
+++ b/src/avtp/acf/Can.c
@@ -153,34 +153,58 @@ void Avtp_Can_SetPad(Avtp_Can_t* pdu, uint8_t value)
     SET_FIELD(AVTP_CAN_FIELD_PAD, value);
 }
 
-void Avtp_Can_SetMtv(Avtp_Can_t* pdu, uint8_t value)
+void Avtp_Can_SetMtv(Avtp_Can_t* pdu, uint64_t value)
 {
-    SET_FIELD(AVTP_CAN_FIELD_MTV, value);
+    if (value) {
+        SET_FIELD(AVTP_CAN_FIELD_MTV, 1);
+    } else {
+        SET_FIELD(AVTP_CAN_FIELD_MTV, 0);
+    }
 }
 
-void Avtp_Can_SetRtr(Avtp_Can_t* pdu, uint8_t value)
+void Avtp_Can_SetRtr(Avtp_Can_t* pdu, uint32_t value)
 {
-    SET_FIELD(AVTP_CAN_FIELD_RTR, value);
+    if (value) {
+        SET_FIELD(AVTP_CAN_FIELD_RTR, 1);
+    } else {
+        SET_FIELD(AVTP_CAN_FIELD_RTR, 0);
+    }
 }
 
-void Avtp_Can_SetEff(Avtp_Can_t* pdu, uint8_t value)
+void Avtp_Can_SetEff(Avtp_Can_t* pdu, uint32_t value)
 {
-    SET_FIELD(AVTP_CAN_FIELD_EFF, value);
+    if (value) {
+        SET_FIELD(AVTP_CAN_FIELD_EFF, 1);
+    } else {
+        SET_FIELD(AVTP_CAN_FIELD_EFF, 0);
+    }
 }
 
 void Avtp_Can_SetBrs(Avtp_Can_t* pdu, uint8_t value)
 {
-    SET_FIELD(AVTP_CAN_FIELD_BRS, value);
+    if (value) {
+        SET_FIELD(AVTP_CAN_FIELD_BRS, 1);
+    } else {
+        SET_FIELD(AVTP_CAN_FIELD_BRS, 0);
+    }
 }
 
 void Avtp_Can_SetFdf(Avtp_Can_t* pdu, uint8_t value)
 {
-    SET_FIELD(AVTP_CAN_FIELD_FDF, value);
+    if (value) {
+        SET_FIELD(AVTP_CAN_FIELD_FDF, 1);
+    } else {
+        SET_FIELD(AVTP_CAN_FIELD_FDF, 0);
+    }
 }
 
 void Avtp_Can_SetEsi(Avtp_Can_t* pdu, uint8_t value)
 {
-    SET_FIELD(AVTP_CAN_FIELD_ESI, value);
+    if (value) {
+        SET_FIELD(AVTP_CAN_FIELD_ESI, 1);
+    } else {
+        SET_FIELD(AVTP_CAN_FIELD_ESI, 0);
+    }
 }
 
 void Avtp_Can_SetCanBusId(Avtp_Can_t* pdu, uint8_t value)


### PR DESCRIPTION
This fixes #66  for ACF-CAN.

Choice of input  datatypes:

 - mtv: 64 bit, this is the save choice and the underlying functions are 64 bit anyway
 - rtr/eff: these are related to a can id, which at most is 29 bit, and mostly the flags are included with, e.g. in `can_frame` in Linux wich is 32 bit
 - FD related flags: BRS/FDF: 8 bit input. in Linux those are in an uint8 field in the `canfd_frame` struct