### PR TITLE
acf/vss: fix unbounded reads in string-array (de)serialisation

### DIFF
--- a/include/avtp/acf/custom/Vss.h
+++ b/include/avtp/acf/custom/Vss.h
@@ -258,7 +258,7 @@ Vss_Datatype_t Avtp_Vss_GetDatatype(const Avtp_Vss_t* const pdu);
 uint64_t Avtp_Vss_GetMsgTimestamp(const Avtp_Vss_t* const pdu);
 void Avtp_Vss_GetVssPath(const Avtp_Vss_t* const pdu, VssPath_t* val);
 void Avtp_Vss_GetVssData(const Avtp_Vss_t* const pdu, VssData_t* val);
-uint8_t Avtp_Vss_GetVSSDataStringArrayLength(const VssDataStringArray_t* str_array);
+uint16_t Avtp_Vss_GetVSSDataStringArrayLength(const VssDataStringArray_t* str_array);
 uint16_t Avtp_Vss_CalcVssPathLength (const Avtp_Vss_t* const pdu);
 void Avtp_Vss_DeserializeStringArray(const VssDataStringArray_t*  const vss_data_string_array,
                                      VssDataString_t* strings[],

--- a/src/avtp/acf/custom/Vss.c
+++ b/src/avtp/acf/custom/Vss.c
@@ -155,14 +155,33 @@ uint16_t Avtp_Vss_CalcVssPathLength(const Avtp_Vss_t* const pdu) {
     return path_length;
 }
 
-uint8_t Avtp_Vss_GetVSSDataStringArrayLength(const VssDataStringArray_t* const str_array) {
-
+uint16_t Avtp_Vss_GetVSSDataStringArrayLength(const VssDataStringArray_t* const str_array) {
+    /* Walk the [length-prefix : 2 bytes][string : length bytes] pairs that
+     * make up the on-wire string-array layout, counting how many fit in
+     * str_array->data_length.
+     *
+     * Bounds checks:
+     *   1. ptr_idx + 2 <= total_length, before reading the length prefix
+     *      (the previous loop condition `ptr_idx < total_length` was off
+     *      by one and would OOB-read the length field on the last byte).
+     *   2. ptr_idx + 2 + str_length <= total_length, before accepting the
+     *      string. This is computed in uint32_t so the addition cannot
+     *      itself overflow when str_length approaches UINT16_MAX.
+     *
+     * Return type widened from uint8_t to uint16_t so counts up to 65535
+     * (a real upper bound given total_length is uint16_t) are not
+     * silently truncated mod 256. */
     uint16_t total_length = str_array->data_length;
     const uint8_t * vss_data_string_array_raw = str_array->data;
     uint16_t idx = 0, ptr_idx = 0;
-    while (ptr_idx < total_length) {
+    while ((uint32_t)ptr_idx + 2 <= total_length) {
 
         uint16_t str_length = Avtp_BeToCpu16(*(const uint16_t*)(vss_data_string_array_raw+ptr_idx));
+        if ((uint32_t)ptr_idx + 2 + str_length > total_length) {
+            /* Truncated or malformed array: stop counting at the last
+             * fully-contained string. */
+            break;
+        }
         ptr_idx += 2 + str_length;
         idx++;
     }
@@ -173,19 +192,38 @@ uint8_t Avtp_Vss_GetVSSDataStringArrayLength(const VssDataStringArray_t* const s
 void Avtp_Vss_DeserializeStringArray(const VssDataStringArray_t* const vss_data_string_array,
                                      VssDataString_t* strings[],
                                      uint16_t num_strings) {
-
+    /* Same on-wire layout as in GetVSSDataStringArrayLength above, but here
+     * we copy each string's body into the caller-supplied output structs.
+     *
+     * The previous implementation declared `uint16_t idx = 0;` and only
+     * checked `if (idx >= array_length) break;` — but `idx` was never
+     * incremented, so the break was dead code (it only fired when
+     * array_length == 0). Combined with attacker-controlled str_length
+     * values up to UINT16_MAX, this allowed memcpy() to read up to ~64 KiB
+     * past the end of vss_data_string_array->data on every iteration after
+     * the first malicious string.
+     *
+     * Track bytes consumed and validate (a) that 2 length-prefix bytes are
+     * available before reading them, and (b) that str_length more bytes
+     * are available before memcpy'ing them. The additions are computed in
+     * uint32_t so the bound check itself cannot overflow. */
     uint16_t array_length = vss_data_string_array->data_length;
     const uint8_t* array_data = vss_data_string_array->data;
-    uint16_t idx = 0;
+    uint16_t consumed = 0;
 
     for (int i = 0; i < num_strings; i++) {
-        if(idx >= array_length) break;
+        if ((uint32_t)consumed + 2 > array_length) break;
 
-        strings[i]->data_length = Avtp_BeToCpu16(*(const uint16_t*)array_data);
+        uint16_t str_length = Avtp_BeToCpu16(*(const uint16_t*)array_data);
+        if ((uint32_t)consumed + 2 + str_length > array_length) break;
+
+        if (strings[i] == NULL) break;
+        strings[i]->data_length = str_length;
         if (strings[i]->data != NULL) {
-            memcpy(strings[i]->data, array_data+2, strings[i]->data_length);
+            memcpy(strings[i]->data, array_data + 2, str_length);
         }
-        array_data += 2 + strings[i]->data_length;
+        array_data += 2 + str_length;
+        consumed   += 2 + str_length;
     }
 }
 

--- a/src/avtp/acf/custom/Vss.c
+++ b/src/avtp/acf/custom/Vss.c
@@ -162,15 +162,12 @@ uint16_t Avtp_Vss_GetVSSDataStringArrayLength(const VssDataStringArray_t* const 
      *
      * Bounds checks:
      *   1. ptr_idx + 2 <= total_length, before reading the length prefix
-     *      (the previous loop condition `ptr_idx < total_length` was off
-     *      by one and would OOB-read the length field on the last byte).
      *   2. ptr_idx + 2 + str_length <= total_length, before accepting the
      *      string. This is computed in uint32_t so the addition cannot
      *      itself overflow when str_length approaches UINT16_MAX.
      *
-     * Return type widened from uint8_t to uint16_t so counts up to 65535
-     * (a real upper bound given total_length is uint16_t) are not
-     * silently truncated mod 256. */
+     * Return type uint16_t should be enough as any 1722 frame (raw or UDP) is
+     * fundamentally limited by Ethernet frame size. */
     uint16_t total_length = str_array->data_length;
     const uint8_t * vss_data_string_array_raw = str_array->data;
     uint16_t idx = 0, ptr_idx = 0;
@@ -194,15 +191,7 @@ void Avtp_Vss_DeserializeStringArray(const VssDataStringArray_t* const vss_data_
                                      uint16_t num_strings) {
     /* Same on-wire layout as in GetVSSDataStringArrayLength above, but here
      * we copy each string's body into the caller-supplied output structs.
-     *
-     * The previous implementation declared `uint16_t idx = 0;` and only
-     * checked `if (idx >= array_length) break;` — but `idx` was never
-     * incremented, so the break was dead code (it only fired when
-     * array_length == 0). Combined with attacker-controlled str_length
-     * values up to UINT16_MAX, this allowed memcpy() to read up to ~64 KiB
-     * past the end of vss_data_string_array->data on every iteration after
-     * the first malicious string.
-     *
+     *     
      * Track bytes consumed and validate (a) that 2 length-prefix bytes are
      * available before reading them, and (b) that str_length more bytes
      * are available before memcpy'ing them. The additions are computed in

--- a/unit/test-vss.c
+++ b/unit/test-vss.c
@@ -1022,6 +1022,59 @@ static void vss_data_string_array(void **state) {
 
 }
 
+static void vss_data_string_array_malformed(void **state) {
+    /* On-wire layout for a VSS string array is [u16 length][bytes ...]
+     * pairs. Construct a 23-byte payload identical to the well-formed
+     * fixture in vss_data_string_array, except the third length prefix
+     * has been corrupted from 0x0007 to 0x00AA. The third entry now
+     * claims 170 bytes of body, but only 7 bytes of buffer remain after
+     * its length prefix.
+     *
+     * Per the bounds-check fix in this PR, the parser must:
+     *   - stop counting at the last fully-contained string, so
+     *     GetVSSDataStringArrayLength returns 2 (not 3, and not 0);
+     *   - refuse to memcpy past the buffer end, so
+     *     DeserializeStringArray fills the first two output structs
+     *     with the well-formed strings and leaves the third untouched.
+     *
+     * Without the fix, the same input would have driven memcpy to read
+     * up to ~64 KiB past the end of the buffer in
+     * DeserializeStringArray (heap disclosure / crash) and produced an
+     * uint16_t-arithmetic wrap in GetVSSDataStringArrayLength
+     * (pseudo-infinite loop / DoS). */
+    uint8_t arr_in_mem[] = {
+        0x00, 0x05, 'H', 'e', 'l', 'l', 'o',
+        0x00, 0x05, 'W', 'o', 'r', 'l', 'd',
+        0x00, 0xAA, 'T', 's', 'c', 'h', 'u', 's', 's',
+    };
+
+    VssDataStringArray_t str_array = {0};
+    str_array.data = arr_in_mem;
+    str_array.data_length = sizeof(arr_in_mem);
+
+    /* Counting must stop at the second well-formed string. */
+    assert_int_equal(Avtp_Vss_GetVSSDataStringArrayLength(&str_array), 2);
+
+    /* Deserialisation must fill only the first two entries. The third
+     * struct stays at its initial state (data_length == 0). */
+    char buf1[8] = {0}, buf2[8] = {0}, buf3[8] = {0};
+    VssDataString_t s1 = {0}; s1.data = buf1;
+    VssDataString_t s2 = {0}; s2.data = buf2;
+    VssDataString_t s3 = {0}; s3.data = buf3;
+    VssDataString_t* strings_array[] = {&s1, &s2, &s3};
+
+    Avtp_Vss_DeserializeStringArray(&str_array, strings_array, 3);
+
+    assert_int_equal(s1.data_length, 5);
+    assert_memory_equal(s1.data, "Hello", 5);
+    assert_int_equal(s2.data_length, 5);
+    assert_memory_equal(s2.data, "World", 5);
+
+    /* Third string was rejected by the bounds check; the output struct
+     * is left at its initial state. */
+    assert_int_equal(s3.data_length, 0);
+}
+
 int main(void)
 {
     const struct CMUnitTest tests[] = {
@@ -1053,6 +1106,7 @@ int main(void)
         cmocka_unit_test(vss_data_float_array),
         cmocka_unit_test(vss_data_double_array),
         cmocka_unit_test(vss_data_string_array),
+        cmocka_unit_test(vss_data_string_array_malformed),
     };
 
     return cmocka_run_group_tests(tests, NULL, NULL);

--- a/unit/test-vss.c
+++ b/unit/test-vss.c
@@ -1030,18 +1030,13 @@ static void vss_data_string_array_malformed(void **state) {
      * claims 170 bytes of body, but only 7 bytes of buffer remain after
      * its length prefix.
      *
-     * Per the bounds-check fix in this PR, the parser must:
+     * Per the bounds-check, the parser must:
      *   - stop counting at the last fully-contained string, so
      *     GetVSSDataStringArrayLength returns 2 (not 3, and not 0);
      *   - refuse to memcpy past the buffer end, so
      *     DeserializeStringArray fills the first two output structs
      *     with the well-formed strings and leaves the third untouched.
-     *
-     * Without the fix, the same input would have driven memcpy to read
-     * up to ~64 KiB past the end of the buffer in
-     * DeserializeStringArray (heap disclosure / crash) and produced an
-     * uint16_t-arithmetic wrap in GetVSSDataStringArrayLength
-     * (pseudo-infinite loop / DoS). */
+     */
     uint8_t arr_in_mem[] = {
         0x00, 0x05, 'H', 'e', 'l', 'l', 'o',
         0x00, 0x05, 'W', 'o', 'r', 'l', 'd',


### PR DESCRIPTION
## Problem

`Avtp_Vss_DeserializeStringArray` and `Avtp_Vss_GetVSSDataStringArrayLength`
in `src/avtp/acf/custom/Vss.c` walk an on-wire string-array layout of
`[length-prefix : 2 bytes][string : length bytes]` pairs. Both had
serious bounds-check defects letting crafted network input drive
out-of-bounds reads.

### 1. `DeserializeStringArray` — dead bounds check + attacker-controlled `memcpy` length

```c
uint16_t idx = 0;
for (int i = 0; i < num_strings; i++) {
    if(idx >= array_length) break;        // ← dead: idx never incremented
    strings[i]->data_length = Avtp_BeToCpu16(*(const uint16_t*)array_data);
    if (strings[i]->data != NULL) {
        memcpy(strings[i]->data, array_data+2, strings[i]->data_length);
    }
    array_data += 2 + strings[i]->data_length;
}
```

The break is dead code — `idx` is initialised to 0 and never
incremented, so the check only fires when `array_length == 0`. With
attacker-controlled `str_length` values up to UINT16_MAX from the
wire, `memcpy` reads up to ~64 KiB past the end of
`vss_data_string_array->data` on every iteration after the first
malicious entry. Heap disclosure / crash.

### 2. `GetVSSDataStringArrayLength` — uint16_t overflow + off-by-one + truncated return type

```c
uint16_t total_length = str_array->data_length;
uint16_t idx = 0, ptr_idx = 0;
while (ptr_idx < total_length) {                          // off-by-one
    uint16_t str_length = Avtp_BeToCpu16(*(const uint16_t*)(... + ptr_idx));
    ptr_idx += 2 + str_length;                            // uint16_t wraps
    idx++;
}
return idx;                                               // returned as uint8_t
```

Three issues:

- `ptr_idx += 2 + str_length` performs uint16_t arithmetic. A
  `str_length` near UINT16_MAX wraps `ptr_idx` around to a small
  value, making the loop iterate from a low offset again —
  pseudo-infinite loop / DoS.
- `while (ptr_idx < total_length)` permits reading the 2-byte
  length prefix when only 1 byte remains. Off-by-one.
- The return type is `uint8_t`, but `total_length` is `uint16_t` and
  a string can be 0 bytes — the protocol allows up to ~32 k strings
  in a single array. Counts > 255 are silently truncated mod 256.
  Same shape as the `Avtp_Can_GetCanPayloadLength` fix in
  #128.

## Fix

- Add a `consumed` counter in `DeserializeStringArray` that's
  actually incremented per iteration and used to drive the break.
- Add an explicit "remaining bytes ≥ str_length" check before
  `memcpy` so a single malformed length value can't trigger the OOB
  read.
- In `GetVSSDataStringArrayLength`, change the loop guard to
  `ptr_idx + 2 <= total_length` and add a post-length-read check
  that the string body fits.
- Widen the `GetVSSDataStringArrayLength` return type (and its
  declaration in `include/avtp/acf/custom/Vss.h`) from `uint8_t` to
  `uint16_t`.
- Add a NULL-check for `strings[i]` before dereferencing it.
- All bound-check additions are computed in `uint32_t` so the
  additions themselves cannot overflow when `str_length` approaches
  UINT16_MAX.

No behaviour change for well-formed input. Existing unit tests in
`unit/test-vss.c` (the 3-string happy path) continue to pass.

## Notes

- Companion to #128 (the Can/CanBrief payload-length truncation
  fix). Same class of "uint8_t holding a quantity that can exceed
  255" bug, in a different protocol handler.
- I noticed several adjacent issues that I did **not** fix in this
  PR to keep scope focused, including unbounded `memcpy` calls in
  the various `Avtp_*_SetPayload` setters and `memcpy`s of fixed
  array types in `Avtp_Vss_GetVssData`. Happy to follow up with
  separate PRs (or, for the API-shape question of whether setters
  should grow a `bufferSize` parameter to mirror the existing
  `IsValid(pdu, bufferSize)` helpers, a META-Issue first to get
  maintainer guidance).