### PR TITLE
Fixed is_valid() for (N)TSCF formats. Added unit tests.

### DIFF
--- a/src/avtp/acf/Ntscf.c
+++ b/src/avtp/acf/Ntscf.c
@@ -159,7 +159,7 @@ uint8_t Avtp_Ntscf_IsValid(Avtp_Ntscf_t* pdu, size_t bufferSize)
     }
 
     // Avtp_Ntscf_GetNtscfDataLength returns quadlets. Convert the length field to octets
-    if (Avtp_Ntscf_GetNtscfDataLength(pdu) * 4> bufferSize) {
+    if (Avtp_Ntscf_GetNtscfDataLength(pdu) > bufferSize) {
         return FALSE;
     }
 

--- a/src/avtp/acf/Tscf.c
+++ b/src/avtp/acf/Tscf.c
@@ -30,8 +30,8 @@
 #ifdef LINUX_KERNEL1722
 #include <linux/errno.h>
 #include <linux/string.h>
-#else  
-#include <errno.h> 
+#else
+#include <errno.h>
 #include <string.h>
 #endif
 
@@ -218,7 +218,7 @@ uint8_t Avtp_Tscf_IsValid(Avtp_Tscf_t* pdu, size_t bufferSize)
     }
 
     // Avtp_Tscf_GetStreamDataLength returns quadlets. Convert the length field to octets
-    if (Avtp_Tscf_GetStreamDataLength(pdu) * 4 > bufferSize) {
+    if (Avtp_Tscf_GetStreamDataLength(pdu) > bufferSize) {
         return FALSE;
     }
 

--- a/unit/CMakeLists.txt
+++ b/unit/CMakeLists.txt
@@ -70,6 +70,16 @@ target_link_libraries(test-rvf open1722 cmocka)
 target_include_directories(test-rvf PUBLIC ../include)
 add_test(NAME test-rvf COMMAND test-rvf)
 
+add_executable(test-tscf test-tscf.c)
+target_link_libraries(test-tscf open1722 cmocka)
+target_include_directories(test-tscf PUBLIC ../include)
+add_test(NAME test-tscf COMMAND test-tscf)
+
+add_executable(test-ntscf test-ntscf.c)
+target_link_libraries(test-ntscf open1722 cmocka)
+target_include_directories(test-ntscf PUBLIC ../include)
+add_test(NAME test-ntscf COMMAND test-ntscf)
+
 add_executable(test-vss test-vss.c)
 target_link_libraries(test-vss open1722 open1722custom cmocka)
 target_include_directories(test-vss PUBLIC ../include)
@@ -77,4 +87,4 @@ add_test(NAME test-vss COMMAND test-vss)
 
 add_dependencies(unittests test-can test-aaf
                 test-avtp test-crf test-cvf
-                test-rvf test-vss)
+                test-rvf test-vss test-tscf test-ntscf)

--- a/unit/test-can.c
+++ b/unit/test-can.c
@@ -116,12 +116,37 @@ static void can_set_payload(void **state) {
     }
 }
 
+static void can_is_valid(void **state) {
+
+    uint8_t pdu[MAX_PDU_SIZE], result;
+
+    // Valid IEEE 1722 CAN Frame
+    Avtp_Can_Init((Avtp_Can_t*)pdu);
+    assert_int_equal(Avtp_Can_IsValid((Avtp_Can_t*)pdu, MAX_PDU_SIZE), 1);
+
+    // Not a IEEE 1722 CAN Frame
+    memset(pdu, 0, MAX_PDU_SIZE);
+    assert_int_equal(Avtp_Can_IsValid((Avtp_Can_t*)pdu, MAX_PDU_SIZE), 0);
+
+    // Valid IEEE 1722 CAN Frame (Length 24, Buffer 25)
+    Avtp_Can_Init((Avtp_Can_t*)pdu);
+    Avtp_Can_SetAcfMsgLength((Avtp_Can_t*)pdu, 6);
+    assert_int_equal(Avtp_Can_IsValid((Avtp_Can_t*)pdu, 25), 1);
+
+    // Invalid IEEE 1722 CAN Frame (Length 24 but buffer only 9!)
+    Avtp_Can_Init((Avtp_Can_t*)pdu);
+    Avtp_Can_SetAcfMsgLength((Avtp_Can_t*)pdu, 6);
+    assert_int_equal(Avtp_Can_IsValid((Avtp_Can_t*)pdu, 9), 0);
+
+}
+
 int main(void)
 {
     const struct CMUnitTest tests[] = {
         cmocka_unit_test(can_init),
         cmocka_unit_test(can_brief_init),
-        cmocka_unit_test(can_set_payload)
+        cmocka_unit_test(can_set_payload),
+        cmocka_unit_test(can_is_valid)
     };
 
     return cmocka_run_group_tests(tests, NULL, NULL);

--- a/unit/test-ntscf.c
+++ b/unit/test-ntscf.c
@@ -1,0 +1,96 @@
+/*
+ * Copyright (c) 2025, COVESA
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ *    * Redistributions of source code must retain the above copyright notice,
+ *      this list of conditions and the following disclaimer.
+ *    * Redistributions in binary form must reproduce the above copyright
+ *      notice, this list of conditions and the following disclaimer in the
+ *      documentation and/or other materials provided with the distribution.
+ *    * Neither the name of COVESA nor the names of its contributors may be
+ *      used to endorse or promote products derived from this software without
+ *      specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+#include <stdarg.h>
+#include <stddef.h>
+#include <setjmp.h>
+#include <cmocka.h>
+#include <arpa/inet.h>
+#include <errno.h>
+#include <string.h>
+#include <math.h>
+#include <stdio.h>
+
+#include "avtp/acf/Ntscf.h"
+#include "avtp/CommonHeader.h"
+
+#define MAX_PDU_SIZE        1500
+
+static void ntscf_init(void **state) {
+
+    uint8_t pdu[MAX_PDU_SIZE];
+    uint8_t init_pdu[AVTP_NTSCF_HEADER_LEN];
+
+    // Check the lengths
+    assert_int_equal(sizeof(Avtp_Ntscf_t), AVTP_NTSCF_HEADER_LEN);
+
+    // Check init function while passing in a null pointer
+    Avtp_Ntscf_Init(NULL);
+
+    // Check if the function is initializing properly
+    Avtp_Ntscf_Init((Avtp_Ntscf_t*)pdu);
+    memset(init_pdu, 0, AVTP_NTSCF_HEADER_LEN);
+    init_pdu[0] = AVTP_SUBTYPE_NTSCF; // Setting AVTP Subtype as NTSCF
+    init_pdu[1] = 0x80; // Setting Stream as valid
+    assert_memory_equal(init_pdu, pdu, AVTP_NTSCF_HEADER_LEN);
+}
+
+static void ntscf_is_valid(void **state) {
+
+    uint8_t pdu[MAX_PDU_SIZE], result;
+
+    // Valid IEEE 1722 NTSCF Frame
+    Avtp_Ntscf_Init((Avtp_Ntscf_t*)pdu);
+    assert_int_equal(Avtp_Ntscf_IsValid((Avtp_Ntscf_t*)pdu, MAX_PDU_SIZE), 1);
+
+    // Not a IEEE 1722 NTSCF Frame
+    memset(pdu, 0, MAX_PDU_SIZE);
+    assert_int_equal(Avtp_Ntscf_IsValid((Avtp_Ntscf_t*)pdu, MAX_PDU_SIZE), 0);
+
+    // Valid IEEE 1722 NTSCF Frame (Length 28, Buffer 30)
+    Avtp_Ntscf_Init((Avtp_Ntscf_t*)pdu);
+    Avtp_Ntscf_SetNtscfDataLength((Avtp_Ntscf_t*)pdu, 28);
+    assert_int_equal(Avtp_Ntscf_IsValid((Avtp_Ntscf_t*)pdu, 30), 1);
+
+    // Invalid IEEE 1722 NTSCF Frame (Length 24 but buffer only 9!)
+    Avtp_Ntscf_Init((Avtp_Ntscf_t*)pdu);
+    Avtp_Ntscf_SetNtscfDataLength((Avtp_Ntscf_t*)pdu, 24);
+    assert_int_equal(Avtp_Ntscf_IsValid((Avtp_Ntscf_t*)pdu, 9), 0);
+
+}
+
+int main(void)
+{
+    const struct CMUnitTest tests[] = {
+        cmocka_unit_test(ntscf_init),
+        cmocka_unit_test(ntscf_is_valid)
+    };
+
+    return cmocka_run_group_tests(tests, NULL, NULL);
+}

--- a/unit/test-tscf.c
+++ b/unit/test-tscf.c
@@ -1,0 +1,96 @@
+/*
+ * Copyright (c) 2025, COVESA
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ *    * Redistributions of source code must retain the above copyright notice,
+ *      this list of conditions and the following disclaimer.
+ *    * Redistributions in binary form must reproduce the above copyright
+ *      notice, this list of conditions and the following disclaimer in the
+ *      documentation and/or other materials provided with the distribution.
+ *    * Neither the name of COVESA nor the names of its contributors may be
+ *      used to endorse or promote products derived from this software without
+ *      specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+#include <stdarg.h>
+#include <stddef.h>
+#include <setjmp.h>
+#include <cmocka.h>
+#include <arpa/inet.h>
+#include <errno.h>
+#include <string.h>
+#include <math.h>
+#include <stdio.h>
+
+#include "avtp/acf/Tscf.h"
+#include "avtp/CommonHeader.h"
+
+#define MAX_PDU_SIZE        1500
+
+static void tscf_init(void **state) {
+
+    uint8_t pdu[MAX_PDU_SIZE];
+    uint8_t init_pdu[AVTP_TSCF_HEADER_LEN];
+
+    // Check the lengths
+    assert_int_equal(sizeof(Avtp_Tscf_t), AVTP_TSCF_HEADER_LEN);
+
+    // Check init function while passing in a null pointer
+    Avtp_Tscf_Init(NULL);
+
+    // Check if the function is initializing properly
+    Avtp_Tscf_Init((Avtp_Tscf_t*)pdu);
+    memset(init_pdu, 0, AVTP_TSCF_HEADER_LEN);
+    init_pdu[0] = AVTP_SUBTYPE_TSCF; // Setting AVTP Subtype as TSCF
+    init_pdu[1] = 0x80; // Setting Stream as valid
+    assert_memory_equal(init_pdu, pdu, AVTP_TSCF_HEADER_LEN);
+}
+
+static void tscf_is_valid(void **state) {
+
+    uint8_t pdu[MAX_PDU_SIZE], result;
+
+    // Valid IEEE 1722 TSCF Frame
+    Avtp_Tscf_Init((Avtp_Tscf_t*)pdu);
+    assert_int_equal(Avtp_Tscf_IsValid((Avtp_Tscf_t*)pdu, MAX_PDU_SIZE), 1);
+
+    // Not a IEEE 1722 TSCF Frame
+    memset(pdu, 0, MAX_PDU_SIZE);
+    assert_int_equal(Avtp_Tscf_IsValid((Avtp_Tscf_t*)pdu, MAX_PDU_SIZE), 0);
+
+    // Valid IEEE 1722 TSCF Frame (Length 28, Buffer 30)
+    Avtp_Tscf_Init((Avtp_Tscf_t*)pdu);
+    Avtp_Tscf_SetStreamDataLength((Avtp_Tscf_t*)pdu, 28);
+    assert_int_equal(Avtp_Tscf_IsValid((Avtp_Tscf_t*)pdu, 30), 1);
+
+    // Invalid IEEE 1722 TSCF Frame (Length 24 but buffer only 9!)
+    Avtp_Tscf_Init((Avtp_Tscf_t*)pdu);
+    Avtp_Tscf_SetStreamDataLength((Avtp_Tscf_t*)pdu, 24);
+    assert_int_equal(Avtp_Tscf_IsValid((Avtp_Tscf_t*)pdu, 9), 0);
+
+}
+
+int main(void)
+{
+    const struct CMUnitTest tests[] = {
+        cmocka_unit_test(tscf_init),
+        cmocka_unit_test(tscf_is_valid),
+    };
+
+    return cmocka_run_group_tests(tests, NULL, NULL);
+}


### PR DESCRIPTION
The PR for Is_Valid() API was incorrect for TSCF and NTSCF format.
This is fixed in this PR. Also added unit tests.