### PR TITLE
Added zephyr_generated_headers as build dependency.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,6 @@
-![GitHub Actions Workflow Status](https://img.shields.io/github/actions/workflow/status/COVESA/Open1722/build-all.yml?branch=main&style=for-the-badge)
-
+![Linux Build Status](https://img.shields.io/github/actions/workflow/status/COVESA/Open1722/build-all.yml?branch=main&style=for-the-badge&logo=linux)
+![Zephyr Build Status](https://img.shields.io/github/actions/workflow/status/COVESA/Open1722/build-zephyr.yml?branch=main&style=for-the-badge&label=zephyr)
+![Linux Kernel Module Build Status](https://img.shields.io/github/actions/workflow/status/COVESA/Open1722/build-linuxkernelmod.yml?branch=main&style=for-the-badge&label=Linux%20Kernel%20Module)
 
 
 <a name="readme-top"></a>

--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -33,7 +33,7 @@ target_include_directories(open1722examples PRIVATE
     $<INSTALL_INTERFACE:include>
     ${CMAKE_CURRENT_SOURCE_DIR})
 if (DEFINED ENV{ZEPHYR_BASE})
-    target_link_libraries(open1722examples PRIVATE zephyr_interface)
+    target_link_libraries(open1722examples PRIVATE zephyr_interface zephyr_generated_headers)
 endif()
 add_dependencies(examples open1722examples)
 

--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -33,7 +33,8 @@ target_include_directories(open1722examples PRIVATE
     $<INSTALL_INTERFACE:include>
     ${CMAKE_CURRENT_SOURCE_DIR})
 if (DEFINED ENV{ZEPHYR_BASE})
-    target_link_libraries(open1722examples PRIVATE zephyr_interface zephyr_generated_headers)
+    add_dependencies(open1722examples zephyr_generated_headers)
+    target_link_libraries(open1722examples PRIVATE zephyr_interface)
 endif()
 add_dependencies(examples open1722examples)
 


### PR DESCRIPTION
This is as per the suggestion in https://github.com/zephyrproject-rtos/zephyr/blob/e2a556ff64170573f21a7e4d21fcb6286f5fb8eb/doc/releases/migration-guide-4.4.rst#kernel to migrate to version 4.4 Kernel.