### PR TITLE
Bugfix/length check

### DIFF
--- a/examples/acf-can/acf-can-common.c
+++ b/examples/acf-can/acf-can-common.c
@@ -271,16 +271,16 @@ int avtp_to_can(uint8_t* pdu, frame_t* can_frames, Avtp_CanVariant_t can_variant
         return -1;
     }
 
+    // Check for stream id
+    if (s_id != stream_id) {
+        return -1;
+    }
+
     // Check sequence numbers.
     if (seq_num != *exp_cf_seqnum) {
         printf("Incorrect sequence num. Expected: %d Recd.: %d\n",
                                             *exp_cf_seqnum, seq_num);
         *exp_cf_seqnum = seq_num;
-    }
-
-    // Check for stream id
-    if (s_id != stream_id) {
-        return -1;
     }
 
     while (proc_bytes < msg_length) {

--- a/examples/acf-can/acf-can-common.h
+++ b/examples/acf-can/acf-can-common.h
@@ -77,7 +77,6 @@ int setup_can_socket(const char* can_ifname, Avtp_CanVariant_t can_variant);
  * Function that converts AVTP Frames to CAN
  *
  * @param pdu: Start of the AVTP Frame
- * @param pdu_length: Length of the read PDU
  * @param can_frames: Array of CAM Frames to be recovered from AVTP Frames
  * @param can_variant: AVTP_CAN_CLASSIC or AVTP_CAN_FD
  * @param use_udp 1: UDP encapsulation, 0: Ethernet
@@ -86,9 +85,9 @@ int setup_can_socket(const char* can_ifname, Avtp_CanVariant_t can_variant);
  * @param exp_udp_seqnum: Expected UDP Encapsulation sequence num.
  * @return Number of CAN messages received
  */
-int avtp_to_can(uint8_t* pdu, uint16_t pdu_length, frame_t* can_frames,
-                Avtp_CanVariant_t can_variant, int use_udp, uint64_t stream_id,
-                uint8_t* exp_cf_seqnum, uint32_t* exp_udp_seqnum);
+int avtp_to_can(uint8_t* pdu, frame_t* can_frames, Avtp_CanVariant_t can_variant,
+                int use_udp, uint64_t stream_id, uint8_t* exp_cf_seqnum,
+                uint32_t* exp_udp_seqnum);
 
 /**
  * Function that converts AVTP Frames to CAN

--- a/examples/acf-can/linux/acf-can-bridge.c
+++ b/examples/acf-can/linux/acf-can-bridge.c
@@ -151,10 +151,18 @@ static error_t parser(int key, char *arg, struct argp_state *state)
         }
         break;
     case ARGPARSE_LISTENER_ID_OPTION:
-        listener_stream_id = atoi(arg);
+        res = sscanf(arg, "%lx", &listener_stream_id);
+        if (res != 1) {
+            fprintf(stderr, "Invalid talker stream id\n");
+            exit(EXIT_FAILURE);
+        }
         break;
     case ARGPARSE_TALKER_ID_OPTION:
-        talker_stream_id = atoi(arg);
+        res = sscanf(arg, "%lx", &talker_stream_id);
+        if (res != 1) {
+            fprintf(stderr, "Invalid talker stream id\n");
+            exit(EXIT_FAILURE);
+        }
         break;
     }
 
@@ -281,7 +289,7 @@ int main(int argc, char *argv[])
     } else {
         printf("\tUsing Ethernet\n");
         printf("\tNetwork Interface: %s\n", ifname);
-        printf("\tDestination MAC Address: %x:%x:%x:%x:%x:%x\n", macaddr[0], macaddr[1], macaddr[2],
+        printf("\tDestination MAC Address: %02x:%02x:%02x:%02x:%02x:%02x\n", macaddr[0], macaddr[1], macaddr[2],
                                                         macaddr[3], macaddr[4], macaddr[5]);
     }
     printf("\tListener Stream ID: %lx, Talker Stream ID: %lx\n", listener_stream_id, talker_stream_id);

--- a/examples/acf-can/linux/acf-can-bridge.c
+++ b/examples/acf-can/linux/acf-can-bridge.c
@@ -216,7 +216,7 @@ void* can_to_avtp_runnable(void* args) {
 void* avtp_to_can_runnable(void* args) {
 
     uint16_t pdu_length = 0, cf_length = 0;
-    uint8_t num_can_msgs = 0;
+    int8_t num_can_msgs = 0;
     uint8_t exp_cf_seqnum = 0;
     uint32_t exp_udp_seqnum = 0;
     uint8_t pdu[MAX_ETH_PDU_SIZE];
@@ -233,10 +233,13 @@ void* avtp_to_can_runnable(void* args) {
 
         num_can_msgs = avtp_to_can(pdu, can_frames, can_variant, use_udp,
                              listener_stream_id, &exp_cf_seqnum, &exp_udp_seqnum);
+        if (num_can_msgs <= 0) {
+            continue;
+        }
         exp_cf_seqnum++;
         exp_udp_seqnum++;
 
-        for (int i = 0; i < num_can_msgs; i++) {
+        for (int8_t i = 0; i < num_can_msgs; i++) {
             int res;
             if (can_variant == AVTP_CAN_FD)
                 res = write(can_socket, &can_frames[i].fd, sizeof(struct canfd_frame));
@@ -246,7 +249,6 @@ void* avtp_to_can_runnable(void* args) {
             if(res < 0)
             {
                 perror("Failed to write to CAN bus");
-                continue;
             }
         }
     }

--- a/examples/acf-can/linux/acf-can-bridge.c
+++ b/examples/acf-can/linux/acf-can-bridge.c
@@ -231,7 +231,7 @@ void* avtp_to_can_runnable(void* args) {
             continue;
         }
 
-        num_can_msgs = avtp_to_can(pdu, pdu_length, can_frames, can_variant, use_udp,
+        num_can_msgs = avtp_to_can(pdu, can_frames, can_variant, use_udp,
                              listener_stream_id, &exp_cf_seqnum, &exp_udp_seqnum);
         exp_cf_seqnum++;
         exp_udp_seqnum++;

--- a/examples/acf-can/linux/acf-can-listener.c
+++ b/examples/acf-can/linux/acf-can-listener.c
@@ -110,7 +110,11 @@ static error_t parser(int key, char *arg, struct argp_state *state)
         }
         break;
     case ARGPARSE_LISTENER_ID_OPTION:
-        listener_stream_id = atoi(arg);
+        res = sscanf(arg, "%lx", &listener_stream_id);
+        if (res != 1) {
+            fprintf(stderr, "Invalid talker stream id\n");
+            exit(EXIT_FAILURE);
+        }
         break;
     }
 

--- a/examples/acf-can/linux/acf-can-listener.c
+++ b/examples/acf-can/linux/acf-can-listener.c
@@ -171,7 +171,7 @@ int main(int argc, char *argv[])
             continue;
         }
 
-        num_can_msgs = avtp_to_can(pdu, pdu_length, can_frames, can_variant, use_udp,
+        num_can_msgs = avtp_to_can(pdu, can_frames, can_variant, use_udp,
                              listener_stream_id, &exp_cf_seqnum, &exp_udp_seqnum);
         exp_cf_seqnum++;
         exp_udp_seqnum++;

--- a/examples/acf-can/linux/acf-can-talker.c
+++ b/examples/acf-can/linux/acf-can-talker.c
@@ -131,7 +131,11 @@ static error_t parser(int key, char *arg, struct argp_state *state)
         }
         break;
     case ARGPARSE_TALKER_ID_OPTION:
-        talker_stream_id = atoi(arg);
+        res = sscanf(arg, "%lx", &talker_stream_id);
+        if (res != 1) {
+            fprintf(stderr, "Invalid talker stream id\n");
+            exit(EXIT_FAILURE);
+        }
         break;
     }
 
@@ -169,7 +173,7 @@ int main(int argc, char *argv[])
     } else {
         printf("\tUsing Ethernet\n");
         printf("\tNetwork Interface: %s\n", ifname);
-        printf("\tDestination MAC Address: %x:%x:%x:%x:%x:%x\n", macaddr[0], macaddr[1], macaddr[2],
+        printf("\tDestination MAC Address: %02x:%02x:%02x:%02x:%02x:%02x\n", macaddr[0], macaddr[1], macaddr[2],
                                                         macaddr[3], macaddr[4], macaddr[5]);
     }
     printf("\tTalker Stream ID: %lx\n", talker_stream_id);

--- a/examples/acf-can/zephyr/acf-can-bridge.c
+++ b/examples/acf-can/zephyr/acf-can-bridge.c
@@ -305,7 +305,7 @@ void avtp_to_can_runnable(void* p1, void* p2, void* p3) {
 
         for (int8_t i = 0; i < num_can_msgs; i++) {
             int res;
-            res = can_send(can_dev, &(can_frames[i].cc), K_MSEC(1), NULL, NULL);
+            res = can_send(can_dev, &(can_frames[i].cc), K_NO_WAIT, NULL, NULL);
             if(res < 0)
             {
                 perror("Failed to write to CAN bus");

--- a/examples/acf-can/zephyr/acf-can-bridge.c
+++ b/examples/acf-can/zephyr/acf-can-bridge.c
@@ -311,7 +311,7 @@ void* avtp_to_can_runnable(void* p1, void* p2, void* p3) {
             continue;
         }
 
-        num_can_msgs = avtp_to_can(pdu, pdu_length, can_frames, can_variant, use_udp,
+        num_can_msgs = avtp_to_can(pdu, can_frames, can_variant, use_udp,
                              listener_stream_id, &exp_cf_seqnum, &exp_udp_seqnum);
         exp_cf_seqnum++;
         exp_udp_seqnum++;


### PR DESCRIPTION
This PR should variety of minor bugs in acf-can applications.

1. Parsing of stream IDs
2. Printing of MAC Addresses while starting
3. Parsing of AVTP frames limited to the length of AVTP packet. Previously padded Ethernet bytes also got parsed which led to invalid CAN frames put on the bus.
4. Zephyr bridge refactored to start the threads though a function immediately instead of through a macro after a waiting time of 5 seconds.