### PR TITLE
Fix typo in examples/acf-can/linux/README.md

### DIFF
--- a/examples/acf-can/linux/README.md
+++ b/examples/acf-can/linux/README.md
@@ -31,7 +31,7 @@ Ethernet using Open1722.
       --usage                Give a short usage message
 ```
 
-## acf-can-talker
+## acf-can-listener 
 _acf-can-listener_ receives IEEE 1722 ACF messages and puts out the corresponding CAN frames on a (virtual) CAN interface. The parameters for its usage are as follows:
 
 ```


### PR DESCRIPTION
Fix the heading for acf-can-listener (it was labeled "acf-can-talker").

(there is a secondary purpose for going through the PR process for such a simple fix... I want to get re-introduced to the team that is creating/maintaining OpenBSD. My work at Iowa State University focuses on CAN tunneling as it relates to the AEF High Speed ISOBUS project. [^1])

[^1]: https://www.aef-online.org/about-us/teams.html#/ExpertTeams