### PR TITLE
Fixed seg faults in CAN apps due to missing break.

### DIFF
--- a/examples/acf-can/acf-can-bridge.c
+++ b/examples/acf-can/acf-can-bridge.c
@@ -118,6 +118,7 @@ static error_t parser(int key, char *arg, struct argp_state *state)
         break;
     case ARGPARSE_CAN_FD_OPTION:
         can_variant = AVTP_CAN_FD;
+        break;
     case ARGPARSE_CAN_IF_OPTION:
         strncpy(can_ifname, arg, sizeof(can_ifname) - 1);
         break;

--- a/examples/acf-can/acf-can-listener.c
+++ b/examples/acf-can/acf-can-listener.c
@@ -93,6 +93,7 @@ static error_t parser(int key, char *arg, struct argp_state *state)
         break;
     case ARGPARSE_CAN_FD_OPTION:
         can_variant = AVTP_CAN_FD;
+        break;
     case ARGPARSE_CAN_IF_OPTION:
         strncpy(can_ifname, arg, sizeof(can_ifname) - 1);
         break;


### PR DESCRIPTION
Missing break in switch case for argument parsing resulted in #68. This PR should fix it.