### PR TITLE
Removed the logo for incubation.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,3 @@
-![Status - Incubating](https://img.shields.io/static/v1?label=Status&message=Incubating&color=FEFF3A&style=for-the-badge)
 ![GitHub Actions Workflow Status](https://img.shields.io/github/actions/workflow/status/COVESA/Open1722/build-all.yml?branch=main&style=for-the-badge)
 
 


### PR DESCRIPTION
Now that we have release a version (v0.8.0) and almost all automotive relevant formats of IEEE 1722-2016 are included, I suggest that we remove the INCUBATING from the README.