### PR TITLE
Added relevant POSIX headers for networking.

### DIFF
--- a/.github/workflows/build-all.yml
+++ b/.github/workflows/build-all.yml
@@ -11,7 +11,7 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v5
     - name: Install dependencies
       run: sudo apt update && sudo apt install -y meson libcmocka0 libcmocka-dev lcov
     - name: Run build_all.sh script

--- a/.github/workflows/build-linuxkernelmod.yml
+++ b/.github/workflows/build-linuxkernelmod.yml
@@ -14,7 +14,7 @@ jobs:
       CONFIG_ACF_CAN: m
     
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v5
     - name: Install dependencies
       run: sudo apt update && sudo apt install -y meson libcmocka0 libcmocka-dev lcov
     - name: Patching license

--- a/.github/workflows/build-zephyr.yml
+++ b/.github/workflows/build-zephyr.yml
@@ -13,7 +13,7 @@ jobs:
     name: Build acf-can-bridge for Zephyr
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Create West Workspace Directory
         run: mkdir west-ws && cp examples/acf-can/zephyr/west.yml west-ws/

--- a/.github/workflows/spdxcheck.yml
+++ b/.github/workflows/spdxcheck.yml
@@ -14,7 +14,7 @@ jobs:
 
     steps:
     - name: Checkout code
-      uses: actions/checkout@v4
+      uses: actions/checkout@v5
       with:
         # required to grab the history of the PR
         fetch-depth: 0

--- a/examples/acf-can/acf-can-common.c
+++ b/examples/acf-can/acf-can-common.c
@@ -36,7 +36,7 @@
 #include <sys/ioctl.h>
 #elif defined(__ZEPHYR__)
 #include <zephyr/kernel.h>
-#include <zephyr/net/socket.h>
+#include <zephyr/posix/sys/socket.h>
 #include <zephyr/net/socketcan.h>
 #include <zephyr/net/socketcan_utils.h>
 #include <zephyr/net/ethernet.h>

--- a/examples/acf-can/zephyr/acf-can-bridge.c
+++ b/examples/acf-can/zephyr/acf-can-bridge.c
@@ -30,7 +30,7 @@
 #include <zephyr/net/ethernet.h>
 #include <zephyr/kernel.h>
 #include <zephyr/drivers/can.h>
-#include <zephyr/net/socket.h>
+#include <zephyr/posix/sys/socket.h>
 #include <zephyr/net/socketcan.h>
 #include <zephyr/net/socketcan_utils.h>
 #include <stdio.h>
@@ -43,7 +43,6 @@
 #include <arpa/inet.h>
 #include <poll.h>
 #include <zephyr/logging/log.h>
-#include <zephyr/net/socket.h>
 #include <zephyr/net/net_if.h>
 #include <zephyr/net/net_l2.h>
 

--- a/examples/common/common.c
+++ b/examples/common/common.c
@@ -37,8 +37,6 @@
 #include <sys/socket.h>
 #include <sys/timerfd.h>
 #include <sys/types.h>
-#elif defined(__ZEPHYR__)
-#include <zephyr/net/socket.h>
 #endif
 
 #include <stdio.h>

--- a/examples/common/common.h
+++ b/examples/common/common.h
@@ -32,7 +32,7 @@
 #ifdef __linux__
 #include <netinet/in.h>
 #elif defined(__ZEPHYR__)
-#include <zephyr/net/socket.h>
+#include <zephyr/posix/sys/socket.h>
 #include <zephyr/net/ethernet.h>
 #define ETH_ALEN NET_ETH_ADDR_LEN
 #endif


### PR DESCRIPTION
Due to a change in Zephyr structure, we need to now specifically add headers for POSIX utilities. See https://github.com/zephyrproject-rtos/zephyr/commit/ac859d0e7736bbffafeb4c1f0faab6b5a60a8922 for the corresponding Zephyr commit.