### PR TITLE
Support new .newlink signature in Linux kernel>=6.10

### DIFF
--- a/examples/acf-can/linux-kernel-mod/acfcanmain.c
+++ b/examples/acf-can/linux-kernel-mod/acfcanmain.c
@@ -39,6 +39,7 @@
 
 #include <linux/init.h>
 #include <linux/uaccess.h>
+#include <linux/version.h>
 
 #include <linux/if_arp.h>
 
@@ -257,9 +258,15 @@ static void acfcan_remove(struct net_device *dev, struct list_head *head)
 	printk(KERN_INFO "ACFCAN interface %s unregistered\n", dev->name);
 }
 
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(6, 10, 0)
+static int acfcan_newlink(struct net_device *dev,
+						  struct rtnl_newlink_params *params,
+						  struct netlink_ext_ack *extack)
+#else
 static int acfcan_newlink(struct net *net, struct net_device *dev,
 						  struct nlattr *tb[], struct nlattr *data[],
 						  struct netlink_ext_ack *extack)
+#endif
 {
 	int err = register_netdevice(dev);
 


### PR DESCRIPTION
Try fixing kernel module.

The signature for .newlink changed in kernel 6.10, see https://github.com/torvalds/linux/commit/69c7be1b903fca2835e80ec506bd1d75ce84fb4d

As we use neither of the parameters that are now in a structure, just `#ifdef`ed the signature

tested compiling and running on

```
# uname -a
Linux fixopen1722 6.17.0-20-generic #20~24.04.1-Ubuntu SMP PREEMPT_DYNAMIC Wed Mar 18 21:40:40 UTC 2 aarch64 aarch64 aarch64 GNU/Linux
root@fixopen1722:~/Open1722/examples/acf-can/linux-kernel-mod# cat /etc/issue
Ubuntu 24.04.4 LTS \n \l

root@fixopen1722:~/Open1722/examples/acf-can/linux-kernel-mod# 
``` 

and 

```
# uname -a
Linux fixopen1722 6.8.0-107-generic #107-Ubuntu SMP PREEMPT_DYNAMIC Fri Mar 13 19:42:33 UTC 2026 aarch64 aarch64 aarch64 GNU/Linux
root@fixopen1722:~/Open1722/examples/acf-can/linux-kernel-mod# cat /etc/issue
Ubuntu 24.04.4 LTS \n \l

root@fixopen1722:~/Open1722/examples/acf-can/linux-kernel-mod# 
```

Only fixes Linux. Zephyr will need a seperate PR