### PR TITLE
Allow installation of examples if they are built.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -70,7 +70,7 @@ endif()
 
 add_subdirectory(src)
 add_custom_target(examples)
-add_subdirectory(examples EXCLUDE_FROM_ALL)
+add_subdirectory(examples)
 
 # Build tests and install artefacts only for Linux systems
 if (CMAKE_SYSTEM_NAME STREQUAL "Linux")

--- a/examples/aaf/CMakeLists.txt
+++ b/examples/aaf/CMakeLists.txt
@@ -27,11 +27,11 @@
 # SPDX-License-Identifier: BSD-3-Clause
 #
 
-add_executable(aaf-talker aaf-talker.c)
+add_executable(aaf-talker EXCLUDE_FROM_ALL aaf-talker.c)
 target_link_libraries(aaf-talker open1722 open1722examples)
 target_include_directories(aaf-talker PUBLIC ${CMAKE_SOURCE_DIR}/include ../)
 
-add_executable(aaf-listener aaf-listener.c)
+add_executable(aaf-listener EXCLUDE_FROM_ALL aaf-listener.c)
 target_link_libraries(aaf-listener open1722 open1722examples)
 target_include_directories(aaf-listener PUBLIC ${CMAKE_SOURCE_DIR}/include ../)
 
@@ -40,4 +40,5 @@ add_dependencies(examples aaf-talker aaf-listener)
 install(TARGETS
     aaf-listener
     aaf-talker
-    RUNTIME DESTINATION bin)
+    RUNTIME DESTINATION bin
+    OPTIONAL)

--- a/examples/acf-can/linux/CMakeLists.txt
+++ b/examples/acf-can/linux/CMakeLists.txt
@@ -27,15 +27,15 @@
 # SPDX-License-Identifier: BSD-3-Clause
 #
 
-add_executable(acf-can-talker acf-can-talker.c ../acf-can-common.c)
+add_executable(acf-can-talker EXCLUDE_FROM_ALL acf-can-talker.c ../acf-can-common.c)
 target_link_libraries(acf-can-talker open1722 open1722examples)
 target_include_directories(acf-can-talker PUBLIC ${CMAKE_SOURCE_DIR}/include ../ ../../)
 
-add_executable(acf-can-listener acf-can-listener.c ../acf-can-common.c)
+add_executable(acf-can-listener EXCLUDE_FROM_ALL acf-can-listener.c ../acf-can-common.c)
 target_link_libraries(acf-can-listener open1722 open1722examples)
 target_include_directories(acf-can-listener PUBLIC ${CMAKE_SOURCE_DIR}/include ../ ../../)
 
-add_executable(acf-can-bridge acf-can-bridge.c ../acf-can-common.c)
+add_executable(acf-can-bridge EXCLUDE_FROM_ALL acf-can-bridge.c ../acf-can-common.c)
 target_link_libraries(acf-can-bridge open1722 open1722examples)
 target_include_directories(acf-can-bridge PUBLIC ${CMAKE_SOURCE_DIR}/include ../ ../../)
 
@@ -45,4 +45,5 @@ install(TARGETS
     acf-can-listener
     acf-can-talker
     acf-can-bridge
-    RUNTIME DESTINATION bin)
+    RUNTIME DESTINATION bin
+    OPTIONAL)

--- a/examples/acf-vss/CMakeLists.txt
+++ b/examples/acf-vss/CMakeLists.txt
@@ -27,11 +27,11 @@
 # SPDX-License-Identifier: BSD-3-Clause
 #
 
-add_executable(acf-vss-talker acf-vss-talker.c)
+add_executable(acf-vss-talker EXCLUDE_FROM_ALL acf-vss-talker.c)
 target_link_libraries(acf-vss-talker open1722 open1722custom open1722examples)
 target_include_directories(acf-vss-talker PUBLIC ${CMAKE_SOURCE_DIR}/include ../)
 
-add_executable(acf-vss-listener acf-vss-listener.c)
+add_executable(acf-vss-listener EXCLUDE_FROM_ALL acf-vss-listener.c)
 target_link_libraries(acf-vss-listener open1722 open1722custom open1722examples)
 target_include_directories(acf-vss-listener PUBLIC ${CMAKE_SOURCE_DIR}/include ../)
 
@@ -40,4 +40,5 @@ add_dependencies(examples acf-vss-talker acf-vss-listener)
 install(TARGETS
     acf-vss-listener
     acf-vss-talker
-    RUNTIME DESTINATION bin)
+    RUNTIME DESTINATION bin
+    OPTIONAL)

--- a/examples/crf/CMakeLists.txt
+++ b/examples/crf/CMakeLists.txt
@@ -27,11 +27,11 @@
 # SPDX-License-Identifier: BSD-3-Clause
 #
 
-add_executable(crf-talker crf-talker.c)
+add_executable(crf-talker EXCLUDE_FROM_ALL crf-talker.c)
 target_link_libraries(crf-talker open1722 open1722examples m)
 target_include_directories(crf-talker PUBLIC ${CMAKE_SOURCE_DIR}/include ../)
 
-add_executable(crf-listener crf-listener.c)
+add_executable(crf-listener EXCLUDE_FROM_ALL crf-listener.c)
 target_link_libraries(crf-listener open1722 open1722examples m)
 target_include_directories(crf-listener PUBLIC ${CMAKE_SOURCE_DIR}/include ../)
 
@@ -40,4 +40,5 @@ add_dependencies(examples crf-talker crf-listener)
 install(TARGETS
     crf-listener
     crf-talker
-    RUNTIME DESTINATION bin)
+    RUNTIME DESTINATION bin
+    OPTIONAL)

--- a/examples/cvf/CMakeLists.txt
+++ b/examples/cvf/CMakeLists.txt
@@ -27,11 +27,11 @@
 # SPDX-License-Identifier: BSD-3-Clause
 #
 
-add_executable(cvf-talker cvf-talker.c)
+add_executable(cvf-talker EXCLUDE_FROM_ALL cvf-talker.c)
 target_link_libraries(cvf-talker open1722 open1722examples)
 target_include_directories(cvf-talker PUBLIC ${CMAKE_SOURCE_DIR}/include ../)
 
-add_executable(cvf-listener cvf-listener.c)
+add_executable(cvf-listener EXCLUDE_FROM_ALL cvf-listener.c)
 target_link_libraries(cvf-listener open1722 open1722examples)
 target_include_directories(cvf-listener PUBLIC ${CMAKE_SOURCE_DIR}/include ../)
 
@@ -40,4 +40,5 @@ add_dependencies(examples cvf-talker cvf-listener)
 install(TARGETS
     cvf-listener
     cvf-talker
-    RUNTIME DESTINATION bin)
+    RUNTIME DESTINATION bin
+    OPTIONAL)

--- a/examples/hello-world/CMakeLists.txt
+++ b/examples/hello-world/CMakeLists.txt
@@ -27,11 +27,11 @@
 # SPDX-License-Identifier: BSD-3-Clause
 #
 
-add_executable(hello-world-talker hello-world-talker.c)
+add_executable(hello-world-talker EXCLUDE_FROM_ALL hello-world-talker.c)
 target_link_libraries(hello-world-talker open1722 open1722examples)
 target_include_directories(hello-world-talker PUBLIC ${CMAKE_SOURCE_DIR}/include ../)
 
-add_executable(hello-world-listener hello-world-listener.c)
+add_executable(hello-world-listener EXCLUDE_FROM_ALL hello-world-listener.c)
 target_link_libraries(hello-world-listener open1722 open1722examples)
 target_include_directories(hello-world-listener PUBLIC ${CMAKE_SOURCE_DIR}/include ../)
 
@@ -40,4 +40,5 @@ add_dependencies(examples hello-world-talker hello-world-listener)
 install(TARGETS
     hello-world-listener
     hello-world-talker
-    RUNTIME DESTINATION bin)
+    RUNTIME DESTINATION bin
+    OPTIONAL)


### PR DESCRIPTION
This PR allows installation of examples/ when ```make install``` is executed with the examples already built.
The idea is to by default install only the libraries and the headers. For examples to be installed, it has to be built in advance. If already built, the executables will be installed.