### PR TITLE
Project Status is now Mature

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,3 @@
-![Status - Incubating](https://img.shields.io/static/v1?label=Status&message=Incubating&color=FEFF3A&style=for-the-badge)
 ![GitHub Actions Workflow Status](https://img.shields.io/github/actions/workflow/status/COVESA/Open1722/build-all.yml?branch=main&style=for-the-badge)
 
 


### PR DESCRIPTION
Per a Technical Steering Team vote on 8/18/2025, Open1722 has reached the Mature Project Status.  So, it no longer needs the Incubating Status badge.  Hence, it was removed.