### PR TITLE
Fix streamid print in examples  to make clear it is hex

### DIFF
--- a/examples/acf-can/linux/acf-can-bridge.c
+++ b/examples/acf-can/linux/acf-can-bridge.c
@@ -292,7 +292,7 @@ int main(int argc, char *argv[])
         printf("\tDestination MAC Address: %02x:%02x:%02x:%02x:%02x:%02x\n", macaddr[0], macaddr[1], macaddr[2],
                                                         macaddr[3], macaddr[4], macaddr[5]);
     }
-    printf("\tListener Stream ID: %lx, Talker Stream ID: %lx\n", listener_stream_id, talker_stream_id);
+    printf("\tListener Stream ID: 0x%lx, Talker Stream ID: 0x%lx\n", listener_stream_id, talker_stream_id);
     printf("\tNumber of ACF messages per AVTP frame in talker stream: %d\n", num_acf_msgs);
 
     // Create an appropriate sockets: UDP or Ethernet raw

--- a/examples/acf-can/linux/acf-can-listener.c
+++ b/examples/acf-can/linux/acf-can-listener.c
@@ -150,7 +150,7 @@ int main(int argc, char *argv[])
         printf("\tUsing Ethernet\n");
         printf("\tNetwork Interface: %s\n", ifname);
     }
-    printf("\tListener Stream ID: %lx\n", listener_stream_id);
+    printf("\tListener Stream ID: 0x%lx\n", listener_stream_id);
 
     // Configure an appropriate socket: UDP or Ethernet Raw
     if (use_udp) {

--- a/examples/acf-can/linux/acf-can-talker.c
+++ b/examples/acf-can/linux/acf-can-talker.c
@@ -176,7 +176,7 @@ int main(int argc, char *argv[])
         printf("\tDestination MAC Address: %02x:%02x:%02x:%02x:%02x:%02x\n", macaddr[0], macaddr[1], macaddr[2],
                                                         macaddr[3], macaddr[4], macaddr[5]);
     }
-    printf("\tTalker Stream ID: %lx\n", talker_stream_id);
+    printf("\tTalker Stream ID: 0x%lx\n", talker_stream_id);
     printf("\tNumber of ACF messages per AVTP frame in talker stream: %d\n", num_acf_msgs);
 
     // Create an appropriate talker socket: UDP or Ethernet raw

--- a/examples/acf-can/zephyr/acf-can-bridge.c
+++ b/examples/acf-can/zephyr/acf-can-bridge.c
@@ -352,7 +352,7 @@ int main(void)
         printf("\tDestination MAC Address: %02x:%02x:%02x:%02x:%02x:%02x\n", macaddr[0], macaddr[1], macaddr[2],
                                                         macaddr[3], macaddr[4], macaddr[5]);
     }
-    printf("\tListener Stream ID: %llx, Talker Stream ID: %llx\n", listener_stream_id, talker_stream_id);
+    printf("\tListener Stream ID: 0x%llx, Talker Stream ID: 0x%llx\n", listener_stream_id, talker_stream_id);
     printf("\tNumber of ACF messages per AVTP frame in talker stream: %d\n", num_acf_msgs);
 
     // Open a CAN socket for reading frames


### PR DESCRIPTION
Before

```
./acf-can-talker -i mon2 -d 16:93:3e:b3:5d:07 --canif vcan0 --stream-id=3735928559 --fd
acf-talker-configuration:
	Using NTSCF
	Using CAN FD interface: vcan0
	Using Ethernet
	Network Interface: mon2
	Destination MAC Address: 16:93:3e:b3:5d:07
	Talker Stream ID: 3735928559
	Number of ACF messages per AVTP frame in talker stream: 1
```

after

```
./acf-can-talker -i mon2 -d 16:93:3e:b3:5d:07 --canif vcan0 --stream-id=3735928559 --fd
...
	Talker Stream ID: 0x3735928559
...
```

which is better, because in the example the actual stream id is  237121996121 (`0x3735928559`)