### PR TITLE
First agentic version of removing conversion and sign-conversion

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -63,7 +63,7 @@ set(CMAKE_CXX_STANDARD_REQUIRED TRUE)
 set(CMAKE_EXPORT_COMPILE_COMMANDS "ON")
 
 # Compiler setting
-add_compile_options(-Wfatal-errors)
+add_compile_options(-Wfatal-errors -Wconversion -Wsign-conversion)
 find_program(CCACHE_BIN ccache)
 if(CCACHE_BIN)
     set_property(GLOBAL PROPERTY RULE_LAUNCH_COMPILE ${CCACHE_BIN})

--- a/examples/common/common.c
+++ b/examples/common/common.c
@@ -62,8 +62,8 @@ int calculate_avtp_time(uint32_t *avtp_time, uint32_t max_transit_time)
         return -1;
     }
 
-    ptime = (tspec.tv_sec * NSEC_PER_SEC) +
-            (max_transit_time * NSEC_PER_MSEC) + tspec.tv_nsec;
+    ptime = ((uint64_t)tspec.tv_sec * NSEC_PER_SEC) +
+            (max_transit_time * NSEC_PER_MSEC) + (uint64_t)tspec.tv_nsec;
 
     *avtp_time = ptime % (1ULL << 32);
 
@@ -81,7 +81,7 @@ int get_presentation_time(uint64_t avtp_time, struct timespec *tspec)
         return -1;
     }
 
-    now = (tspec->tv_sec * NSEC_PER_SEC) + tspec->tv_nsec;
+    now = ((uint64_t)tspec->tv_sec * NSEC_PER_SEC) + (uint64_t)tspec->tv_nsec;
 
     /* The avtp_timestamp within AAF packet is the lower part (32
      * less-significant bits) from presentation time calculated by the
@@ -96,8 +96,8 @@ int get_presentation_time(uint64_t avtp_time, struct timespec *tspec)
     if (ptime < now)
         ptime += (1ULL << 32);
 
-    tspec->tv_sec = ptime / NSEC_PER_SEC;
-    tspec->tv_nsec = ptime % NSEC_PER_SEC;
+    tspec->tv_sec = (__time_t)(ptime / NSEC_PER_SEC);
+    tspec->tv_nsec = (__syscall_slong_t)(ptime % NSEC_PER_SEC);
 
     return 0;
 }
@@ -147,12 +147,12 @@ int setup_socket_address(int fd, const char *ifname, uint8_t macaddr[],
     }
 
     sk_addr->sll_family = AF_PACKET;
-    sk_addr->sll_protocol = htons(protocol);
+    sk_addr->sll_protocol = htons((uint16_t)protocol);
     sk_addr->sll_halen = ETH_ALEN;
     sk_addr->sll_ifindex = req.ifr_ifindex;
 #elif defined(__ZEPHYR__)
     sk_addr->sll_family = AF_PACKET;
-    sk_addr->sll_protocol = htons(protocol);
+    sk_addr->sll_protocol = htons((uint16_t)protocol);
     sk_addr->sll_halen = ETH_ALEN;
     sk_addr->sll_ifindex = net_if_get_by_iface(net_if_get_default());
 #endif
@@ -166,7 +166,7 @@ int setup_udp_socket_address(struct in_addr *addr, uint32_t port,
 
     sk_addr->sin_family = AF_INET;
     sk_addr->sin_addr = *addr;
-    sk_addr->sin_port = htons(port);
+    sk_addr->sin_port = htons((uint16_t)port);
 
     return 0;
 
@@ -239,7 +239,7 @@ int create_listener_socket_udp(uint32_t udp_port) {
     // Initialize the socket
     memset((char *) &sk_addr, 0, sizeof(sk_addr));
     sk_addr.sin_family = AF_INET;
-    sk_addr.sin_port = htons(udp_port);
+    sk_addr.sin_port = htons((uint16_t)udp_port);
     sk_addr.sin_addr.s_addr = htonl(INADDR_ANY);
 
     res = bind(fd, (struct sockaddr *) &sk_addr, sizeof(sk_addr));
@@ -260,7 +260,7 @@ int create_listener_socket(char *ifname, uint8_t* macaddr, int protocol)
     int fd, res;
     struct sockaddr_ll sk_addr;
 
-    fd = socket(AF_PACKET, SOCK_DGRAM, htons(protocol));
+    fd = socket(AF_PACKET, SOCK_DGRAM, htons((uint16_t)protocol));
     if (fd < 0) {
         perror("Failed to open socket");
         return -1;

--- a/include/avtp/acf/Abb.h
+++ b/include/avtp/acf/Abb.h
@@ -145,7 +145,7 @@ static inline void Avtp_Abb_Init(Avtp_Abb_t* msg) {
  * @returns The value of the pad field.
  */
 static inline uint8_t Avtp_Abb_GetPad(const Avtp_Abb_t* msg) {
-    return __Avtp_Abb_GetField(AVTP_ABB_FIELD_PAD);
+    return (uint8_t) __Avtp_Abb_GetField(AVTP_ABB_FIELD_PAD);
 }
 
 /**
@@ -156,7 +156,7 @@ static inline uint8_t Avtp_Abb_GetPad(const Avtp_Abb_t* msg) {
  * @returns The value of the mtv flag.
  */
 static inline bool Avtp_Abb_IsMtv(const Avtp_Abb_t* msg) {
-    return __Avtp_Abb_GetField(AVTP_ABB_FIELD_MTV);
+    return (bool) __Avtp_Abb_GetField(AVTP_ABB_FIELD_MTV);
 }
 
 /**
@@ -166,7 +166,7 @@ static inline bool Avtp_Abb_IsMtv(const Avtp_Abb_t* msg) {
  * @returns The value of the byte_bus_id field.
  */
 static inline uint16_t Avtp_Abb_GetByteBusId(const Avtp_Abb_t* msg) {
-    return __Avtp_Abb_GetField(AVTP_ABB_FIELD_BYTE_BUS_ID);
+    return (uint16_t) __Avtp_Abb_GetField(AVTP_ABB_FIELD_BYTE_BUS_ID);
 }
 
 /**
@@ -176,7 +176,7 @@ static inline uint16_t Avtp_Abb_GetByteBusId(const Avtp_Abb_t* msg) {
  * @returns The value of the evt field.
  */
 static inline uint8_t Avtp_Abb_GetEvt(const Avtp_Abb_t* msg) {
-    return __Avtp_Abb_GetField(AVTP_ABB_FIELD_EVT);
+    return (uint8_t) __Avtp_Abb_GetField(AVTP_ABB_FIELD_EVT);
 }
 
 /**
@@ -186,7 +186,7 @@ static inline uint8_t Avtp_Abb_GetEvt(const Avtp_Abb_t* msg) {
  * @returns The value of the hs field.
  */
 static inline bool Avtp_Abb_IsHs(const Avtp_Abb_t* msg) {
-    return __Avtp_Abb_GetField(AVTP_ABB_FIELD_HS);
+    return (bool) __Avtp_Abb_GetField(AVTP_ABB_FIELD_HS);
 }
 
 /**
@@ -196,7 +196,7 @@ static inline bool Avtp_Abb_IsHs(const Avtp_Abb_t* msg) {
  * @returns The value of the cs field.
  */
 static inline bool Avtp_Abb_IsCs(const Avtp_Abb_t* msg) {
-    return __Avtp_Abb_GetField(AVTP_ABB_FIELD_CS);
+    return (bool) __Avtp_Abb_GetField(AVTP_ABB_FIELD_CS);
 }
 
 /**
@@ -207,7 +207,7 @@ static inline bool Avtp_Abb_IsCs(const Avtp_Abb_t* msg) {
  * @returns The value of the transaction_num field.
  */
 static inline uint8_t Avtp_Abb_GetTransactionNum(const Avtp_Abb_t* msg) {
-    return __Avtp_Abb_GetField(AVTP_ABB_FIELD_TRANSACTION_NUM);
+    return (uint8_t) __Avtp_Abb_GetField(AVTP_ABB_FIELD_TRANSACTION_NUM);
 }
 
 /**
@@ -217,7 +217,7 @@ static inline uint8_t Avtp_Abb_GetTransactionNum(const Avtp_Abb_t* msg) {
  * @returns The value of the op flag.
  */
 static inline bool Avtp_Abb_IsOp(const Avtp_Abb_t* msg) {
-    return __Avtp_Abb_GetField(AVTP_ABB_FIELD_OP);
+    return (bool) __Avtp_Abb_GetField(AVTP_ABB_FIELD_OP);
 }
 
 /**
@@ -227,7 +227,7 @@ static inline bool Avtp_Abb_IsOp(const Avtp_Abb_t* msg) {
  * @returns The value of the rsp flag.
  */
 static inline bool Avtp_Abb_IsRsp(const Avtp_Abb_t* msg) {
-    return __Avtp_Abb_GetField(AVTP_ABB_FIELD_RSP);
+    return (bool) __Avtp_Abb_GetField(AVTP_ABB_FIELD_RSP);
 }
 
 /**
@@ -237,7 +237,7 @@ static inline bool Avtp_Abb_IsRsp(const Avtp_Abb_t* msg) {
  * @returns The value of the err flag.
  */
 static inline bool Avtp_Abb_IsErr(const Avtp_Abb_t* msg) {
-    return __Avtp_Abb_GetField(AVTP_ABB_FIELD_ERR);
+    return (bool) __Avtp_Abb_GetField(AVTP_ABB_FIELD_ERR);
 }
 
 /**
@@ -247,7 +247,7 @@ static inline bool Avtp_Abb_IsErr(const Avtp_Abb_t* msg) {
  * @returns The value of the ms flag.
  */
 static inline bool Avtp_Abb_IsMs(const Avtp_Abb_t* msg) {
-    return __Avtp_Abb_GetField(AVTP_ABB_FIELD_MS);
+    return (bool) __Avtp_Abb_GetField(AVTP_ABB_FIELD_MS);
 }
 
 /**
@@ -258,7 +258,7 @@ static inline bool Avtp_Abb_IsMs(const Avtp_Abb_t* msg) {
  * @returns The value of the read_size/segment_num field.
  */
 static inline uint16_t Avtp_Abb_GetReadSize(const Avtp_Abb_t* msg) {
-    return __Avtp_Abb_GetField(AVTP_ABB_FIELD_READ_SIZE_SEGMENT_NUM);
+    return (uint16_t) __Avtp_Abb_GetField(AVTP_ABB_FIELD_READ_SIZE_SEGMENT_NUM);
 }
 
 /**
@@ -269,7 +269,7 @@ static inline uint16_t Avtp_Abb_GetReadSize(const Avtp_Abb_t* msg) {
  * @returns The value of the read_size/segment_num field.
  */
 static inline uint16_t Avtp_Abb_GetSegmentNum(const Avtp_Abb_t* msg) {
-    return __Avtp_Abb_GetField(AVTP_ABB_FIELD_READ_SIZE_SEGMENT_NUM);
+    return (uint16_t) __Avtp_Abb_GetField(AVTP_ABB_FIELD_READ_SIZE_SEGMENT_NUM);
 }
 
 /**
@@ -281,9 +281,9 @@ static inline uint16_t Avtp_Abb_GetSegmentNum(const Avtp_Abb_t* msg) {
  * @returns The payload length in bytes.
  */
 static inline uint16_t Avtp_Abb_GetPayloadLen(const Avtp_Abb_t* msg) {
-    return __Avtp_Abb_GetField(AVTP_ABB_FIELD_ACF_MSG_LENGTH) * AVTP_QUADLET_SIZE
+    return (uint16_t) (__Avtp_Abb_GetField(AVTP_ABB_FIELD_ACF_MSG_LENGTH) * AVTP_QUADLET_SIZE
            - AVTP_ABB_HEADER_LEN
-           - __Avtp_Abb_GetField(AVTP_ABB_FIELD_PAD);
+           - __Avtp_Abb_GetField(AVTP_ABB_FIELD_PAD));
 }
 
 /**
@@ -294,7 +294,7 @@ static inline uint16_t Avtp_Abb_GetPayloadLen(const Avtp_Abb_t* msg) {
  * @returns The total message length in bytes.
  */
 static inline uint16_t Avtp_Abb_GetLen(const Avtp_Abb_t* msg) {
-    return __Avtp_Abb_GetField(AVTP_ABB_FIELD_ACF_MSG_LENGTH) * AVTP_QUADLET_SIZE;
+    return (uint16_t) (__Avtp_Abb_GetField(AVTP_ABB_FIELD_ACF_MSG_LENGTH) * AVTP_QUADLET_SIZE);
 }
 
 /**

--- a/include/avtp/acf/AcfCommon.h
+++ b/include/avtp/acf/AcfCommon.h
@@ -143,7 +143,7 @@ static inline Avtp_AcfMsgType_t Avtp_AcfCommon_GetAcfMsgType(const Avtp_AcfCommo
  * @returns Returns the ACF message length field of the PDU.
  */
 static inline uint16_t Avtp_AcfCommon_GetAcfMsgLength(const Avtp_AcfCommon_t* const pdu) {
-    return GET_ACF_COMMON_FIELD(AVTP_ACF_FIELD_ACF_MSG_LENGTH);
+    return (uint16_t) GET_ACF_COMMON_FIELD(AVTP_ACF_FIELD_ACF_MSG_LENGTH);
 }
 
 /**

--- a/include/avtp/acf/Can.h
+++ b/include/avtp/acf/Can.h
@@ -111,7 +111,7 @@ static const Avtp_FieldDescriptor_t Avtp_CanFieldDesc[AVTP_CAN_FIELD_MAX] =
  * @returns Value of the ACF message type field.
  */
 static inline uint8_t Avtp_Can_GetAcfMsgType(const Avtp_Can_t* const pdu) {
-    return GET_CAN_FIELD(AVTP_CAN_FIELD_ACF_MSG_TYPE);
+    return (uint8_t) GET_CAN_FIELD(AVTP_CAN_FIELD_ACF_MSG_TYPE);
 }
 
 /**
@@ -121,7 +121,7 @@ static inline uint8_t Avtp_Can_GetAcfMsgType(const Avtp_Can_t* const pdu) {
  * @returns Value of the ACF message length field.
  */
 static inline uint16_t Avtp_Can_GetAcfMsgLength(const Avtp_Can_t* const pdu) {
-    return GET_CAN_FIELD(AVTP_CAN_FIELD_ACF_MSG_LENGTH);
+    return (uint16_t) GET_CAN_FIELD(AVTP_CAN_FIELD_ACF_MSG_LENGTH);
 }
 
 /**
@@ -131,7 +131,7 @@ static inline uint16_t Avtp_Can_GetAcfMsgLength(const Avtp_Can_t* const pdu) {
  * @returns Value of the ACF padding field.
  */
 static inline uint8_t Avtp_Can_GetPad(const Avtp_Can_t* const pdu) {
-    return GET_CAN_FIELD(AVTP_CAN_FIELD_PAD);
+    return (uint8_t) GET_CAN_FIELD(AVTP_CAN_FIELD_PAD);
 }
 
 /**
@@ -141,7 +141,7 @@ static inline uint8_t Avtp_Can_GetPad(const Avtp_Can_t* const pdu) {
  * @returns Value of the ACF CAN PDU MTV field.
  */
 static inline uint8_t Avtp_Can_GetMtv(const Avtp_Can_t* const pdu) {
-    return GET_CAN_FIELD(AVTP_CAN_FIELD_MTV);
+    return (uint8_t) GET_CAN_FIELD(AVTP_CAN_FIELD_MTV);
 }
 
 /**
@@ -151,7 +151,7 @@ static inline uint8_t Avtp_Can_GetMtv(const Avtp_Can_t* const pdu) {
  * @returns Value of the ACF CAN PDU RTR field.
  */
 static inline uint8_t Avtp_Can_GetRtr(const Avtp_Can_t* const pdu) {
-    return GET_CAN_FIELD(AVTP_CAN_FIELD_RTR);
+    return (uint8_t) GET_CAN_FIELD(AVTP_CAN_FIELD_RTR);
 }
 
 /**
@@ -161,7 +161,7 @@ static inline uint8_t Avtp_Can_GetRtr(const Avtp_Can_t* const pdu) {
  * @returns Value of the ACF CAN PDU EFF field.
  */
 static inline uint8_t Avtp_Can_GetEff(const Avtp_Can_t* const pdu) {
-    return GET_CAN_FIELD(AVTP_CAN_FIELD_EFF);
+    return (uint8_t) GET_CAN_FIELD(AVTP_CAN_FIELD_EFF);
 }
 
 /**
@@ -171,7 +171,7 @@ static inline uint8_t Avtp_Can_GetEff(const Avtp_Can_t* const pdu) {
  * @returns Value of the ACF CAN PDU BRS field.
  */
 static inline uint8_t Avtp_Can_GetBrs(const Avtp_Can_t* const pdu) {
-    return GET_CAN_FIELD(AVTP_CAN_FIELD_BRS);
+    return (uint8_t) GET_CAN_FIELD(AVTP_CAN_FIELD_BRS);
 }
 
 /**
@@ -181,7 +181,7 @@ static inline uint8_t Avtp_Can_GetBrs(const Avtp_Can_t* const pdu) {
  * @returns Value of the ACF CAN PDU FDF field.
  */
 static inline uint8_t Avtp_Can_GetFdf(const Avtp_Can_t* const pdu) {
-    return GET_CAN_FIELD(AVTP_CAN_FIELD_FDF);
+    return (uint8_t) GET_CAN_FIELD(AVTP_CAN_FIELD_FDF);
 }
 
 /**
@@ -191,7 +191,7 @@ static inline uint8_t Avtp_Can_GetFdf(const Avtp_Can_t* const pdu) {
  * @returns Value of the ACF CAN PDU ESI field.
  */
 static inline uint8_t Avtp_Can_GetEsi(const Avtp_Can_t* const pdu) {
-    return GET_CAN_FIELD(AVTP_CAN_FIELD_ESI);
+    return (uint8_t) GET_CAN_FIELD(AVTP_CAN_FIELD_ESI);
 }
 
 /**
@@ -201,7 +201,7 @@ static inline uint8_t Avtp_Can_GetEsi(const Avtp_Can_t* const pdu) {
  * @returns Value of the ACF CAN PDU CAN Bus ID field.
  */
 static inline uint8_t Avtp_Can_GetCanBusId(const Avtp_Can_t* const pdu) {
-    return GET_CAN_FIELD(AVTP_CAN_FIELD_CAN_BUS_ID);
+    return (uint8_t) GET_CAN_FIELD(AVTP_CAN_FIELD_CAN_BUS_ID);
 }
 
 /**
@@ -221,7 +221,7 @@ static inline uint64_t Avtp_Can_GetMessageTimestamp(const Avtp_Can_t* const pdu)
  * @returns Value of the ACF CAN PDU CAN Identifier field.
  */
 static inline uint32_t Avtp_Can_GetCanIdentifier(const Avtp_Can_t* const pdu) {
-    return GET_CAN_FIELD(AVTP_CAN_FIELD_CAN_IDENTIFIER);
+    return (uint32_t) GET_CAN_FIELD(AVTP_CAN_FIELD_CAN_IDENTIFIER);
 }
 
 /**

--- a/include/avtp/acf/CanBrief.h
+++ b/include/avtp/acf/CanBrief.h
@@ -120,7 +120,7 @@ static inline uint64_t Avtp_CanBrief_GetField(const Avtp_CanBrief_t* const pdu, 
  * @returns Value of the ACF message type field.
  */
 static inline uint8_t Avtp_CanBrief_GetAcfMsgType(const Avtp_CanBrief_t* const pdu) {
-    return GET_CAN_BRIEF_FIELD(AVTP_CAN_BRIEF_FIELD_ACF_MSG_TYPE);
+    return (uint8_t) GET_CAN_BRIEF_FIELD(AVTP_CAN_BRIEF_FIELD_ACF_MSG_TYPE);
 }
 /**
  * Return the value of an an ACF message length field as specified in the IEEE 1722 Specification.
@@ -129,7 +129,7 @@ static inline uint8_t Avtp_CanBrief_GetAcfMsgType(const Avtp_CanBrief_t* const p
  * @returns Value of the ACF message length field.
  */
 static inline uint16_t Avtp_CanBrief_GetAcfMsgLength(const Avtp_CanBrief_t* const pdu) {
-    return GET_CAN_BRIEF_FIELD(AVTP_CAN_BRIEF_FIELD_ACF_MSG_LENGTH);
+    return (uint16_t) GET_CAN_BRIEF_FIELD(AVTP_CAN_BRIEF_FIELD_ACF_MSG_LENGTH);
 }
 
 /**
@@ -139,7 +139,7 @@ static inline uint16_t Avtp_CanBrief_GetAcfMsgLength(const Avtp_CanBrief_t* cons
  * @returns Value of the ACF padding field.
  */
 static inline uint8_t Avtp_CanBrief_GetPad(const Avtp_CanBrief_t* const pdu) {
-    return GET_CAN_BRIEF_FIELD(AVTP_CAN_BRIEF_FIELD_PAD);
+    return (uint8_t) GET_CAN_BRIEF_FIELD(AVTP_CAN_BRIEF_FIELD_PAD);
 }
 
 /** 
@@ -149,7 +149,7 @@ static inline uint8_t Avtp_CanBrief_GetPad(const Avtp_CanBrief_t* const pdu) {
  * @returns Value of the ACF CAN Brief PDU MTV field.
  */
 static inline uint8_t Avtp_CanBrief_GetMtv(const Avtp_CanBrief_t* const pdu) {
-    return GET_CAN_BRIEF_FIELD(AVTP_CAN_BRIEF_FIELD_MTV);
+    return (uint8_t) GET_CAN_BRIEF_FIELD(AVTP_CAN_BRIEF_FIELD_MTV);
 }
 
 /**
@@ -159,7 +159,7 @@ static inline uint8_t Avtp_CanBrief_GetMtv(const Avtp_CanBrief_t* const pdu) {
  * @returns Value of the ACF CAN Brief PDU RTR field.
  */
 static inline uint8_t Avtp_CanBrief_GetRtr(const Avtp_CanBrief_t* const pdu) {
-    return GET_CAN_BRIEF_FIELD(AVTP_CAN_BRIEF_FIELD_RTR);
+    return (uint8_t) GET_CAN_BRIEF_FIELD(AVTP_CAN_BRIEF_FIELD_RTR);
 }
 
 /**
@@ -169,7 +169,7 @@ static inline uint8_t Avtp_CanBrief_GetRtr(const Avtp_CanBrief_t* const pdu) {
  * @returns Value of the ACF CAN Brief PDU EFF field.
  */
 static inline uint8_t Avtp_CanBrief_GetEff(const Avtp_CanBrief_t* const pdu) {
-    return GET_CAN_BRIEF_FIELD(AVTP_CAN_BRIEF_FIELD_EFF);
+    return (uint8_t) GET_CAN_BRIEF_FIELD(AVTP_CAN_BRIEF_FIELD_EFF);
 }
 
 /** 
@@ -179,7 +179,7 @@ static inline uint8_t Avtp_CanBrief_GetEff(const Avtp_CanBrief_t* const pdu) {
  * @returns Value of the ACF CAN Brief PDU BRS field.
  */
 static inline uint8_t Avtp_CanBrief_GetBrs(const Avtp_CanBrief_t* const pdu) {
-    return GET_CAN_BRIEF_FIELD(AVTP_CAN_BRIEF_FIELD_BRS);
+    return (uint8_t) GET_CAN_BRIEF_FIELD(AVTP_CAN_BRIEF_FIELD_BRS);
 }
 
 /**
@@ -189,7 +189,7 @@ static inline uint8_t Avtp_CanBrief_GetBrs(const Avtp_CanBrief_t* const pdu) {
  * @returns Value of the ACF CAN Brief PDU FDF field.
  */
 static inline uint8_t Avtp_CanBrief_GetFdf(const Avtp_CanBrief_t* const pdu) {
-    return GET_CAN_BRIEF_FIELD(AVTP_CAN_BRIEF_FIELD_FDF);
+    return (uint8_t) GET_CAN_BRIEF_FIELD(AVTP_CAN_BRIEF_FIELD_FDF);
 }
 
 /**
@@ -199,7 +199,7 @@ static inline uint8_t Avtp_CanBrief_GetFdf(const Avtp_CanBrief_t* const pdu) {
  * @returns Value of the ACF CAN Brief PDU ESI field.
  */
 static inline uint8_t Avtp_CanBrief_GetEsi(const Avtp_CanBrief_t* const pdu) {
-    return GET_CAN_BRIEF_FIELD(AVTP_CAN_BRIEF_FIELD_ESI);
+    return (uint8_t) GET_CAN_BRIEF_FIELD(AVTP_CAN_BRIEF_FIELD_ESI);
 }
 
 /**
@@ -209,7 +209,7 @@ static inline uint8_t Avtp_CanBrief_GetEsi(const Avtp_CanBrief_t* const pdu) {
  * @returns Value of the ACF CAN Brief PDU CAN Bus ID field.
  */
 static inline uint8_t Avtp_CanBrief_GetCanBusId(const Avtp_CanBrief_t* const pdu) {
-    return GET_CAN_BRIEF_FIELD(AVTP_CAN_BRIEF_FIELD_CAN_BUS_ID);
+    return (uint8_t) GET_CAN_BRIEF_FIELD(AVTP_CAN_BRIEF_FIELD_CAN_BUS_ID);
 }
 
 /**
@@ -219,7 +219,7 @@ static inline uint8_t Avtp_CanBrief_GetCanBusId(const Avtp_CanBrief_t* const pdu
  * @returns Value of the ACF CAN Brief PDU CAN Identifier field.
  */
 static inline uint32_t Avtp_CanBrief_GetCanIdentifier(const Avtp_CanBrief_t* const pdu) {
-    return GET_CAN_BRIEF_FIELD(AVTP_CAN_BRIEF_FIELD_CAN_IDENTIFIER);
+    return (uint32_t) GET_CAN_BRIEF_FIELD(AVTP_CAN_BRIEF_FIELD_CAN_IDENTIFIER);
 }
 
 /**

--- a/include/avtp/acf/CanBriefV2.h
+++ b/include/avtp/acf/CanBriefV2.h
@@ -138,7 +138,7 @@ static inline void Avtp_CanBriefV2_Init(Avtp_CanBriefV2_t* msg) {
  * @returns The value of the pad field.
  */
 static inline uint8_t Avtp_CanBriefV2_GetPad(const Avtp_CanBriefV2_t* msg) {
-    return __Avtp_CanBriefV2_GetField(AVTP_CAN_BRIEF_V2_FIELD_PAD);
+    return (uint8_t) __Avtp_CanBriefV2_GetField(AVTP_CAN_BRIEF_V2_FIELD_PAD);
 }
 
 /**
@@ -149,7 +149,7 @@ static inline uint8_t Avtp_CanBriefV2_GetPad(const Avtp_CanBriefV2_t* msg) {
  * @returns The value of the mtv flag.
  */
 static inline bool Avtp_CanBriefV2_IsMtv(const Avtp_CanBriefV2_t* msg) {
-    return __Avtp_CanBriefV2_GetField(AVTP_CAN_BRIEF_V2_FIELD_MTV);
+    return (bool) __Avtp_CanBriefV2_GetField(AVTP_CAN_BRIEF_V2_FIELD_MTV);
 }
 
 /**
@@ -160,7 +160,7 @@ static inline bool Avtp_CanBriefV2_IsMtv(const Avtp_CanBriefV2_t* msg) {
  * @returns The value of the rtr flag.
  */
 static inline bool Avtp_CanBriefV2_IsRtr(const Avtp_CanBriefV2_t* msg) {
-    return __Avtp_CanBriefV2_GetField(AVTP_CAN_BRIEF_V2_FIELD_RTR);
+    return (bool) __Avtp_CanBriefV2_GetField(AVTP_CAN_BRIEF_V2_FIELD_RTR);
 }
 
 /**
@@ -171,7 +171,7 @@ static inline bool Avtp_CanBriefV2_IsRtr(const Avtp_CanBriefV2_t* msg) {
  * @returns The value of the eff flag.
  */
 static inline bool Avtp_CanBriefV2_IsEff(const Avtp_CanBriefV2_t* msg) {
-    return __Avtp_CanBriefV2_GetField(AVTP_CAN_BRIEF_V2_FIELD_EFF);
+    return (bool) __Avtp_CanBriefV2_GetField(AVTP_CAN_BRIEF_V2_FIELD_EFF);
 }
 
 /**
@@ -181,7 +181,7 @@ static inline bool Avtp_CanBriefV2_IsEff(const Avtp_CanBriefV2_t* msg) {
  * @returns The value of the can_bus_id field.
  */
 static inline uint16_t Avtp_CanBriefV2_GetCanBusId(const Avtp_CanBriefV2_t* msg) {
-    return __Avtp_CanBriefV2_GetField(AVTP_CAN_BRIEF_V2_FIELD_CAN_BUS_ID);
+    return (uint16_t) __Avtp_CanBriefV2_GetField(AVTP_CAN_BRIEF_V2_FIELD_CAN_BUS_ID);
 }
 
 /**
@@ -191,7 +191,7 @@ static inline uint16_t Avtp_CanBriefV2_GetCanBusId(const Avtp_CanBriefV2_t* msg)
  * @returns The value of the brs flag.
  */
 static inline bool Avtp_CanBriefV2_IsBrs(const Avtp_CanBriefV2_t* msg) {
-    return __Avtp_CanBriefV2_GetField(AVTP_CAN_BRIEF_V2_FIELD_BRS);
+    return (bool) __Avtp_CanBriefV2_GetField(AVTP_CAN_BRIEF_V2_FIELD_BRS);
 }
 
 /**
@@ -201,7 +201,7 @@ static inline bool Avtp_CanBriefV2_IsBrs(const Avtp_CanBriefV2_t* msg) {
  * @returns The value of the fdf flag.
  */
 static inline bool Avtp_CanBriefV2_IsFdf(const Avtp_CanBriefV2_t* msg) {
-    return __Avtp_CanBriefV2_GetField(AVTP_CAN_BRIEF_V2_FIELD_FDF);
+    return (bool) __Avtp_CanBriefV2_GetField(AVTP_CAN_BRIEF_V2_FIELD_FDF);
 }
 
 /**
@@ -212,7 +212,7 @@ static inline bool Avtp_CanBriefV2_IsFdf(const Avtp_CanBriefV2_t* msg) {
  * @returns The value of the esi flag.
  */
 static inline bool Avtp_CanBriefV2_IsEsi(const Avtp_CanBriefV2_t* msg) {
-    return __Avtp_CanBriefV2_GetField(AVTP_CAN_BRIEF_V2_FIELD_ESI);
+    return (bool) __Avtp_CanBriefV2_GetField(AVTP_CAN_BRIEF_V2_FIELD_ESI);
 }
 
 /**
@@ -222,7 +222,7 @@ static inline bool Avtp_CanBriefV2_IsEsi(const Avtp_CanBriefV2_t* msg) {
  * @returns The value of the can_identifier field.
  */
 static inline uint32_t Avtp_CanBriefV2_GetCanIdentifier(const Avtp_CanBriefV2_t* msg) {
-    return __Avtp_CanBriefV2_GetField(AVTP_CAN_BRIEF_V2_FIELD_CAN_IDENTIFIER);
+    return (uint32_t) __Avtp_CanBriefV2_GetField(AVTP_CAN_BRIEF_V2_FIELD_CAN_IDENTIFIER);
 }
 
 /**
@@ -234,9 +234,9 @@ static inline uint32_t Avtp_CanBriefV2_GetCanIdentifier(const Avtp_CanBriefV2_t*
  * @returns The payload length in bytes.
  */
 static inline uint16_t Avtp_CanBriefV2_GetPayloadLen(const Avtp_CanBriefV2_t* msg) {
-    return __Avtp_CanBriefV2_GetField(AVTP_CAN_BRIEF_V2_FIELD_ACF_MSG_LENGTH) * AVTP_QUADLET_SIZE
+    return (uint16_t) (__Avtp_CanBriefV2_GetField(AVTP_CAN_BRIEF_V2_FIELD_ACF_MSG_LENGTH) * AVTP_QUADLET_SIZE
            - AVTP_CAN_BRIEF_V2_HEADER_LEN
-           - __Avtp_CanBriefV2_GetField(AVTP_CAN_BRIEF_V2_FIELD_PAD);
+           - __Avtp_CanBriefV2_GetField(AVTP_CAN_BRIEF_V2_FIELD_PAD));
 }
 
 /**
@@ -247,7 +247,7 @@ static inline uint16_t Avtp_CanBriefV2_GetPayloadLen(const Avtp_CanBriefV2_t* ms
  * @returns The total message length in bytes.
  */
 static inline uint16_t Avtp_CanBriefV2_GetLen(const Avtp_CanBriefV2_t* msg) {
-    return __Avtp_CanBriefV2_GetField(AVTP_CAN_BRIEF_V2_FIELD_ACF_MSG_LENGTH) * AVTP_QUADLET_SIZE;
+    return (uint16_t) (__Avtp_CanBriefV2_GetField(AVTP_CAN_BRIEF_V2_FIELD_ACF_MSG_LENGTH) * AVTP_QUADLET_SIZE);
 }
 
 /**

--- a/include/avtp/acf/CanV2.h
+++ b/include/avtp/acf/CanV2.h
@@ -141,7 +141,7 @@ static inline void Avtp_CanV2_Init(Avtp_CanV2_t* msg) {
  * @returns The value of the pad field.
  */
 static inline uint8_t Avtp_CanV2_GetPad(const Avtp_CanV2_t* msg) {
-    return __Avtp_CanV2_GetField(AVTP_CAN_V2_FIELD_PAD);
+    return (uint8_t) __Avtp_CanV2_GetField(AVTP_CAN_V2_FIELD_PAD);
 }
 
 /**
@@ -152,7 +152,7 @@ static inline uint8_t Avtp_CanV2_GetPad(const Avtp_CanV2_t* msg) {
  * @returns The value of the mtv flag.
  */
 static inline bool Avtp_CanV2_IsMtv(const Avtp_CanV2_t* msg) {
-    return __Avtp_CanV2_GetField(AVTP_CAN_V2_FIELD_MTV);
+    return (bool) __Avtp_CanV2_GetField(AVTP_CAN_V2_FIELD_MTV);
 }
 
 /**
@@ -163,7 +163,7 @@ static inline bool Avtp_CanV2_IsMtv(const Avtp_CanV2_t* msg) {
  * @returns The value of the rtr flag.
  */
 static inline bool Avtp_CanV2_IsRtr(const Avtp_CanV2_t* msg) {
-    return __Avtp_CanV2_GetField(AVTP_CAN_V2_FIELD_RTR);
+    return (bool) __Avtp_CanV2_GetField(AVTP_CAN_V2_FIELD_RTR);
 }
 
 /**
@@ -174,7 +174,7 @@ static inline bool Avtp_CanV2_IsRtr(const Avtp_CanV2_t* msg) {
  * @returns The value of the eff flag.
  */
 static inline bool Avtp_CanV2_IsEff(const Avtp_CanV2_t* msg) {
-    return __Avtp_CanV2_GetField(AVTP_CAN_V2_FIELD_EFF);
+    return (bool) __Avtp_CanV2_GetField(AVTP_CAN_V2_FIELD_EFF);
 }
 
 /**
@@ -184,7 +184,7 @@ static inline bool Avtp_CanV2_IsEff(const Avtp_CanV2_t* msg) {
  * @returns The value of the can_bus_id field.
  */
 static inline uint16_t Avtp_CanV2_GetCanBusId(const Avtp_CanV2_t* msg) {
-    return __Avtp_CanV2_GetField(AVTP_CAN_V2_FIELD_CAN_BUS_ID);
+    return (uint16_t) __Avtp_CanV2_GetField(AVTP_CAN_V2_FIELD_CAN_BUS_ID);
 }
 
 /**
@@ -195,7 +195,7 @@ static inline uint16_t Avtp_CanV2_GetCanBusId(const Avtp_CanV2_t* msg) {
  * @returns The value of the message_timestamp field.
  */
 static inline uint64_t Avtp_CanV2_GetMessageTimestamp(const Avtp_CanV2_t* msg) {
-    return __Avtp_CanV2_GetField(AVTP_CAN_V2_FIELD_MESSAGE_TIMESTAMP);
+    return (uint64_t) __Avtp_CanV2_GetField(AVTP_CAN_V2_FIELD_MESSAGE_TIMESTAMP);
 }
 
 /**
@@ -205,7 +205,7 @@ static inline uint64_t Avtp_CanV2_GetMessageTimestamp(const Avtp_CanV2_t* msg) {
  * @returns The value of the brs flag.
  */
 static inline bool Avtp_CanV2_IsBrs(const Avtp_CanV2_t* msg) {
-    return __Avtp_CanV2_GetField(AVTP_CAN_V2_FIELD_BRS);
+    return (bool) __Avtp_CanV2_GetField(AVTP_CAN_V2_FIELD_BRS);
 }
 
 /**
@@ -215,7 +215,7 @@ static inline bool Avtp_CanV2_IsBrs(const Avtp_CanV2_t* msg) {
  * @returns The value of the fdf flag.
  */
 static inline bool Avtp_CanV2_IsFdf(const Avtp_CanV2_t* msg) {
-    return __Avtp_CanV2_GetField(AVTP_CAN_V2_FIELD_FDF);
+    return (bool) __Avtp_CanV2_GetField(AVTP_CAN_V2_FIELD_FDF);
 }
 
 /**
@@ -225,7 +225,7 @@ static inline bool Avtp_CanV2_IsFdf(const Avtp_CanV2_t* msg) {
  * @returns The value of the esi flag.
  */
 static inline bool Avtp_CanV2_IsEsi(const Avtp_CanV2_t* msg) {
-    return __Avtp_CanV2_GetField(AVTP_CAN_V2_FIELD_ESI);
+    return (bool) __Avtp_CanV2_GetField(AVTP_CAN_V2_FIELD_ESI);
 }
 
 /**
@@ -235,7 +235,7 @@ static inline bool Avtp_CanV2_IsEsi(const Avtp_CanV2_t* msg) {
  * @returns The value of the can_identifier field.
  */
 static inline uint32_t Avtp_CanV2_GetCanIdentifier(const Avtp_CanV2_t* msg) {
-    return __Avtp_CanV2_GetField(AVTP_CAN_V2_FIELD_CAN_IDENTIFIER);
+    return (uint32_t) __Avtp_CanV2_GetField(AVTP_CAN_V2_FIELD_CAN_IDENTIFIER);
 }
 
 /**
@@ -247,9 +247,9 @@ static inline uint32_t Avtp_CanV2_GetCanIdentifier(const Avtp_CanV2_t* msg) {
  * @returns The payload length in bytes.
  */
 static inline uint16_t Avtp_CanV2_GetPayloadLen(const Avtp_CanV2_t* msg) {
-    return __Avtp_CanV2_GetField(AVTP_CAN_V2_FIELD_ACF_MSG_LENGTH) * AVTP_QUADLET_SIZE
+    return (uint16_t) (__Avtp_CanV2_GetField(AVTP_CAN_V2_FIELD_ACF_MSG_LENGTH) * AVTP_QUADLET_SIZE
            - AVTP_CAN_V2_HEADER_LEN
-           - __Avtp_CanV2_GetField(AVTP_CAN_V2_FIELD_PAD);
+           - __Avtp_CanV2_GetField(AVTP_CAN_V2_FIELD_PAD));
 }
 
 /**
@@ -260,7 +260,7 @@ static inline uint16_t Avtp_CanV2_GetPayloadLen(const Avtp_CanV2_t* msg) {
  * @returns The total message length in bytes.
  */
 static inline uint16_t Avtp_CanV2_GetLen(const Avtp_CanV2_t* msg) {
-    return __Avtp_CanV2_GetField(AVTP_CAN_V2_FIELD_ACF_MSG_LENGTH) * AVTP_QUADLET_SIZE;
+    return (uint16_t) (__Avtp_CanV2_GetField(AVTP_CAN_V2_FIELD_ACF_MSG_LENGTH) * AVTP_QUADLET_SIZE);
 }
 
 /**

--- a/include/avtp/acf/CanXl.h
+++ b/include/avtp/acf/CanXl.h
@@ -147,7 +147,7 @@ static inline void Avtp_CanXl_Init(Avtp_CanXl_t* msg) {
  * @returns The value of the pad field.
  */
 static inline uint8_t Avtp_CanXl_GetPad(const Avtp_CanXl_t* msg) {
-    return __Avtp_CanXl_GetField(AVTP_CANXL_FIELD_PAD);
+    return (uint8_t) __Avtp_CanXl_GetField(AVTP_CANXL_FIELD_PAD);
 }
 
 /**
@@ -158,7 +158,7 @@ static inline uint8_t Avtp_CanXl_GetPad(const Avtp_CanXl_t* msg) {
  * @returns The value of the mtv flag.
  */
 static inline bool Avtp_CanXl_IsMtv(const Avtp_CanXl_t* msg) {
-    return __Avtp_CanXl_GetField(AVTP_CANXL_FIELD_MTV);
+    return (bool) __Avtp_CanXl_GetField(AVTP_CANXL_FIELD_MTV);
 }
 
 /**
@@ -168,7 +168,7 @@ static inline bool Avtp_CanXl_IsMtv(const Avtp_CanXl_t* msg) {
  * @returns The value of the can_bus_id field.
  */
 static inline uint16_t Avtp_CanXl_GetCanBusId(const Avtp_CanXl_t* msg) {
-    return __Avtp_CanXl_GetField(AVTP_CANXL_FIELD_CAN_BUS_ID);
+    return (uint16_t) __Avtp_CanXl_GetField(AVTP_CANXL_FIELD_CAN_BUS_ID);
 }
 
 /**
@@ -179,7 +179,7 @@ static inline uint16_t Avtp_CanXl_GetCanBusId(const Avtp_CanXl_t* msg) {
  * @returns The value of the message_timestamp field.
  */
 static inline uint64_t Avtp_CanXl_GetMessageTimestamp(const Avtp_CanXl_t* msg) {
-    return __Avtp_CanXl_GetField(AVTP_CANXL_FIELD_MESSAGE_TIMESTAMP);
+    return (uint64_t) __Avtp_CanXl_GetField(AVTP_CANXL_FIELD_MESSAGE_TIMESTAMP);
 }
 
 /**
@@ -189,7 +189,7 @@ static inline uint64_t Avtp_CanXl_GetMessageTimestamp(const Avtp_CanXl_t* msg) {
  * @returns The value of the vcid field.
  */
 static inline uint8_t Avtp_CanXl_GetVcid(const Avtp_CanXl_t* msg) {
-    return __Avtp_CanXl_GetField(AVTP_CANXL_FIELD_VCID);
+    return (uint8_t) __Avtp_CanXl_GetField(AVTP_CANXL_FIELD_VCID);
 }
 
 /**
@@ -199,7 +199,7 @@ static inline uint8_t Avtp_CanXl_GetVcid(const Avtp_CanXl_t* msg) {
  * @returns The value of the sdt field.
  */
 static inline uint8_t Avtp_CanXl_GetSdt(const Avtp_CanXl_t* msg) {
-    return __Avtp_CanXl_GetField(AVTP_CANXL_FIELD_SDT);
+    return (uint8_t) __Avtp_CanXl_GetField(AVTP_CANXL_FIELD_SDT);
 }
 
 /**
@@ -209,7 +209,7 @@ static inline uint8_t Avtp_CanXl_GetSdt(const Avtp_CanXl_t* msg) {
  * @returns The value of the rrs flag.
  */
 static inline bool Avtp_CanXl_IsRrs(const Avtp_CanXl_t* msg) {
-    return __Avtp_CanXl_GetField(AVTP_CANXL_FIELD_RRS);
+    return (bool) __Avtp_CanXl_GetField(AVTP_CANXL_FIELD_RRS);
 }
 
 /**
@@ -219,7 +219,7 @@ static inline bool Avtp_CanXl_IsRrs(const Avtp_CanXl_t* msg) {
  * @returns The value of the sec flag.
  */
 static inline bool Avtp_CanXl_IsSec(const Avtp_CanXl_t* msg) {
-    return __Avtp_CanXl_GetField(AVTP_CANXL_FIELD_SEC);
+    return (bool) __Avtp_CanXl_GetField(AVTP_CANXL_FIELD_SEC);
 }
 
 /**
@@ -229,7 +229,7 @@ static inline bool Avtp_CanXl_IsSec(const Avtp_CanXl_t* msg) {
  * @returns The value of the priority_id field.
  */
 static inline uint16_t Avtp_CanXl_GetPriorityId(const Avtp_CanXl_t* msg) {
-    return __Avtp_CanXl_GetField(AVTP_CANXL_FIELD_PRIORITY_ID);
+    return (uint16_t) __Avtp_CanXl_GetField(AVTP_CANXL_FIELD_PRIORITY_ID);
 }
 
 /**
@@ -239,7 +239,7 @@ static inline uint16_t Avtp_CanXl_GetPriorityId(const Avtp_CanXl_t* msg) {
  * @returns The value of the acceptance_field.
  */
 static inline uint32_t Avtp_CanXl_GetAcceptanceField(const Avtp_CanXl_t* msg) {
-    return __Avtp_CanXl_GetField(AVTP_CANXL_FIELD_ACCEPTANCE_FIELD);
+    return (uint32_t) __Avtp_CanXl_GetField(AVTP_CANXL_FIELD_ACCEPTANCE_FIELD);
 }
 
 /**
@@ -250,7 +250,7 @@ static inline uint32_t Avtp_CanXl_GetAcceptanceField(const Avtp_CanXl_t* msg) {
  * @returns The value of the transaction_num field.
  */
 static inline uint8_t Avtp_CanXl_GetTransactionNum(const Avtp_CanXl_t* msg) {
-    return __Avtp_CanXl_GetField(AVTP_CANXL_FIELD_TRANSACTION_NUM);
+    return (uint8_t) __Avtp_CanXl_GetField(AVTP_CANXL_FIELD_TRANSACTION_NUM);
 }
 
 /**
@@ -260,7 +260,7 @@ static inline uint8_t Avtp_CanXl_GetTransactionNum(const Avtp_CanXl_t* msg) {
  * @returns The value of the ms flag.
  */
 static inline bool Avtp_CanXl_IsMs(const Avtp_CanXl_t* msg) {
-    return __Avtp_CanXl_GetField(AVTP_CANXL_FIELD_MS);
+    return (bool) __Avtp_CanXl_GetField(AVTP_CANXL_FIELD_MS);
 }
 
 /**
@@ -270,7 +270,7 @@ static inline bool Avtp_CanXl_IsMs(const Avtp_CanXl_t* msg) {
  * @returns The value of the segment_num field.
  */
 static inline uint16_t Avtp_CanXl_GetSegmentNum(const Avtp_CanXl_t* msg) {
-    return __Avtp_CanXl_GetField(AVTP_CANXL_FIELD_SEGMENT_NUM);
+    return (uint16_t) __Avtp_CanXl_GetField(AVTP_CANXL_FIELD_SEGMENT_NUM);
 }
 
 /**
@@ -282,9 +282,9 @@ static inline uint16_t Avtp_CanXl_GetSegmentNum(const Avtp_CanXl_t* msg) {
  * @returns The payload length in bytes.
  */
 static inline uint16_t Avtp_CanXl_GetPayloadLen(const Avtp_CanXl_t* msg) {
-    return __Avtp_CanXl_GetField(AVTP_CANXL_FIELD_ACF_MSG_LENGTH) * AVTP_QUADLET_SIZE
+    return (uint16_t) (__Avtp_CanXl_GetField(AVTP_CANXL_FIELD_ACF_MSG_LENGTH) * AVTP_QUADLET_SIZE
            - AVTP_CANXL_HEADER_LEN
-           - __Avtp_CanXl_GetField(AVTP_CANXL_FIELD_PAD);
+           - __Avtp_CanXl_GetField(AVTP_CANXL_FIELD_PAD));
 }
 
 /**
@@ -295,7 +295,7 @@ static inline uint16_t Avtp_CanXl_GetPayloadLen(const Avtp_CanXl_t* msg) {
  * @returns The total message length in bytes.
  */
 static inline uint16_t Avtp_CanXl_GetLen(const Avtp_CanXl_t* msg) {
-    return __Avtp_CanXl_GetField(AVTP_CANXL_FIELD_ACF_MSG_LENGTH) * AVTP_QUADLET_SIZE;
+    return (uint16_t) (__Avtp_CanXl_GetField(AVTP_CANXL_FIELD_ACF_MSG_LENGTH) * AVTP_QUADLET_SIZE);
 }
 
 /**

--- a/include/avtp/acf/CanXlBrief.h
+++ b/include/avtp/acf/CanXlBrief.h
@@ -145,7 +145,7 @@ static inline void Avtp_CanXlBrief_Init(Avtp_CanXlBrief_t* msg) {
  * @returns The value of the pad field.
  */
 static inline uint8_t Avtp_CanXlBrief_GetPad(const Avtp_CanXlBrief_t* msg) {
-    return __Avtp_CanXlBrief_GetField(AVTP_CANXL_BRIEF_FIELD_PAD);
+    return (uint8_t) __Avtp_CanXlBrief_GetField(AVTP_CANXL_BRIEF_FIELD_PAD);
 }
 
 /**
@@ -156,7 +156,7 @@ static inline uint8_t Avtp_CanXlBrief_GetPad(const Avtp_CanXlBrief_t* msg) {
  * @returns The value of the mtv flag.
  */
 static inline bool Avtp_CanXlBrief_IsMtv(const Avtp_CanXlBrief_t* msg) {
-    return __Avtp_CanXlBrief_GetField(AVTP_CANXL_BRIEF_FIELD_MTV);
+    return (bool) __Avtp_CanXlBrief_GetField(AVTP_CANXL_BRIEF_FIELD_MTV);
 }
 
 /**
@@ -166,7 +166,7 @@ static inline bool Avtp_CanXlBrief_IsMtv(const Avtp_CanXlBrief_t* msg) {
  * @returns The value of the can_bus_id field.
  */
 static inline uint16_t Avtp_CanXlBrief_GetCanBusId(const Avtp_CanXlBrief_t* msg) {
-    return __Avtp_CanXlBrief_GetField(AVTP_CANXL_BRIEF_FIELD_CAN_BUS_ID);
+    return (uint16_t) __Avtp_CanXlBrief_GetField(AVTP_CANXL_BRIEF_FIELD_CAN_BUS_ID);
 }
 
 /**
@@ -176,7 +176,7 @@ static inline uint16_t Avtp_CanXlBrief_GetCanBusId(const Avtp_CanXlBrief_t* msg)
  * @returns The value of the vcid field.
  */
 static inline uint8_t Avtp_CanXlBrief_GetVcid(const Avtp_CanXlBrief_t* msg) {
-    return __Avtp_CanXlBrief_GetField(AVTP_CANXL_BRIEF_FIELD_VCID);
+    return (uint8_t) __Avtp_CanXlBrief_GetField(AVTP_CANXL_BRIEF_FIELD_VCID);
 }
 
 /**
@@ -186,7 +186,7 @@ static inline uint8_t Avtp_CanXlBrief_GetVcid(const Avtp_CanXlBrief_t* msg) {
  * @returns The value of the sdt field.
  */
 static inline uint8_t Avtp_CanXlBrief_GetSdt(const Avtp_CanXlBrief_t* msg) {
-    return __Avtp_CanXlBrief_GetField(AVTP_CANXL_BRIEF_FIELD_SDT);
+    return (uint8_t) __Avtp_CanXlBrief_GetField(AVTP_CANXL_BRIEF_FIELD_SDT);
 }
 
 /**
@@ -196,7 +196,7 @@ static inline uint8_t Avtp_CanXlBrief_GetSdt(const Avtp_CanXlBrief_t* msg) {
  * @returns The value of the rrs flag.
  */
 static inline bool Avtp_CanXlBrief_IsRrs(const Avtp_CanXlBrief_t* msg) {
-    return __Avtp_CanXlBrief_GetField(AVTP_CANXL_BRIEF_FIELD_RRS);
+    return (bool) __Avtp_CanXlBrief_GetField(AVTP_CANXL_BRIEF_FIELD_RRS);
 }
 
 /**
@@ -206,7 +206,7 @@ static inline bool Avtp_CanXlBrief_IsRrs(const Avtp_CanXlBrief_t* msg) {
  * @returns The value of the sec flag.
  */
 static inline bool Avtp_CanXlBrief_IsSec(const Avtp_CanXlBrief_t* msg) {
-    return __Avtp_CanXlBrief_GetField(AVTP_CANXL_BRIEF_FIELD_SEC);
+    return (bool) __Avtp_CanXlBrief_GetField(AVTP_CANXL_BRIEF_FIELD_SEC);
 }
 
 /**
@@ -217,7 +217,7 @@ static inline bool Avtp_CanXlBrief_IsSec(const Avtp_CanXlBrief_t* msg) {
  * @returns The value of the priority_id field.
  */
 static inline uint16_t Avtp_CanXlBrief_GetPriorityId(const Avtp_CanXlBrief_t* msg) {
-    return __Avtp_CanXlBrief_GetField(AVTP_CANXL_BRIEF_FIELD_PRIORITY_ID);
+    return (uint16_t) __Avtp_CanXlBrief_GetField(AVTP_CANXL_BRIEF_FIELD_PRIORITY_ID);
 }
 
 /**
@@ -227,7 +227,7 @@ static inline uint16_t Avtp_CanXlBrief_GetPriorityId(const Avtp_CanXlBrief_t* ms
  * @returns The value of the acceptance_field.
  */
 static inline uint32_t Avtp_CanXlBrief_GetAcceptanceField(const Avtp_CanXlBrief_t* msg) {
-    return __Avtp_CanXlBrief_GetField(AVTP_CANXL_BRIEF_FIELD_ACCEPTANCE_FIELD);
+    return (uint32_t) __Avtp_CanXlBrief_GetField(AVTP_CANXL_BRIEF_FIELD_ACCEPTANCE_FIELD);
 }
 
 /**
@@ -238,7 +238,7 @@ static inline uint32_t Avtp_CanXlBrief_GetAcceptanceField(const Avtp_CanXlBrief_
  * @returns The value of the transaction_num field.
  */
 static inline uint8_t Avtp_CanXlBrief_GetTransactionNum(const Avtp_CanXlBrief_t* msg) {
-    return __Avtp_CanXlBrief_GetField(AVTP_CANXL_BRIEF_FIELD_TRANSACTION_NUM);
+    return (uint8_t) __Avtp_CanXlBrief_GetField(AVTP_CANXL_BRIEF_FIELD_TRANSACTION_NUM);
 }
 
 /**
@@ -248,7 +248,7 @@ static inline uint8_t Avtp_CanXlBrief_GetTransactionNum(const Avtp_CanXlBrief_t*
  * @returns The value of the ms flag.
  */
 static inline bool Avtp_CanXlBrief_IsMs(const Avtp_CanXlBrief_t* msg) {
-    return __Avtp_CanXlBrief_GetField(AVTP_CANXL_BRIEF_FIELD_MS);
+    return (bool) __Avtp_CanXlBrief_GetField(AVTP_CANXL_BRIEF_FIELD_MS);
 }
 
 /**
@@ -259,7 +259,7 @@ static inline bool Avtp_CanXlBrief_IsMs(const Avtp_CanXlBrief_t* msg) {
  * @returns The value of the segment_num field.
  */
 static inline uint16_t Avtp_CanXlBrief_GetSegmentNum(const Avtp_CanXlBrief_t* msg) {
-    return __Avtp_CanXlBrief_GetField(AVTP_CANXL_BRIEF_FIELD_SEGMENT_NUM);
+    return (uint16_t) __Avtp_CanXlBrief_GetField(AVTP_CANXL_BRIEF_FIELD_SEGMENT_NUM);
 }
 
 /**
@@ -271,9 +271,9 @@ static inline uint16_t Avtp_CanXlBrief_GetSegmentNum(const Avtp_CanXlBrief_t* ms
  * @returns The payload length in bytes.
  */
 static inline uint16_t Avtp_CanXlBrief_GetPayloadLen(const Avtp_CanXlBrief_t* msg) {
-    return __Avtp_CanXlBrief_GetField(AVTP_CANXL_BRIEF_FIELD_ACF_MSG_LENGTH) * AVTP_QUADLET_SIZE
+    return (uint16_t) (__Avtp_CanXlBrief_GetField(AVTP_CANXL_BRIEF_FIELD_ACF_MSG_LENGTH) * AVTP_QUADLET_SIZE
            - AVTP_CANXL_BRIEF_HEADER_LEN
-           - __Avtp_CanXlBrief_GetField(AVTP_CANXL_BRIEF_FIELD_PAD);
+           - __Avtp_CanXlBrief_GetField(AVTP_CANXL_BRIEF_FIELD_PAD));
 }
 
 /**
@@ -284,7 +284,7 @@ static inline uint16_t Avtp_CanXlBrief_GetPayloadLen(const Avtp_CanXlBrief_t* ms
  * @returns The total message length in bytes.
  */
 static inline uint16_t Avtp_CanXlBrief_GetLen(const Avtp_CanXlBrief_t* msg) {
-    return __Avtp_CanXlBrief_GetField(AVTP_CANXL_BRIEF_FIELD_ACF_MSG_LENGTH) * AVTP_QUADLET_SIZE;
+    return (uint16_t) (__Avtp_CanXlBrief_GetField(AVTP_CANXL_BRIEF_FIELD_ACF_MSG_LENGTH) * AVTP_QUADLET_SIZE);
 }
 
 /**

--- a/include/avtp/acf/FlexRay.h
+++ b/include/avtp/acf/FlexRay.h
@@ -113,7 +113,7 @@ static const Avtp_FieldDescriptor_t Avtp_FlexRayFieldDesc[AVTP_FLEXRAY_FIELD_MAX
  * @returns Value of the ACF message type field.
  */
 static inline uint8_t Avtp_FlexRay_GetAcfMsgType(const Avtp_FlexRay_t* const pdu) {
-    return GET_FLEXRAY_FIELD(AVTP_FLEXRAY_FIELD_ACF_MSG_TYPE);
+    return (uint8_t) GET_FLEXRAY_FIELD(AVTP_FLEXRAY_FIELD_ACF_MSG_TYPE);
 }
 
 /** 
@@ -123,7 +123,7 @@ static inline uint8_t Avtp_FlexRay_GetAcfMsgType(const Avtp_FlexRay_t* const pdu
  * @returns Value of the ACF message length field.
  */
 static inline uint16_t Avtp_FlexRay_GetAcfMsgLength(const Avtp_FlexRay_t* const pdu) {
-    return GET_FLEXRAY_FIELD(AVTP_FLEXRAY_FIELD_ACF_MSG_LENGTH);
+    return (uint16_t) GET_FLEXRAY_FIELD(AVTP_FLEXRAY_FIELD_ACF_MSG_LENGTH);
 }
 
 /**
@@ -133,7 +133,7 @@ static inline uint16_t Avtp_FlexRay_GetAcfMsgLength(const Avtp_FlexRay_t* const 
  * @returns Value of the ACF FlexRay PDU padding field.
  */
 static inline uint8_t Avtp_FlexRay_GetPad(const Avtp_FlexRay_t* const pdu) {
-    return GET_FLEXRAY_FIELD(AVTP_FLEXRAY_FIELD_PAD);
+    return (uint8_t) GET_FLEXRAY_FIELD(AVTP_FLEXRAY_FIELD_PAD);
 }
 
 /**
@@ -143,7 +143,7 @@ static inline uint8_t Avtp_FlexRay_GetPad(const Avtp_FlexRay_t* const pdu) {
  * @returns Value of the ACF FlexRay PDU MTV field.
  */
 static inline uint8_t Avtp_FlexRay_GetMtv(const Avtp_FlexRay_t* const pdu) {
-    return GET_FLEXRAY_FIELD(AVTP_FLEXRAY_FIELD_MTV);
+    return (uint8_t) GET_FLEXRAY_FIELD(AVTP_FLEXRAY_FIELD_MTV);
 }
 
 /**
@@ -153,7 +153,7 @@ static inline uint8_t Avtp_FlexRay_GetMtv(const Avtp_FlexRay_t* const pdu) {
  * @returns Value of the ACF FlexRay PDU FR Bus ID field.
  */
 static inline uint8_t Avtp_FlexRay_GetFrBusId(const Avtp_FlexRay_t* const pdu) {
-    return GET_FLEXRAY_FIELD(AVTP_FLEXRAY_FIELD_FR_BUS_ID);
+    return (uint8_t) GET_FLEXRAY_FIELD(AVTP_FLEXRAY_FIELD_FR_BUS_ID);
 }
 
 /**
@@ -163,7 +163,7 @@ static inline uint8_t Avtp_FlexRay_GetFrBusId(const Avtp_FlexRay_t* const pdu) {
  * @returns Value of the ACF FlexRay PDU Channel field.
  */
 static inline uint8_t Avtp_FlexRay_GetChan(const Avtp_FlexRay_t* const pdu) {
-    return GET_FLEXRAY_FIELD(AVTP_FLEXRAY_FIELD_CHAN);
+    return (uint8_t) GET_FLEXRAY_FIELD(AVTP_FLEXRAY_FIELD_CHAN);
 }
 
 /**
@@ -173,7 +173,7 @@ static inline uint8_t Avtp_FlexRay_GetChan(const Avtp_FlexRay_t* const pdu) {
  * @returns Value of the ACF FlexRay PDU STR field.
  */
 static inline uint8_t Avtp_FlexRay_GetStr(const Avtp_FlexRay_t* const pdu) {
-    return GET_FLEXRAY_FIELD(AVTP_FLEXRAY_FIELD_STR);
+    return (uint8_t) GET_FLEXRAY_FIELD(AVTP_FLEXRAY_FIELD_STR);
 }
 
 /**
@@ -183,7 +183,7 @@ static inline uint8_t Avtp_FlexRay_GetStr(const Avtp_FlexRay_t* const pdu) {
  * @returns Value of the ACF FlexRay PDU SYN field.
  */
 static inline uint8_t Avtp_FlexRay_GetSyn(const Avtp_FlexRay_t* const pdu) {
-    return GET_FLEXRAY_FIELD(AVTP_FLEXRAY_FIELD_SYN);
+    return (uint8_t) GET_FLEXRAY_FIELD(AVTP_FLEXRAY_FIELD_SYN);
 }
 
 /**
@@ -193,7 +193,7 @@ static inline uint8_t Avtp_FlexRay_GetSyn(const Avtp_FlexRay_t* const pdu) {
  * @returns Value of the ACF FlexRay PDU PRE field.
  */
 static inline uint8_t Avtp_FlexRay_GetPre(const Avtp_FlexRay_t* const pdu) {
-    return GET_FLEXRAY_FIELD(AVTP_FLEXRAY_FIELD_PRE);
+    return (uint8_t) GET_FLEXRAY_FIELD(AVTP_FLEXRAY_FIELD_PRE);
 }
 
 /**
@@ -203,7 +203,7 @@ static inline uint8_t Avtp_FlexRay_GetPre(const Avtp_FlexRay_t* const pdu) {
  * @returns Value of the ACF FlexRay PDU NFI field.
  */
 static inline uint8_t Avtp_FlexRay_GetNfi(const Avtp_FlexRay_t* const pdu) {
-    return GET_FLEXRAY_FIELD(AVTP_FLEXRAY_FIELD_NFI);
+    return (uint8_t) GET_FLEXRAY_FIELD(AVTP_FLEXRAY_FIELD_NFI);
 }
 
 /**
@@ -223,7 +223,7 @@ static inline uint64_t Avtp_FlexRay_GetMessageTimestamp(const Avtp_FlexRay_t* co
  * @returns Value of the ACF FlexRay PDU FR Frame ID field.
  */
 static inline uint16_t Avtp_FlexRay_GetFrFrameId(const Avtp_FlexRay_t* const pdu) {
-    return GET_FLEXRAY_FIELD(AVTP_FLEXRAY_FIELD_FR_FRAME_ID);
+    return (uint16_t) GET_FLEXRAY_FIELD(AVTP_FLEXRAY_FIELD_FR_FRAME_ID);
 }
 
 /**
@@ -233,7 +233,7 @@ static inline uint16_t Avtp_FlexRay_GetFrFrameId(const Avtp_FlexRay_t* const pdu
  * @returns Value of the ACF FlexRay PDU Cycle field.
  */
 static inline uint8_t Avtp_FlexRay_GetCycle(const Avtp_FlexRay_t* const pdu) {
-    return GET_FLEXRAY_FIELD(AVTP_FLEXRAY_FIELD_CYCLE);
+    return (uint8_t) GET_FLEXRAY_FIELD(AVTP_FLEXRAY_FIELD_CYCLE);
 }
 
 /**

--- a/include/avtp/acf/Gbb.h
+++ b/include/avtp/acf/Gbb.h
@@ -147,7 +147,7 @@ static inline void Avtp_Gbb_Init(Avtp_Gbb_t* msg) {
  * @returns The value of the pad field.
  */
 static inline uint8_t Avtp_Gbb_GetPad(const Avtp_Gbb_t* msg) {
-    return __Avtp_Gbb_GetField(AVTP_GBB_FIELD_PAD);
+    return (uint8_t) __Avtp_Gbb_GetField(AVTP_GBB_FIELD_PAD);
 }
 
 /**
@@ -158,7 +158,7 @@ static inline uint8_t Avtp_Gbb_GetPad(const Avtp_Gbb_t* msg) {
  * @returns The value of the mtv flag.
  */
 static inline bool Avtp_Gbb_IsMtv(const Avtp_Gbb_t* msg) {
-    return __Avtp_Gbb_GetField(AVTP_GBB_FIELD_MTV);
+    return (bool) __Avtp_Gbb_GetField(AVTP_GBB_FIELD_MTV);
 }
 
 /**
@@ -168,7 +168,7 @@ static inline bool Avtp_Gbb_IsMtv(const Avtp_Gbb_t* msg) {
  * @returns The value of the byte_bus_id field.
  */
 static inline uint16_t Avtp_Gbb_GetByteBusId(const Avtp_Gbb_t* msg) {
-    return __Avtp_Gbb_GetField(AVTP_GBB_FIELD_BYTE_BUS_ID);
+    return (uint16_t) __Avtp_Gbb_GetField(AVTP_GBB_FIELD_BYTE_BUS_ID);
 }
 
 /**
@@ -179,7 +179,7 @@ static inline uint16_t Avtp_Gbb_GetByteBusId(const Avtp_Gbb_t* msg) {
  * @returns The value of the message_timestamp field.
  */
 static inline uint64_t Avtp_Gbb_GetMessageTimestamp(const Avtp_Gbb_t* msg) {
-    return __Avtp_Gbb_GetField(AVTP_GBB_FIELD_MESSAGE_TIMESTAMP);
+    return (uint64_t) __Avtp_Gbb_GetField(AVTP_GBB_FIELD_MESSAGE_TIMESTAMP);
 }
 
 /**
@@ -189,7 +189,7 @@ static inline uint64_t Avtp_Gbb_GetMessageTimestamp(const Avtp_Gbb_t* msg) {
  * @returns The value of the evt field.
  */
 static inline uint8_t Avtp_Gbb_GetEvt(const Avtp_Gbb_t* msg) {
-    return __Avtp_Gbb_GetField(AVTP_GBB_FIELD_EVT);
+    return (uint8_t) __Avtp_Gbb_GetField(AVTP_GBB_FIELD_EVT);
 }
 
 /**
@@ -199,7 +199,7 @@ static inline uint8_t Avtp_Gbb_GetEvt(const Avtp_Gbb_t* msg) {
  * @returns The value of the hs field.
  */
 static inline bool Avtp_Gbb_IsHs(const Avtp_Gbb_t* msg) {
-    return __Avtp_Gbb_GetField(AVTP_GBB_FIELD_HS);
+    return (bool) __Avtp_Gbb_GetField(AVTP_GBB_FIELD_HS);
 }
 
 /**
@@ -209,7 +209,7 @@ static inline bool Avtp_Gbb_IsHs(const Avtp_Gbb_t* msg) {
  * @returns The value of the cs field.
  */
 static inline bool Avtp_Gbb_IsCs(const Avtp_Gbb_t* msg) {
-    return __Avtp_Gbb_GetField(AVTP_GBB_FIELD_CS);
+    return (bool) __Avtp_Gbb_GetField(AVTP_GBB_FIELD_CS);
 }
 
 /**
@@ -220,7 +220,7 @@ static inline bool Avtp_Gbb_IsCs(const Avtp_Gbb_t* msg) {
  * @returns The value of the transaction_num field.
  */
 static inline uint8_t Avtp_Gbb_GetTransactionNum(const Avtp_Gbb_t* msg) {
-    return __Avtp_Gbb_GetField(AVTP_GBB_FIELD_TRANSACTION_NUM);
+    return (uint8_t) __Avtp_Gbb_GetField(AVTP_GBB_FIELD_TRANSACTION_NUM);
 }
 
 /**
@@ -230,7 +230,7 @@ static inline uint8_t Avtp_Gbb_GetTransactionNum(const Avtp_Gbb_t* msg) {
  * @returns The value of the op flag.
  */
 static inline bool Avtp_Gbb_IsOp(const Avtp_Gbb_t* msg) {
-    return __Avtp_Gbb_GetField(AVTP_GBB_FIELD_OP);
+    return (bool) __Avtp_Gbb_GetField(AVTP_GBB_FIELD_OP);
 }
 
 /**
@@ -240,7 +240,7 @@ static inline bool Avtp_Gbb_IsOp(const Avtp_Gbb_t* msg) {
  * @returns The value of the rsp flag.
  */
 static inline bool Avtp_Gbb_IsRsp(const Avtp_Gbb_t* msg) {
-    return __Avtp_Gbb_GetField(AVTP_GBB_FIELD_RSP);
+    return (bool) __Avtp_Gbb_GetField(AVTP_GBB_FIELD_RSP);
 }
 
 /**
@@ -250,7 +250,7 @@ static inline bool Avtp_Gbb_IsRsp(const Avtp_Gbb_t* msg) {
  * @returns The value of the err flag.
  */
 static inline bool Avtp_Gbb_IsErr(const Avtp_Gbb_t* msg) {
-    return __Avtp_Gbb_GetField(AVTP_GBB_FIELD_ERR);
+    return (bool) __Avtp_Gbb_GetField(AVTP_GBB_FIELD_ERR);
 }
 
 /**
@@ -260,7 +260,7 @@ static inline bool Avtp_Gbb_IsErr(const Avtp_Gbb_t* msg) {
  * @returns The value of the ms flag.
  */
 static inline bool Avtp_Gbb_IsMs(const Avtp_Gbb_t* msg) {
-    return __Avtp_Gbb_GetField(AVTP_GBB_FIELD_MS);
+    return (bool) __Avtp_Gbb_GetField(AVTP_GBB_FIELD_MS);
 }
 
 /**
@@ -271,7 +271,7 @@ static inline bool Avtp_Gbb_IsMs(const Avtp_Gbb_t* msg) {
  * @returns The value of the read_size/segment_num field.
  */
 static inline uint16_t Avtp_Gbb_GetReadSize(const Avtp_Gbb_t* msg) {
-    return __Avtp_Gbb_GetField(AVTP_GBB_FIELD_READ_SIZE_SEGMENT_NUM);
+    return (uint16_t) __Avtp_Gbb_GetField(AVTP_GBB_FIELD_READ_SIZE_SEGMENT_NUM);
 }
 
 /**
@@ -282,7 +282,7 @@ static inline uint16_t Avtp_Gbb_GetReadSize(const Avtp_Gbb_t* msg) {
  * @returns The value of the read_size/segment_num field.
  */
 static inline uint16_t Avtp_Gbb_GetSegmentNum(const Avtp_Gbb_t* msg) {
-    return __Avtp_Gbb_GetField(AVTP_GBB_FIELD_READ_SIZE_SEGMENT_NUM);
+    return (uint16_t) __Avtp_Gbb_GetField(AVTP_GBB_FIELD_READ_SIZE_SEGMENT_NUM);
 }
 
 /**
@@ -294,9 +294,9 @@ static inline uint16_t Avtp_Gbb_GetSegmentNum(const Avtp_Gbb_t* msg) {
  * @returns The payload length in bytes.
  */
 static inline uint16_t Avtp_Gbb_GetPayloadLen(const Avtp_Gbb_t* msg) {
-    return __Avtp_Gbb_GetField(AVTP_GBB_FIELD_ACF_MSG_LENGTH) * AVTP_QUADLET_SIZE
+    return (uint16_t) (__Avtp_Gbb_GetField(AVTP_GBB_FIELD_ACF_MSG_LENGTH) * AVTP_QUADLET_SIZE
            - AVTP_GBB_HEADER_LEN
-           - __Avtp_Gbb_GetField(AVTP_GBB_FIELD_PAD);
+           - __Avtp_Gbb_GetField(AVTP_GBB_FIELD_PAD));
 }
 
 /**
@@ -307,7 +307,7 @@ static inline uint16_t Avtp_Gbb_GetPayloadLen(const Avtp_Gbb_t* msg) {
  * @returns The total message length in bytes.
  */
 static inline uint16_t Avtp_Gbb_GetLen(const Avtp_Gbb_t* msg) {
-    return __Avtp_Gbb_GetField(AVTP_GBB_FIELD_ACF_MSG_LENGTH) * AVTP_QUADLET_SIZE;
+    return (uint16_t) (__Avtp_Gbb_GetField(AVTP_GBB_FIELD_ACF_MSG_LENGTH) * AVTP_QUADLET_SIZE);
 }
 
 /**

--- a/include/avtp/acf/Gisf.h
+++ b/include/avtp/acf/Gisf.h
@@ -147,7 +147,7 @@ static inline void Avtp_Gisf_Init(Avtp_Gisf_t* msg) {
  * @returns The value of the pad field.
  */
 static inline uint8_t Avtp_Gisf_GetPad(const Avtp_Gisf_t* msg) {
-    return __Avtp_Gisf_GetField(AVTP_GISF_FIELD_PAD);
+    return (uint8_t) __Avtp_Gisf_GetField(AVTP_GISF_FIELD_PAD);
 }
 
 /**
@@ -158,7 +158,7 @@ static inline uint8_t Avtp_Gisf_GetPad(const Avtp_Gisf_t* msg) {
  * @returns The value of the mtv flag.
  */
 static inline bool Avtp_Gisf_IsMtv(const Avtp_Gisf_t* msg) {
-    return __Avtp_Gisf_GetField(AVTP_GISF_FIELD_MTV);
+    return (bool) __Avtp_Gisf_GetField(AVTP_GISF_FIELD_MTV);
 }
 
 /**
@@ -169,7 +169,7 @@ static inline bool Avtp_Gisf_IsMtv(const Avtp_Gisf_t* msg) {
  * @returns The value of the image_sensor_id field.
  */
 static inline uint16_t Avtp_Gisf_GetImageSensorId(const Avtp_Gisf_t* msg) {
-    return __Avtp_Gisf_GetField(AVTP_GISF_FIELD_IMAGE_SENSOR_ID);
+    return (uint16_t) __Avtp_Gisf_GetField(AVTP_GISF_FIELD_IMAGE_SENSOR_ID);
 }
 
 /**
@@ -180,7 +180,7 @@ static inline uint16_t Avtp_Gisf_GetImageSensorId(const Avtp_Gisf_t* msg) {
  * @returns The value of the message_timestamp field.
  */
 static inline uint64_t Avtp_Gisf_GetMessageTimestamp(const Avtp_Gisf_t* msg) {
-    return __Avtp_Gisf_GetField(AVTP_GISF_FIELD_MESSAGE_TIMESTAMP);
+    return (uint64_t) __Avtp_Gisf_GetField(AVTP_GISF_FIELD_MESSAGE_TIMESTAMP);
 }
 
 /**
@@ -190,7 +190,7 @@ static inline uint64_t Avtp_Gisf_GetMessageTimestamp(const Avtp_Gisf_t* msg) {
  * @returns The value of the el flag.
  */
 static inline bool Avtp_Gisf_IsEl(const Avtp_Gisf_t* msg) {
-    return __Avtp_Gisf_GetField(AVTP_GISF_FIELD_EL);
+    return (bool) __Avtp_Gisf_GetField(AVTP_GISF_FIELD_EL);
 }
 
 /**
@@ -201,7 +201,7 @@ static inline bool Avtp_Gisf_IsEl(const Avtp_Gisf_t* msg) {
  * @returns The value of the tl flag.
  */
 static inline bool Avtp_Gisf_IsTl(const Avtp_Gisf_t* msg) {
-    return __Avtp_Gisf_GetField(AVTP_GISF_FIELD_TL);
+    return (bool) __Avtp_Gisf_GetField(AVTP_GISF_FIELD_TL);
 }
 
 /**
@@ -212,7 +212,7 @@ static inline bool Avtp_Gisf_IsTl(const Avtp_Gisf_t* msg) {
  * @returns The value of the ef flag.
  */
 static inline bool Avtp_Gisf_IsEf(const Avtp_Gisf_t* msg) {
-    return __Avtp_Gisf_GetField(AVTP_GISF_FIELD_EF);
+    return (bool) __Avtp_Gisf_GetField(AVTP_GISF_FIELD_EF);
 }
 
 /**
@@ -222,7 +222,7 @@ static inline bool Avtp_Gisf_IsEf(const Avtp_Gisf_t* msg) {
  * @returns The value of the evt field.
  */
 static inline uint8_t Avtp_Gisf_GetEvt(const Avtp_Gisf_t* msg) {
-    return __Avtp_Gisf_GetField(AVTP_GISF_FIELD_EVT);
+    return (uint8_t) __Avtp_Gisf_GetField(AVTP_GISF_FIELD_EVT);
 }
 
 /**
@@ -233,7 +233,7 @@ static inline uint8_t Avtp_Gisf_GetEvt(const Avtp_Gisf_t* msg) {
  * @returns The value of the bf flag.
  */
 static inline bool Avtp_Gisf_IsBf(const Avtp_Gisf_t* msg) {
-    return __Avtp_Gisf_GetField(AVTP_GISF_FIELD_BF);
+    return (bool) __Avtp_Gisf_GetField(AVTP_GISF_FIELD_BF);
 }
 
 /**
@@ -243,7 +243,7 @@ static inline bool Avtp_Gisf_IsBf(const Avtp_Gisf_t* msg) {
  * @returns The value of the line_type_id value.
  */
 static inline uint8_t Avtp_Gisf_GetLineTypeId(const Avtp_Gisf_t* msg) {
-    return __Avtp_Gisf_GetField(AVTP_GISF_FIELD_LINE_TYPE_ID);
+    return (uint8_t) __Avtp_Gisf_GetField(AVTP_GISF_FIELD_LINE_TYPE_ID);
 }
 
 /**
@@ -254,7 +254,7 @@ static inline uint8_t Avtp_Gisf_GetLineTypeId(const Avtp_Gisf_t* msg) {
  * @returns The value of the evt2 field.
  */
 static inline uint8_t Avtp_Gisf_GetEvt2(const Avtp_Gisf_t* msg) {
-    return __Avtp_Gisf_GetField(AVTP_GISF_FIELD_EVT2);
+    return (uint8_t) __Avtp_Gisf_GetField(AVTP_GISF_FIELD_EVT2);
 }
 
 /**
@@ -265,7 +265,7 @@ static inline uint8_t Avtp_Gisf_GetEvt2(const Avtp_Gisf_t* msg) {
  * @returns The value of the i_seq_num field.
  */
 static inline uint8_t Avtp_Gisf_GetISeqNum(const Avtp_Gisf_t* msg) {
-    return __Avtp_Gisf_GetField(AVTP_GISF_FIELD_I_SEQ_NUM);
+    return (uint8_t) __Avtp_Gisf_GetField(AVTP_GISF_FIELD_I_SEQ_NUM);
 }
 
 /**
@@ -275,7 +275,7 @@ static inline uint8_t Avtp_Gisf_GetISeqNum(const Avtp_Gisf_t* msg) {
  * @returns The value of the line_number field.
  */
 static inline uint16_t Avtp_Gisf_GetLineNumber(const Avtp_Gisf_t* msg) {
-    return __Avtp_Gisf_GetField(AVTP_GISF_FIELD_LINE_NUMBER);
+    return (uint16_t) __Avtp_Gisf_GetField(AVTP_GISF_FIELD_LINE_NUMBER);
 }
 
 /**
@@ -287,9 +287,9 @@ static inline uint16_t Avtp_Gisf_GetLineNumber(const Avtp_Gisf_t* msg) {
  * @returns The payload length in bytes.
  */
 static inline uint16_t Avtp_Gisf_GetPayloadLen(const Avtp_Gisf_t* msg) {
-    return __Avtp_Gisf_GetField(AVTP_GISF_FIELD_ACF_MSG_LENGTH) * AVTP_QUADLET_SIZE
+    return (uint16_t) (__Avtp_Gisf_GetField(AVTP_GISF_FIELD_ACF_MSG_LENGTH) * AVTP_QUADLET_SIZE
            - AVTP_GISF_HEADER_LEN
-           - __Avtp_Gisf_GetField(AVTP_GISF_FIELD_PAD);
+           - __Avtp_Gisf_GetField(AVTP_GISF_FIELD_PAD));
 }
 
 /**
@@ -300,7 +300,7 @@ static inline uint16_t Avtp_Gisf_GetPayloadLen(const Avtp_Gisf_t* msg) {
  * @returns The total message length in bytes.
  */
 static inline uint16_t Avtp_Gisf_GetLen(const Avtp_Gisf_t* msg) {
-    return __Avtp_Gisf_GetField(AVTP_GISF_FIELD_ACF_MSG_LENGTH) * AVTP_QUADLET_SIZE;
+    return (uint16_t) (__Avtp_Gisf_GetField(AVTP_GISF_FIELD_ACF_MSG_LENGTH) * AVTP_QUADLET_SIZE);
 }
 
 /**

--- a/include/avtp/acf/Gpc.h
+++ b/include/avtp/acf/Gpc.h
@@ -89,7 +89,7 @@ static const Avtp_FieldDescriptor_t Avtp_GpcFieldDesc[AVTP_GPC_FIELD_MAX] =
  * @returns The value of the ACF Message Type Field.
  */
 static inline uint8_t Avtp_Gpc_GetAcfMsgType(const Avtp_Gpc_t* const pdu) {
-    return GET_GPC_FIELD(AVTP_GPC_FIELD_ACF_MSG_TYPE);
+    return (uint8_t) GET_GPC_FIELD(AVTP_GPC_FIELD_ACF_MSG_TYPE);
 }
 
 /**
@@ -99,7 +99,7 @@ static inline uint8_t Avtp_Gpc_GetAcfMsgType(const Avtp_Gpc_t* const pdu) {
  * @returns The value of the ACF Message Length Field.
  */
 static inline uint16_t Avtp_Gpc_GetAcfMsgLength(const Avtp_Gpc_t* const pdu) {
-    return GET_GPC_FIELD(AVTP_GPC_FIELD_ACF_MSG_LENGTH);
+    return (uint16_t) GET_GPC_FIELD(AVTP_GPC_FIELD_ACF_MSG_LENGTH);
 }
 
 /**
@@ -109,7 +109,7 @@ static inline uint16_t Avtp_Gpc_GetAcfMsgLength(const Avtp_Gpc_t* const pdu) {
  * @returns The value of the GPC Message ID Field.
  */
 static inline uint64_t Avtp_Gpc_GetGpcMsgId(const Avtp_Gpc_t* const pdu) {
-    return GET_GPC_FIELD(AVTP_GPC_FIELD_GPC_MSG_ID);
+    return (uint64_t) GET_GPC_FIELD(AVTP_GPC_FIELD_GPC_MSG_ID);
 }
 
 /**

--- a/include/avtp/acf/Lin.h
+++ b/include/avtp/acf/Lin.h
@@ -97,7 +97,7 @@ static const Avtp_FieldDescriptor_t Avtp_LinFieldDesc[AVTP_LIN_FIELD_MAX] =
  * @returns The value of the ACF Message Type field.
  */
 static inline uint8_t Avtp_Lin_GetAcfMsgType(const Avtp_Lin_t* const pdu) {
-    return GET_LIN_FIELD(AVTP_LIN_FIELD_ACF_MSG_TYPE);
+    return (uint8_t) GET_LIN_FIELD(AVTP_LIN_FIELD_ACF_MSG_TYPE);
 }
 
 /**
@@ -107,7 +107,7 @@ static inline uint8_t Avtp_Lin_GetAcfMsgType(const Avtp_Lin_t* const pdu) {
  * @returns The value of the ACF Message Length field.
  */
 static inline uint16_t Avtp_Lin_GetAcfMsgLength(const Avtp_Lin_t* const pdu) {
-    return GET_LIN_FIELD(AVTP_LIN_FIELD_ACF_MSG_LENGTH);
+    return (uint16_t) GET_LIN_FIELD(AVTP_LIN_FIELD_ACF_MSG_LENGTH);
 }
 
 /**
@@ -117,7 +117,7 @@ static inline uint16_t Avtp_Lin_GetAcfMsgLength(const Avtp_Lin_t* const pdu) {
  * @returns The value of the ACF Lin PDU Pad field.
  */
 static inline uint8_t Avtp_Lin_GetPad(const Avtp_Lin_t* const pdu) {
-    return GET_LIN_FIELD(AVTP_LIN_FIELD_PAD);
+    return (uint8_t) GET_LIN_FIELD(AVTP_LIN_FIELD_PAD);
 }
 
 /**
@@ -127,7 +127,7 @@ static inline uint8_t Avtp_Lin_GetPad(const Avtp_Lin_t* const pdu) {
  * @returns The value of the ACF Lin PDU MTV field.
  */
 static inline uint8_t Avtp_Lin_GetMtv(const Avtp_Lin_t* const pdu) {
-    return GET_LIN_FIELD(AVTP_LIN_FIELD_MTV);
+    return (uint8_t) GET_LIN_FIELD(AVTP_LIN_FIELD_MTV);
 }
 
 /**
@@ -137,7 +137,7 @@ static inline uint8_t Avtp_Lin_GetMtv(const Avtp_Lin_t* const pdu) {
  * @returns The value of the ACF Lin PDU Lin Bus ID field.
  */
 static inline uint8_t Avtp_Lin_GetLinBusId(const Avtp_Lin_t* const pdu) {
-    return GET_LIN_FIELD(AVTP_LIN_FIELD_LIN_BUS_ID);
+    return (uint8_t) GET_LIN_FIELD(AVTP_LIN_FIELD_LIN_BUS_ID);
 }
 
 /**
@@ -147,7 +147,7 @@ static inline uint8_t Avtp_Lin_GetLinBusId(const Avtp_Lin_t* const pdu) {
  * @returns The value of the ACF Lin PDU Lin Identifier field.
  */
 static inline uint8_t Avtp_Lin_GetLinIdentifier(const Avtp_Lin_t* const pdu) {
-    return GET_LIN_FIELD(AVTP_LIN_FIELD_LIN_IDENTIFIER);
+    return (uint8_t) GET_LIN_FIELD(AVTP_LIN_FIELD_LIN_IDENTIFIER);
 }
 
 /**
@@ -157,7 +157,7 @@ static inline uint8_t Avtp_Lin_GetLinIdentifier(const Avtp_Lin_t* const pdu) {
  * @returns The value of the ACF Lin PDU Message Timestamp field.
  */
 static inline uint64_t Avtp_Lin_GetMessageTimestamp(const Avtp_Lin_t* const pdu) {
-    return GET_LIN_FIELD(AVTP_LIN_FIELD_MESSAGE_TIMESTAMP);
+    return (uint64_t) GET_LIN_FIELD(AVTP_LIN_FIELD_MESSAGE_TIMESTAMP);
 }
 
 /**

--- a/include/avtp/acf/Most.h
+++ b/include/avtp/acf/Most.h
@@ -109,7 +109,7 @@ static const Avtp_FieldDescriptor_t Avtp_MostFieldDesc[AVTP_MOST_FIELD_MAX] =
  * @returns Value of the ACF message type field.
  */
 static inline uint8_t Avtp_Most_GetAcfMsgType(const Avtp_Most_t* const pdu) {
-    return GET_MOST_FIELD(AVTP_MOST_FIELD_ACF_MSG_TYPE);
+    return (uint8_t) GET_MOST_FIELD(AVTP_MOST_FIELD_ACF_MSG_TYPE);
 }
 
 /**
@@ -119,7 +119,7 @@ static inline uint8_t Avtp_Most_GetAcfMsgType(const Avtp_Most_t* const pdu) {
  * @returns Value of the ACF message length field.
  */
 static inline uint16_t Avtp_Most_GetAcfMsgLength(const Avtp_Most_t* const pdu) {
-    return GET_MOST_FIELD(AVTP_MOST_FIELD_ACF_MSG_LENGTH);
+    return (uint16_t) GET_MOST_FIELD(AVTP_MOST_FIELD_ACF_MSG_LENGTH);
 }
 
 /**
@@ -129,7 +129,7 @@ static inline uint16_t Avtp_Most_GetAcfMsgLength(const Avtp_Most_t* const pdu) {
  * @returns Value of the ACF Most PDU padding field.
  */
 static inline uint8_t Avtp_Most_GetPad(const Avtp_Most_t* const pdu) {
-    return GET_MOST_FIELD(AVTP_MOST_FIELD_PAD);
+    return (uint8_t) GET_MOST_FIELD(AVTP_MOST_FIELD_PAD);
 }
 
 /**
@@ -139,7 +139,7 @@ static inline uint8_t Avtp_Most_GetPad(const Avtp_Most_t* const pdu) {
  * @returns Value of the ACF Most PDU MTV field.
  */
 static inline uint8_t Avtp_Most_GetMtv(const Avtp_Most_t* const pdu) {
-    return GET_MOST_FIELD(AVTP_MOST_FIELD_MTV);
+    return (uint8_t) GET_MOST_FIELD(AVTP_MOST_FIELD_MTV);
 }
 
 /**
@@ -149,7 +149,7 @@ static inline uint8_t Avtp_Most_GetMtv(const Avtp_Most_t* const pdu) {
  * @returns Value of the ACF Most PDU Most Net ID field.
  */
 static inline uint8_t Avtp_Most_GetMostNetId(const Avtp_Most_t* const pdu) {
-    return GET_MOST_FIELD(AVTP_MOST_FIELD_MOST_NET_ID);
+    return (uint8_t) GET_MOST_FIELD(AVTP_MOST_FIELD_MOST_NET_ID);
 }
 
 /**
@@ -159,7 +159,7 @@ static inline uint8_t Avtp_Most_GetMostNetId(const Avtp_Most_t* const pdu) {
  * @returns Value of the ACF Most PDU Message Timestamp field.
  */
 static inline uint64_t Avtp_Most_GetMessageTimestamp(const Avtp_Most_t* const pdu) {
-    return GET_MOST_FIELD(AVTP_MOST_FIELD_MESSAGE_TIMESTAMP);
+    return (uint64_t) GET_MOST_FIELD(AVTP_MOST_FIELD_MESSAGE_TIMESTAMP);
 }
 
 /**
@@ -169,7 +169,7 @@ static inline uint64_t Avtp_Most_GetMessageTimestamp(const Avtp_Most_t* const pd
  * @returns Value of the ACF Most PDU Device ID field.
  */
 static inline uint16_t Avtp_Most_GetDeviceId(const Avtp_Most_t* const pdu) {
-    return GET_MOST_FIELD(AVTP_MOST_FIELD_DEVICE_ID);
+    return (uint16_t) GET_MOST_FIELD(AVTP_MOST_FIELD_DEVICE_ID);
 }
 
 /**
@@ -179,7 +179,7 @@ static inline uint16_t Avtp_Most_GetDeviceId(const Avtp_Most_t* const pdu) {
  * @returns Value of the ACF Most PDU FBlock ID field.
  */
 static inline uint8_t Avtp_Most_GetFblockId(const Avtp_Most_t* const pdu) {
-    return GET_MOST_FIELD(AVTP_MOST_FIELD_FBLOCK_ID);
+    return (uint8_t) GET_MOST_FIELD(AVTP_MOST_FIELD_FBLOCK_ID);
 }
 
 /**
@@ -189,7 +189,7 @@ static inline uint8_t Avtp_Most_GetFblockId(const Avtp_Most_t* const pdu) {
  * @returns Value of the ACF Most PDU Inst ID field.
  */
 static inline uint8_t Avtp_Most_GetInstId(const Avtp_Most_t* const pdu) {
-    return GET_MOST_FIELD(AVTP_MOST_FIELD_INST_ID);
+    return (uint8_t) GET_MOST_FIELD(AVTP_MOST_FIELD_INST_ID);
 }
 
 /**
@@ -199,7 +199,7 @@ static inline uint8_t Avtp_Most_GetInstId(const Avtp_Most_t* const pdu) {
  * @returns Value of the ACF Most PDU Func ID field.
  */
 static inline uint16_t Avtp_Most_GetFuncId(const Avtp_Most_t* const pdu) {
-    return GET_MOST_FIELD(AVTP_MOST_FIELD_FUNC_ID);
+    return (uint16_t) GET_MOST_FIELD(AVTP_MOST_FIELD_FUNC_ID);
 }
 
 /**
@@ -209,7 +209,7 @@ static inline uint16_t Avtp_Most_GetFuncId(const Avtp_Most_t* const pdu) {
  * @returns Value of the ACF Most PDU Op Type field.
  */
 static inline uint8_t Avtp_Most_GetOpType(const Avtp_Most_t* const pdu) {
-    return GET_MOST_FIELD(AVTP_MOST_FIELD_OP_TYPE);
+    return (uint8_t) GET_MOST_FIELD(AVTP_MOST_FIELD_OP_TYPE);
 }
 
 /**

--- a/include/avtp/acf/Ntscf.h
+++ b/include/avtp/acf/Ntscf.h
@@ -95,7 +95,7 @@ static const Avtp_FieldDescriptor_t Avtp_NtscfFieldDesc[AVTP_NTSCF_FIELD_MAX] =
  * @returns Value of the NTSCF PDU subtype field.
  */
 static inline uint8_t Avtp_Ntscf_GetSubtype(const Avtp_Ntscf_t* const pdu) {
-    return GET_NTSCF_FIELD(AVTP_NTSCF_FIELD_SUBTYPE);
+    return (uint8_t) GET_NTSCF_FIELD(AVTP_NTSCF_FIELD_SUBTYPE);
 }
 
 /**
@@ -105,7 +105,7 @@ static inline uint8_t Avtp_Ntscf_GetSubtype(const Avtp_Ntscf_t* const pdu) {
  * @returns Value of the NTSCF PDU SV field.
  */
 static inline uint8_t Avtp_Ntscf_GetSv(const Avtp_Ntscf_t* const pdu) {
-    return GET_NTSCF_FIELD(AVTP_NTSCF_FIELD_SV);
+    return (uint8_t) GET_NTSCF_FIELD(AVTP_NTSCF_FIELD_SV);
 }
 
 /**
@@ -115,7 +115,7 @@ static inline uint8_t Avtp_Ntscf_GetSv(const Avtp_Ntscf_t* const pdu) {
  * @returns Value of the NTSCF PDU version field.
  */
 static inline uint8_t Avtp_Ntscf_GetVersion(const Avtp_Ntscf_t* const pdu) {
-    return GET_NTSCF_FIELD(AVTP_NTSCF_FIELD_VERSION);
+    return (uint8_t) GET_NTSCF_FIELD(AVTP_NTSCF_FIELD_VERSION);
 }
 
 /**
@@ -125,7 +125,7 @@ static inline uint8_t Avtp_Ntscf_GetVersion(const Avtp_Ntscf_t* const pdu) {
  * @returns Value of the NTSCF PDU Ntscf Data Length field.
  */
 static inline uint16_t Avtp_Ntscf_GetNtscfDataLength(const Avtp_Ntscf_t* const pdu) {
-    return GET_NTSCF_FIELD(AVTP_NTSCF_FIELD_NTSCF_DATA_LENGTH);
+    return (uint16_t) GET_NTSCF_FIELD(AVTP_NTSCF_FIELD_NTSCF_DATA_LENGTH);
 }
 
 /**
@@ -135,7 +135,7 @@ static inline uint16_t Avtp_Ntscf_GetNtscfDataLength(const Avtp_Ntscf_t* const p
  * @returns Value of the NTSCF PDU Sequence Number field.
  */
 static inline uint8_t Avtp_Ntscf_GetSequenceNum(const Avtp_Ntscf_t* const pdu) {
-    return GET_NTSCF_FIELD(AVTP_NTSCF_FIELD_SEQUENCE_NUM);
+    return (uint8_t) GET_NTSCF_FIELD(AVTP_NTSCF_FIELD_SEQUENCE_NUM);
 }
 
 /**
@@ -145,7 +145,7 @@ static inline uint8_t Avtp_Ntscf_GetSequenceNum(const Avtp_Ntscf_t* const pdu) {
  * @returns Value of the NTSCF PDU Stream ID field.
  */
 static inline uint64_t Avtp_Ntscf_GetStreamId(const Avtp_Ntscf_t* const pdu) {
-    return GET_NTSCF_FIELD(AVTP_NTSCF_FIELD_STREAM_ID);
+    return (uint64_t) GET_NTSCF_FIELD(AVTP_NTSCF_FIELD_STREAM_ID);
 }
 
 /**
@@ -249,7 +249,7 @@ static inline void Avtp_Ntscf_Init(Avtp_Ntscf_t* pdu) {
  * @returns This function returns the value of the field.
  */
 static inline uint64_t Avtp_Ntscf_GetField(const Avtp_Ntscf_t* const pdu, Avtp_NtscfFields_t field) {
-    return GET_NTSCF_FIELD(field);
+    return (uint64_t) GET_NTSCF_FIELD(field);
 }
 
 /**

--- a/include/avtp/acf/Sensor.h
+++ b/include/avtp/acf/Sensor.h
@@ -97,7 +97,7 @@ static const Avtp_FieldDescriptor_t Avtp_SensorFieldDesc[AVTP_SENSOR_FIELD_MAX] 
  * @returns Value of the ACF message type field.
  */
 static inline uint8_t Avtp_Sensor_GetAcfMsgType(const Avtp_Sensor_t* const pdu) {
-    return GET_SENSOR_FIELD(AVTP_SENSOR_FIELD_ACF_MSG_TYPE);
+    return (uint8_t) GET_SENSOR_FIELD(AVTP_SENSOR_FIELD_ACF_MSG_TYPE);
 }
 
 /**
@@ -107,7 +107,7 @@ static inline uint8_t Avtp_Sensor_GetAcfMsgType(const Avtp_Sensor_t* const pdu) 
  * @returns Value of the ACF message length field.
  */
 static inline uint16_t Avtp_Sensor_GetAcfMsgLength(const Avtp_Sensor_t* const pdu) {
-    return GET_SENSOR_FIELD(AVTP_SENSOR_FIELD_ACF_MSG_LENGTH);
+    return (uint16_t) GET_SENSOR_FIELD(AVTP_SENSOR_FIELD_ACF_MSG_LENGTH);
 }
 
 /**
@@ -117,7 +117,7 @@ static inline uint16_t Avtp_Sensor_GetAcfMsgLength(const Avtp_Sensor_t* const pd
  * @returns Value of the MTV field.
  */
 static inline uint8_t Avtp_Sensor_GetMtv(const Avtp_Sensor_t* const pdu) {
-    return GET_SENSOR_FIELD(AVTP_SENSOR_FIELD_MTV);
+    return (uint8_t) GET_SENSOR_FIELD(AVTP_SENSOR_FIELD_MTV);
 }
 
 /**
@@ -127,7 +127,7 @@ static inline uint8_t Avtp_Sensor_GetMtv(const Avtp_Sensor_t* const pdu) {
  * @returns Value of the Num Sensor field.
  */
 static inline uint8_t Avtp_Sensor_GetNumSensor(const Avtp_Sensor_t* const pdu) {
-    return GET_SENSOR_FIELD(AVTP_SENSOR_FIELD_NUM_SENSOR);
+    return (uint8_t) GET_SENSOR_FIELD(AVTP_SENSOR_FIELD_NUM_SENSOR);
 }
 
 /**
@@ -137,7 +137,7 @@ static inline uint8_t Avtp_Sensor_GetNumSensor(const Avtp_Sensor_t* const pdu) {
  * @returns Value of the Sz field.
  */
 static inline uint8_t Avtp_Sensor_GetSz(const Avtp_Sensor_t* const pdu) {
-    return GET_SENSOR_FIELD(AVTP_SENSOR_FIELD_SZ);
+    return (uint8_t) GET_SENSOR_FIELD(AVTP_SENSOR_FIELD_SZ);
 }
 
 /**
@@ -147,7 +147,7 @@ static inline uint8_t Avtp_Sensor_GetSz(const Avtp_Sensor_t* const pdu) {
  * @returns Value of the Sensor Group field.
  */
 static inline uint8_t Avtp_Sensor_GetSensorGroup(const Avtp_Sensor_t* const pdu) {
-    return GET_SENSOR_FIELD(AVTP_SENSOR_FIELD_SENSOR_GROUP);
+    return (uint8_t) GET_SENSOR_FIELD(AVTP_SENSOR_FIELD_SENSOR_GROUP);
 }
 
 /**
@@ -157,7 +157,7 @@ static inline uint8_t Avtp_Sensor_GetSensorGroup(const Avtp_Sensor_t* const pdu)
  * @returns Value of the Message Timestamp field.
  */
 static inline uint64_t Avtp_Sensor_GetMessageTimestamp(const Avtp_Sensor_t* const pdu) {
-    return GET_SENSOR_FIELD(AVTP_SENSOR_FIELD_MESSAGE_TIMESTAMP);
+    return (uint64_t) GET_SENSOR_FIELD(AVTP_SENSOR_FIELD_MESSAGE_TIMESTAMP);
 }
 
 /**

--- a/include/avtp/acf/SensorBrief.h
+++ b/include/avtp/acf/SensorBrief.h
@@ -94,7 +94,7 @@ static const Avtp_FieldDescriptor_t Avtp_SensorBriefFieldDesc[AVTP_SENSOR_FIELD_
  * @returns Value of the ACF message type field.
  */
 static inline uint8_t Avtp_SensorBrief_GetAcfMsgType(const Avtp_SensorBrief_t* const pdu) {
-    return GET_SENSOR_BRIEF_FIELD(AVTP_SENSOR_BRIEF_FIELD_ACF_MSG_TYPE);
+    return (uint8_t) GET_SENSOR_BRIEF_FIELD(AVTP_SENSOR_BRIEF_FIELD_ACF_MSG_TYPE);
 }
 
 /**
@@ -104,7 +104,7 @@ static inline uint8_t Avtp_SensorBrief_GetAcfMsgType(const Avtp_SensorBrief_t* c
  * @returns Value of the ACF message length field.
  */
 static inline uint16_t Avtp_SensorBrief_GetAcfMsgLength(const Avtp_SensorBrief_t* const pdu) {
-    return GET_SENSOR_BRIEF_FIELD(AVTP_SENSOR_BRIEF_FIELD_ACF_MSG_LENGTH);
+    return (uint16_t) GET_SENSOR_BRIEF_FIELD(AVTP_SENSOR_BRIEF_FIELD_ACF_MSG_LENGTH);
 }
 
 /**
@@ -114,7 +114,7 @@ static inline uint16_t Avtp_SensorBrief_GetAcfMsgLength(const Avtp_SensorBrief_t
  * @returns Value of the MTV field.
  */
 static inline uint8_t Avtp_SensorBrief_GetMtv(const Avtp_SensorBrief_t* const pdu) {
-    return GET_SENSOR_BRIEF_FIELD(AVTP_SENSOR_BRIEF_FIELD_MTV);
+    return (uint8_t) GET_SENSOR_BRIEF_FIELD(AVTP_SENSOR_BRIEF_FIELD_MTV);
 }
 
 /**
@@ -124,7 +124,7 @@ static inline uint8_t Avtp_SensorBrief_GetMtv(const Avtp_SensorBrief_t* const pd
  * @returns Value of the Num Sensor field.
  */
 static inline uint8_t Avtp_SensorBrief_GetNumSensor(const Avtp_SensorBrief_t* const pdu) {
-    return GET_SENSOR_BRIEF_FIELD(AVTP_SENSOR_BRIEF_FIELD_NUM_SENSOR);
+    return (uint8_t) GET_SENSOR_BRIEF_FIELD(AVTP_SENSOR_BRIEF_FIELD_NUM_SENSOR);
 }
 
 /**
@@ -134,7 +134,7 @@ static inline uint8_t Avtp_SensorBrief_GetNumSensor(const Avtp_SensorBrief_t* co
  * @returns Value of the Sz field.
  */
 static inline uint8_t Avtp_SensorBrief_GetSz(const Avtp_SensorBrief_t* const pdu) {
-    return GET_SENSOR_BRIEF_FIELD(AVTP_SENSOR_BRIEF_FIELD_SZ);
+    return (uint8_t) GET_SENSOR_BRIEF_FIELD(AVTP_SENSOR_BRIEF_FIELD_SZ);
 }
 
 /**
@@ -144,7 +144,7 @@ static inline uint8_t Avtp_SensorBrief_GetSz(const Avtp_SensorBrief_t* const pdu
  * @returns Value of the Sensor Group field.
  */
 static inline uint8_t Avtp_SensorBrief_GetSensorGroup(const Avtp_SensorBrief_t* const pdu) {
-    return GET_SENSOR_BRIEF_FIELD(AVTP_SENSOR_BRIEF_FIELD_SENSOR_GROUP);
+    return (uint8_t) GET_SENSOR_BRIEF_FIELD(AVTP_SENSOR_BRIEF_FIELD_SENSOR_GROUP);
 }
 
 /**

--- a/include/avtp/acf/Tscf.h
+++ b/include/avtp/acf/Tscf.h
@@ -107,7 +107,7 @@ static const Avtp_FieldDescriptor_t Avtp_TscfFieldDesc[AVTP_TSCF_FIELD_MAX] =
  * @returns Value of the TSCF PDU subtype field.
  */
 static inline uint8_t Avtp_Tscf_GetSubtype(const Avtp_Tscf_t* const pdu) {
-    return GET_TSCF_FIELD(AVTP_TSCF_FIELD_SUBTYPE);
+    return (uint8_t) GET_TSCF_FIELD(AVTP_TSCF_FIELD_SUBTYPE);
 }
 
 /**
@@ -117,7 +117,7 @@ static inline uint8_t Avtp_Tscf_GetSubtype(const Avtp_Tscf_t* const pdu) {
  * @returns Value of the TSCF PDU SV field.
  */
 static inline uint8_t Avtp_Tscf_GetSv(const Avtp_Tscf_t* const pdu) {
-    return GET_TSCF_FIELD(AVTP_TSCF_FIELD_SV);
+    return (uint8_t) GET_TSCF_FIELD(AVTP_TSCF_FIELD_SV);
 }
 
 /**
@@ -127,7 +127,7 @@ static inline uint8_t Avtp_Tscf_GetSv(const Avtp_Tscf_t* const pdu) {
  * @returns Value of the TSCF PDU version field.
  */
 static inline uint8_t Avtp_Tscf_GetVersion(const Avtp_Tscf_t* const pdu) {
-    return GET_TSCF_FIELD(AVTP_TSCF_FIELD_VERSION);
+    return (uint8_t) GET_TSCF_FIELD(AVTP_TSCF_FIELD_VERSION);
 }
 
 /**
@@ -137,7 +137,7 @@ static inline uint8_t Avtp_Tscf_GetVersion(const Avtp_Tscf_t* const pdu) {
  * @returns Value of the TSCF PDU MR field.
  */
 static inline uint8_t Avtp_Tscf_GetMr(const Avtp_Tscf_t* const pdu) {
-    return GET_TSCF_FIELD(AVTP_TSCF_FIELD_MR);
+    return (uint8_t) GET_TSCF_FIELD(AVTP_TSCF_FIELD_MR);
 }
 
 /**
@@ -147,7 +147,7 @@ static inline uint8_t Avtp_Tscf_GetMr(const Avtp_Tscf_t* const pdu) {
  * @returns Value of the TSCF PDU TV field.
  */
 static inline uint8_t Avtp_Tscf_GetTv(const Avtp_Tscf_t* const pdu) {
-    return GET_TSCF_FIELD(AVTP_TSCF_FIELD_TV);
+    return (uint8_t) GET_TSCF_FIELD(AVTP_TSCF_FIELD_TV);
 }
 
 /**
@@ -157,7 +157,7 @@ static inline uint8_t Avtp_Tscf_GetTv(const Avtp_Tscf_t* const pdu) {
  * @returns Value of the TSCF PDU Sequence Number field.
  */
 static inline uint8_t Avtp_Tscf_GetSequenceNum(const Avtp_Tscf_t* const pdu) {
-    return GET_TSCF_FIELD(AVTP_TSCF_FIELD_SEQUENCE_NUM);
+    return (uint8_t) GET_TSCF_FIELD(AVTP_TSCF_FIELD_SEQUENCE_NUM);
 }
 
 /**
@@ -167,7 +167,7 @@ static inline uint8_t Avtp_Tscf_GetSequenceNum(const Avtp_Tscf_t* const pdu) {
  * @returns Value of the TSCF PDU TU field.
  */
 static inline uint8_t Avtp_Tscf_GetTu(const Avtp_Tscf_t* const pdu) {
-    return GET_TSCF_FIELD(AVTP_TSCF_FIELD_TU);
+    return (uint8_t) GET_TSCF_FIELD(AVTP_TSCF_FIELD_TU);
 }
 
 /**
@@ -177,7 +177,7 @@ static inline uint8_t Avtp_Tscf_GetTu(const Avtp_Tscf_t* const pdu) {
  * @returns Value of the TSCF PDU Stream ID field.
  */
 static inline uint64_t Avtp_Tscf_GetStreamId(const Avtp_Tscf_t* const pdu) {
-    return GET_TSCF_FIELD(AVTP_TSCF_FIELD_STREAM_ID);
+    return (uint64_t) GET_TSCF_FIELD(AVTP_TSCF_FIELD_STREAM_ID);
 }
 
 /**
@@ -187,7 +187,7 @@ static inline uint64_t Avtp_Tscf_GetStreamId(const Avtp_Tscf_t* const pdu) {
  * @returns Value of the TSCF PDU AVTP Timestamp field.
  */
 static inline uint32_t Avtp_Tscf_GetAvtpTimestamp(const Avtp_Tscf_t* const pdu) {
-    return GET_TSCF_FIELD(AVTP_TSCF_FIELD_AVTP_TIMESTAMP);
+    return (uint32_t) GET_TSCF_FIELD(AVTP_TSCF_FIELD_AVTP_TIMESTAMP);
 }
 
 /**
@@ -197,7 +197,7 @@ static inline uint32_t Avtp_Tscf_GetAvtpTimestamp(const Avtp_Tscf_t* const pdu) 
  * @returns Value of the TSCF PDU Stream Data Length field.
  */
 static inline uint16_t Avtp_Tscf_GetStreamDataLength(const Avtp_Tscf_t* const pdu) {
-    return GET_TSCF_FIELD(AVTP_TSCF_FIELD_STREAM_DATA_LENGTH);
+    return (uint16_t) GET_TSCF_FIELD(AVTP_TSCF_FIELD_STREAM_DATA_LENGTH);
 }
 
 /**
@@ -366,7 +366,7 @@ static inline void Avtp_Tscf_Init(Avtp_Tscf_t* pdu) {
  * @returns This function returns the value of the field.
  */
 static inline uint64_t Avtp_Tscf_GetField(const Avtp_Tscf_t* const pdu, Avtp_TscfFields_t field) {
-    return GET_TSCF_FIELD(field);
+    return (uint64_t) GET_TSCF_FIELD(field);
 }
 
 /**

--- a/src/avtp/CommonHeader.c
+++ b/src/avtp/CommonHeader.c
@@ -62,17 +62,17 @@ uint64_t Avtp_CommonHeader_GetField(const Avtp_CommonHeader_t* const pdu,
 
 uint8_t Avtp_CommonHeader_GetSubtype(const Avtp_CommonHeader_t* const pdu)
 {
-    return GET_FIELD(AVTP_COMMON_HEADER_FIELD_SUBTYPE);
+    return (uint8_t)GET_FIELD(AVTP_COMMON_HEADER_FIELD_SUBTYPE);
 }
 
 uint8_t Avtp_CommonHeader_GetH(const Avtp_CommonHeader_t* const pdu)
 {
-    return GET_FIELD(AVTP_COMMON_HEADER_FIELD_H);
+    return (uint8_t)GET_FIELD(AVTP_COMMON_HEADER_FIELD_H);
 }
 
 uint8_t Avtp_CommonHeader_GetVersion(const Avtp_CommonHeader_t* const pdu)
 {
-    return GET_FIELD(AVTP_COMMON_HEADER_FIELD_VERSION);
+    return (uint8_t)GET_FIELD(AVTP_COMMON_HEADER_FIELD_VERSION);
 }
 
 void Avtp_CommonHeader_SetField(Avtp_CommonHeader_t* pdu,

--- a/src/avtp/Crf.c
+++ b/src/avtp/Crf.c
@@ -78,42 +78,42 @@ uint64_t Avtp_Crf_GetField(const Avtp_Crf_t* const pdu, Avtp_CrfField_t field)
 
 uint8_t Avtp_Crf_GetSubtype(const Avtp_Crf_t* const pdu)
 {
-    return GET_FIELD(AVTP_CRF_FIELD_SUBTYPE);
+    return (uint8_t)GET_FIELD(AVTP_CRF_FIELD_SUBTYPE);
 }
 
 uint8_t Avtp_Crf_GetSv(const Avtp_Crf_t* const pdu)
 {
-    return GET_FIELD(AVTP_CRF_FIELD_SV);
+    return (uint8_t)GET_FIELD(AVTP_CRF_FIELD_SV);
 }
 
 uint8_t Avtp_Crf_GetVersion(const Avtp_Crf_t* const pdu)
 {
-    return GET_FIELD(AVTP_CRF_FIELD_VERSION);
+    return (uint8_t)GET_FIELD(AVTP_CRF_FIELD_VERSION);
 }
 
 uint8_t Avtp_Crf_GetMr(const Avtp_Crf_t* const pdu)
 {
-    return GET_FIELD(AVTP_CRF_FIELD_MR);
+    return (uint8_t)GET_FIELD(AVTP_CRF_FIELD_MR);
 }
 
 uint8_t Avtp_Crf_GetFs(const Avtp_Crf_t* const pdu)
 {
-    return GET_FIELD(AVTP_CRF_FIELD_FS);
+    return (uint8_t)GET_FIELD(AVTP_CRF_FIELD_FS);
 }
 
 uint8_t Avtp_Crf_GetTu(const Avtp_Crf_t* const pdu)
 {
-    return GET_FIELD(AVTP_CRF_FIELD_TU);
+    return (uint8_t)GET_FIELD(AVTP_CRF_FIELD_TU);
 }
 
 uint8_t Avtp_Crf_GetSequenceNum(const Avtp_Crf_t* const pdu)
 {
-    return GET_FIELD(AVTP_CRF_FIELD_SEQUENCE_NUM);
+    return (uint8_t)GET_FIELD(AVTP_CRF_FIELD_SEQUENCE_NUM);
 }
 
 uint8_t Avtp_Crf_GetType(const Avtp_Crf_t* const pdu)
 {
-    return GET_FIELD(AVTP_CRF_FIELD_TYPE);
+    return (uint8_t)GET_FIELD(AVTP_CRF_FIELD_TYPE);
 }
 
 uint64_t Avtp_Crf_GetStreamId(const Avtp_Crf_t* const pdu)
@@ -123,22 +123,22 @@ uint64_t Avtp_Crf_GetStreamId(const Avtp_Crf_t* const pdu)
 
 uint8_t Avtp_Crf_GetPull(const Avtp_Crf_t* const pdu)
 {
-    return GET_FIELD(AVTP_CRF_FIELD_PULL);
+    return (uint8_t)GET_FIELD(AVTP_CRF_FIELD_PULL);
 }
 
 uint32_t Avtp_Crf_GetBaseFrequency(const Avtp_Crf_t* const pdu)
 {
-    return GET_FIELD(AVTP_CRF_FIELD_BASE_FREQUENCY);
+    return (uint32_t)GET_FIELD(AVTP_CRF_FIELD_BASE_FREQUENCY);
 }
 
 uint16_t Avtp_Crf_GetCrfDataLength(const Avtp_Crf_t* const pdu)
 {
-    return GET_FIELD(AVTP_CRF_FIELD_CRF_DATA_LENGTH);
+    return (uint16_t)GET_FIELD(AVTP_CRF_FIELD_CRF_DATA_LENGTH);
 }
 
 uint16_t Avtp_Crf_GetTimestampInterval(const Avtp_Crf_t* const pdu)
 {
-    return GET_FIELD(AVTP_CRF_FIELD_TIMESTAMP_INTERVAL);
+    return (uint16_t)GET_FIELD(AVTP_CRF_FIELD_TIMESTAMP_INTERVAL);
 }
 
 void Avtp_Crf_SetField(Avtp_Crf_t* pdu, Avtp_CrfField_t field, uint64_t value)

--- a/src/avtp/Rvf.c
+++ b/src/avtp/Rvf.c
@@ -96,37 +96,37 @@ uint64_t Avtp_Rvf_GetField(const Avtp_Rvf_t* const pdu, Avtp_RvfField_t field)
 
 uint8_t Avtp_Rvf_GetSubtype(const Avtp_Rvf_t* const pdu)
 {
-    return GET_FIELD(AVTP_RVF_FIELD_SUBTYPE);
+    return (uint8_t)GET_FIELD(AVTP_RVF_FIELD_SUBTYPE);
 }
 
 uint8_t Avtp_Rvf_GetSv(const Avtp_Rvf_t* const pdu)
 {
-    return GET_FIELD(AVTP_RVF_FIELD_SV);
+    return (uint8_t)GET_FIELD(AVTP_RVF_FIELD_SV);
 }
 
 uint8_t Avtp_Rvf_GetVersion(const Avtp_Rvf_t* const pdu)
 {
-    return GET_FIELD(AVTP_RVF_FIELD_VERSION);
+    return (uint8_t)GET_FIELD(AVTP_RVF_FIELD_VERSION);
 }
 
 uint8_t Avtp_Rvf_GetMr(const Avtp_Rvf_t* const pdu)
 {
-    return GET_FIELD(AVTP_RVF_FIELD_MR);
+    return (uint8_t)GET_FIELD(AVTP_RVF_FIELD_MR);
 }
 
 uint8_t Avtp_Rvf_GetTv(const Avtp_Rvf_t* const pdu)
 {
-    return GET_FIELD(AVTP_RVF_FIELD_TV);
+    return (uint8_t)GET_FIELD(AVTP_RVF_FIELD_TV);
 }
 
 uint8_t Avtp_Rvf_GetSequenceNum(const Avtp_Rvf_t* const pdu)
 {
-    return GET_FIELD(AVTP_RVF_FIELD_SEQUENCE_NUM);
+    return (uint8_t)GET_FIELD(AVTP_RVF_FIELD_SEQUENCE_NUM);
 }
 
 uint8_t Avtp_Rvf_GetTu(const Avtp_Rvf_t* const pdu)
 {
-    return GET_FIELD(AVTP_RVF_FIELD_TU);
+    return (uint8_t)GET_FIELD(AVTP_RVF_FIELD_TU);
 }
 
 uint64_t Avtp_Rvf_GetStreamId(const Avtp_Rvf_t* const pdu)
@@ -136,87 +136,87 @@ uint64_t Avtp_Rvf_GetStreamId(const Avtp_Rvf_t* const pdu)
 
 uint32_t Avtp_Rvf_GetAvtpTimestamp(const Avtp_Rvf_t* const pdu)
 {
-    return GET_FIELD(AVTP_RVF_FIELD_AVTP_TIMESTAMP);
+    return (uint32_t)GET_FIELD(AVTP_RVF_FIELD_AVTP_TIMESTAMP);
 }
 
 uint16_t Avtp_Rvf_GetActivePixels(const Avtp_Rvf_t* const pdu)
 {
-    return GET_FIELD(AVTP_RVF_FIELD_ACTIVE_PIXELS);
+    return (uint16_t)GET_FIELD(AVTP_RVF_FIELD_ACTIVE_PIXELS);
 }
 
 uint16_t Avtp_Rvf_GetTotalLines(const Avtp_Rvf_t* const pdu)
 {
-    return GET_FIELD(AVTP_RVF_FIELD_TOTAL_LINES);
+    return (uint16_t)GET_FIELD(AVTP_RVF_FIELD_TOTAL_LINES);
 }
 
 uint16_t Avtp_Rvf_GetStreamDataLength(const Avtp_Rvf_t* const pdu)
 {
-    return GET_FIELD(AVTP_RVF_FIELD_STREAM_DATA_LEN);
+    return (uint16_t)GET_FIELD(AVTP_RVF_FIELD_STREAM_DATA_LEN);
 }
 
 uint8_t Avtp_Rvf_GetAp(const Avtp_Rvf_t* const pdu)
 {
-    return GET_FIELD(AVTP_RVF_FIELD_AP);
+    return (uint8_t)GET_FIELD(AVTP_RVF_FIELD_AP);
 }
 
 uint8_t Avtp_Rvf_GetF(const Avtp_Rvf_t* const pdu)
 {
-    return GET_FIELD(AVTP_RVF_FIELD_F);
+    return (uint8_t)GET_FIELD(AVTP_RVF_FIELD_F);
 }
 
 uint8_t Avtp_Rvf_GetEf(const Avtp_Rvf_t* const pdu)
 {
-    return GET_FIELD(AVTP_RVF_FIELD_EF);
+    return (uint8_t)GET_FIELD(AVTP_RVF_FIELD_EF);
 }
 
 uint8_t Avtp_Rvf_GetEvt(const Avtp_Rvf_t* const pdu)
 {
-    return GET_FIELD(AVTP_RVF_FIELD_EVT);
+    return (uint8_t)GET_FIELD(AVTP_RVF_FIELD_EVT);
 }
 
 uint8_t Avtp_Rvf_GetPd(const Avtp_Rvf_t* const pdu)
 {
-    return GET_FIELD(AVTP_RVF_FIELD_PD);
+    return (uint8_t)GET_FIELD(AVTP_RVF_FIELD_PD);
 }
 
 uint8_t Avtp_Rvf_GetI(const Avtp_Rvf_t* const pdu)
 {
-    return GET_FIELD(AVTP_RVF_FIELD_I);
+    return (uint8_t)GET_FIELD(AVTP_RVF_FIELD_I);
 }
 
 Avtp_RvfPixelDepth_t Avtp_Rvf_GetPixelDepth(const Avtp_Rvf_t* const pdu)
 {
-    return GET_FIELD(AVTP_RVF_FIELD_PIXEL_DEPTH);
+    return (Avtp_RvfPixelDepth_t)GET_FIELD(AVTP_RVF_FIELD_PIXEL_DEPTH);
 }
 
 Avtp_RvfPixelFormat_t Avtp_Rvf_GetPixelFormat(const Avtp_Rvf_t* const pdu)
 {
-    return GET_FIELD(AVTP_RVF_FIELD_PIXEL_FORMAT);
+    return (Avtp_RvfPixelFormat_t)GET_FIELD(AVTP_RVF_FIELD_PIXEL_FORMAT);
 }
 
 Avtp_RvfFrameRate_t Avtp_Rvf_GetFrameRate(const Avtp_Rvf_t* const pdu)
 {
-    return GET_FIELD(AVTP_RVF_FIELD_FRAME_RATE);
+    return (Avtp_RvfFrameRate_t)GET_FIELD(AVTP_RVF_FIELD_FRAME_RATE);
 }
 
 Avtp_RvfColorspace_t Avtp_Rvf_GetColorspace(const Avtp_Rvf_t* const pdu)
 {
-    return GET_FIELD(AVTP_RVF_FIELD_COLORSPACE);
+    return (Avtp_RvfColorspace_t)GET_FIELD(AVTP_RVF_FIELD_COLORSPACE);
 }
 
 uint8_t Avtp_Rvf_GetNumLines(const Avtp_Rvf_t* const pdu)
 {
-    return GET_FIELD(AVTP_RVF_FIELD_NUM_LINES);
+    return (uint8_t)GET_FIELD(AVTP_RVF_FIELD_NUM_LINES);
 }
 
 uint8_t Avtp_Rvf_GetISeqNum(const Avtp_Rvf_t* const pdu)
 {
-    return GET_FIELD(AVTP_RVF_FIELD_I_SEQ_NUM);
+    return (uint8_t)GET_FIELD(AVTP_RVF_FIELD_I_SEQ_NUM);
 }
 
 uint16_t Avtp_Rvf_GetLineNumber(const Avtp_Rvf_t* const pdu)
 {
-    return GET_FIELD(AVTP_RVF_FIELD_LINE_NUMBER);
+    return (uint16_t)GET_FIELD(AVTP_RVF_FIELD_LINE_NUMBER);
 }
 
 void Avtp_Rvf_SetField(Avtp_Rvf_t* pdu, Avtp_RvfField_t field, uint64_t value)

--- a/src/avtp/Utils.c
+++ b/src/avtp/Utils.c
@@ -60,17 +60,17 @@ uint64_t Avtp_GetField(const Avtp_FieldDescriptor_t* fieldDescriptors,
             uint8_t quadletBits;
             uint8_t quadletShift;
             if (processedBits == 0) {
-                quadletBits = MIN(32 - fieldDescriptor->offset, fieldDescriptor->bits - processedBits);
-                quadletShift = 32 - quadletBits - fieldDescriptor->offset;
+                quadletBits = (uint8_t)MIN(32 - fieldDescriptor->offset, fieldDescriptor->bits - processedBits);
+                quadletShift = (uint8_t)(32 - quadletBits - fieldDescriptor->offset);
             } else {
-                quadletBits = MIN(32, fieldDescriptor->bits - processedBits);
-                quadletShift = 32 - quadletBits;
+                quadletBits = (uint8_t)MIN(32, fieldDescriptor->bits - processedBits);
+                quadletShift = (uint8_t)(32 - quadletBits);
             }
-            uint32_t quadletMask = ((1ULL << quadletBits) - 1ULL) << quadletShift;
+            uint32_t quadletMask = (uint32_t)(((1ULL << quadletBits) - 1ULL) << quadletShift);
             const uint32_t* quadletPtr = (const uint32_t*)(pdu + quadletId * 4);
             uint32_t quadletHostOrder = Avtp_BeToCpu32(*quadletPtr);
             uint32_t partialValue = (quadletHostOrder & quadletMask) >> quadletShift;
-            result |= (uint64_t)(partialValue) << (fieldDescriptor->bits - processedBits - quadletBits);
+            result |= (uint64_t)(partialValue) << ((uint32_t)(fieldDescriptor->bits - processedBits - quadletBits));
 
             quadletOffset += 1;
             processedBits += quadletBits;
@@ -91,14 +91,14 @@ void Avtp_SetField(const Avtp_FieldDescriptor_t* fieldDescriptors,
             uint8_t quadletBits;
             uint8_t quadletShift;
             if (processedBits == 0) {
-                quadletBits = MIN(32 - fieldDescriptor->offset, fieldDescriptor->bits - processedBits);
-                quadletShift = 32 - quadletBits - fieldDescriptor->offset;
+                quadletBits = (uint8_t)MIN(32 - fieldDescriptor->offset, fieldDescriptor->bits - processedBits);
+                quadletShift = (uint8_t)(32 - quadletBits - fieldDescriptor->offset);
             } else {
-                quadletBits = MIN(32, fieldDescriptor->bits - processedBits);
-                quadletShift = 32 - quadletBits;
+                quadletBits = (uint8_t)MIN(32, fieldDescriptor->bits - processedBits);
+                quadletShift = (uint8_t)(32 - quadletBits);
             }
-            uint32_t partialValue = value >> (fieldDescriptor->bits - processedBits - quadletBits);
-            uint32_t quadletMask = ((1ULL << quadletBits) - 1ULL) << quadletShift;
+            uint32_t partialValue = (uint32_t)(value >> (fieldDescriptor->bits - processedBits - quadletBits));
+            uint32_t quadletMask = (uint32_t)(((1ULL << quadletBits) - 1ULL) << quadletShift);
             uint32_t* quadletPtr = (uint32_t*)(pdu + quadletId * 4);
             uint32_t quadletHostOrder = Avtp_BeToCpu32(*quadletPtr);
             quadletHostOrder = (quadletHostOrder & ~quadletMask) | ((partialValue << quadletShift) & quadletMask);

--- a/src/avtp/aaf/Aaf.c
+++ b/src/avtp/aaf/Aaf.c
@@ -65,37 +65,37 @@ uint64_t Avtp_Aaf_GetField(const Avtp_Aaf_t* const pdu, Avtp_AafFields_t field)
 
 uint8_t Avtp_Aaf_GetSubtype(const Avtp_Aaf_t* const pdu)
 {
-    return GET_FIELD(AVTP_AAF_FIELD_SUBTYPE);
+    return (uint8_t)GET_FIELD(AVTP_AAF_FIELD_SUBTYPE);
 }
 
 uint8_t Avtp_Aaf_GetSv(const Avtp_Aaf_t* const pdu)
 {
-    return GET_FIELD(AVTP_AAF_FIELD_SV);
+    return (uint8_t)GET_FIELD(AVTP_AAF_FIELD_SV);
 }
 
 uint8_t Avtp_Aaf_GetVersion(const Avtp_Aaf_t* const pdu)
 {
-    return GET_FIELD(AVTP_AAF_FIELD_VERSION);
+    return (uint8_t)GET_FIELD(AVTP_AAF_FIELD_VERSION);
 }
 
 uint8_t Avtp_Aaf_GetMr(const Avtp_Aaf_t* const pdu)
 {
-    return GET_FIELD(AVTP_AAF_FIELD_MR);
+    return (uint8_t)GET_FIELD(AVTP_AAF_FIELD_MR);
 }
 
 uint8_t Avtp_Aaf_GetTv(const Avtp_Aaf_t* const pdu)
 {
-    return GET_FIELD(AVTP_AAF_FIELD_TV);
+    return (uint8_t)GET_FIELD(AVTP_AAF_FIELD_TV);
 }
 
 uint8_t Avtp_Aaf_GetSequenceNum(const Avtp_Aaf_t* const pdu)
 {
-    return GET_FIELD(AVTP_AAF_FIELD_SEQUENCE_NUM);
+    return (uint8_t)GET_FIELD(AVTP_AAF_FIELD_SEQUENCE_NUM);
 }
 
 uint8_t Avtp_Aaf_GetTu(const Avtp_Aaf_t* const pdu)
 {
-    return GET_FIELD(AVTP_AAF_FIELD_TU);
+    return (uint8_t)GET_FIELD(AVTP_AAF_FIELD_TU);
 }
 
 uint64_t Avtp_Aaf_GetStreamId(const Avtp_Aaf_t* const pdu)
@@ -105,32 +105,32 @@ uint64_t Avtp_Aaf_GetStreamId(const Avtp_Aaf_t* const pdu)
 
 uint32_t Avtp_Aaf_GetAvtpTimestamp(const Avtp_Aaf_t* const pdu)
 {
-    return GET_FIELD(AVTP_AAF_FIELD_AVTP_TIMESTAMP);
+    return (uint32_t)GET_FIELD(AVTP_AAF_FIELD_AVTP_TIMESTAMP);
 }
 
 uint8_t Avtp_Aaf_GetFormat(const Avtp_Aaf_t* const pdu)
 {
-    return GET_FIELD(AVTP_AAF_FIELD_FORMAT);
+    return (uint8_t)GET_FIELD(AVTP_AAF_FIELD_FORMAT);
 }
 
 uint16_t Avtp_Aaf_GetStreamDataLength(const Avtp_Aaf_t* const pdu)
 {
-    return GET_FIELD(AVTP_AAF_FIELD_STREAM_DATA_LENGTH);
+    return (uint16_t)GET_FIELD(AVTP_AAF_FIELD_STREAM_DATA_LENGTH);
 }
 
 uint8_t Avtp_Aaf_GetAfsd(const Avtp_Aaf_t* const pdu)
 {
-    return GET_FIELD(AVTP_AAF_FIELD_AFSD);
+    return (uint8_t)GET_FIELD(AVTP_AAF_FIELD_AFSD);
 }
 
 uint8_t Avtp_Aaf_GetSp(const Avtp_Aaf_t* const pdu)
 {
-    return GET_FIELD(AVTP_AAF_FIELD_SP);
+    return (uint8_t)GET_FIELD(AVTP_AAF_FIELD_SP);
 }
 
 uint8_t Avtp_Aaf_GetEvt(const Avtp_Aaf_t* const pdu)
 {
-    return GET_FIELD(AVTP_AAF_FIELD_EVT);
+    return (uint8_t)GET_FIELD(AVTP_AAF_FIELD_EVT);
 }
 
 void Avtp_Aaf_SetField(Avtp_Aaf_t* pdu, Avtp_AafFields_t field, uint64_t value)

--- a/src/avtp/aaf/Pcm.c
+++ b/src/avtp/aaf/Pcm.c
@@ -76,37 +76,37 @@ uint64_t Avtp_Pcm_GetField(const Avtp_Pcm_t* const pdu, Avtp_PcmFields_t field)
 
 uint8_t Avtp_Pcm_GetSubtype(const Avtp_Pcm_t* const pdu)
 {
-    return GET_FIELD(AVTP_PCM_FIELD_SUBTYPE);
+    return (uint8_t)GET_FIELD(AVTP_PCM_FIELD_SUBTYPE);
 }
 
 uint8_t Avtp_Pcm_GetSv(const Avtp_Pcm_t* const pdu)
 {
-    return GET_FIELD(AVTP_PCM_FIELD_SV);
+    return (uint8_t)GET_FIELD(AVTP_PCM_FIELD_SV);
 }
 
 uint8_t Avtp_Pcm_GetVersion(const Avtp_Pcm_t* const pdu)
 {
-    return GET_FIELD(AVTP_PCM_FIELD_VERSION);
+    return (uint8_t)GET_FIELD(AVTP_PCM_FIELD_VERSION);
 }
 
 uint8_t Avtp_Pcm_GetMr(const Avtp_Pcm_t* const pdu)
 {
-    return GET_FIELD(AVTP_PCM_FIELD_MR);
+    return (uint8_t)GET_FIELD(AVTP_PCM_FIELD_MR);
 }
 
 uint8_t Avtp_Pcm_GetTv(const Avtp_Pcm_t* const pdu)
 {
-    return GET_FIELD(AVTP_PCM_FIELD_TV);
+    return (uint8_t)GET_FIELD(AVTP_PCM_FIELD_TV);
 }
 
 uint8_t Avtp_Pcm_GetSequenceNum(const Avtp_Pcm_t* const pdu)
 {
-    return GET_FIELD(AVTP_PCM_FIELD_SEQUENCE_NUM);
+    return (uint8_t)GET_FIELD(AVTP_PCM_FIELD_SEQUENCE_NUM);
 }
 
 uint8_t Avtp_Pcm_GetTu(const Avtp_Pcm_t* const pdu)
 {
-    return GET_FIELD(AVTP_PCM_FIELD_TU);
+    return (uint8_t)GET_FIELD(AVTP_PCM_FIELD_TU);
 }
 
 uint64_t Avtp_Pcm_GetStreamId(const Avtp_Pcm_t* const pdu)
@@ -116,42 +116,42 @@ uint64_t Avtp_Pcm_GetStreamId(const Avtp_Pcm_t* const pdu)
 
 uint32_t Avtp_Pcm_GetAvtpTimestamp(const Avtp_Pcm_t* const pdu)
 {
-    return GET_FIELD(AVTP_PCM_FIELD_AVTP_TIMESTAMP);
+    return (uint32_t)GET_FIELD(AVTP_PCM_FIELD_AVTP_TIMESTAMP);
 }
 
 Avtp_AafFormat_t Avtp_Pcm_GetFormat(const Avtp_Pcm_t* const pdu)
 {
-    return GET_FIELD(AVTP_PCM_FIELD_FORMAT);
+    return (Avtp_AafFormat_t)GET_FIELD(AVTP_PCM_FIELD_FORMAT);
 }
 
 Avtp_AafNsr_t Avtp_Pcm_GetNsr(const Avtp_Pcm_t* const pdu)
 {
-    return GET_FIELD(AVTP_PCM_FIELD_NSR);
+    return (Avtp_AafNsr_t)GET_FIELD(AVTP_PCM_FIELD_NSR);
 }
 
 uint16_t Avtp_Pcm_GetChannelsPerFrame(const Avtp_Pcm_t* const pdu)
 {
-    return GET_FIELD(AVTP_PCM_FIELD_CHANNELS_PER_FRAME);
+    return (uint16_t)GET_FIELD(AVTP_PCM_FIELD_CHANNELS_PER_FRAME);
 }
 
 uint8_t Avtp_Pcm_GetBitDepth(const Avtp_Pcm_t* const pdu)
 {
-    return GET_FIELD(AVTP_PCM_FIELD_BIT_DEPTH);
+    return (uint8_t)GET_FIELD(AVTP_PCM_FIELD_BIT_DEPTH);
 }
 
 uint16_t Avtp_Pcm_GetStreamDataLength(const Avtp_Pcm_t* const pdu)
 {
-    return GET_FIELD(AVTP_PCM_FIELD_STREAM_DATA_LENGTH);
+    return (uint16_t)GET_FIELD(AVTP_PCM_FIELD_STREAM_DATA_LENGTH);
 }
 
 Avtp_AafSp_t Avtp_Pcm_GetSp(const Avtp_Pcm_t* const pdu)
 {
-    return GET_FIELD(AVTP_PCM_FIELD_SP);
+    return (Avtp_AafSp_t)GET_FIELD(AVTP_PCM_FIELD_SP);
 }
 
 uint8_t Avtp_Pcm_GetEvt(const Avtp_Pcm_t* const pdu)
 {
-    return GET_FIELD(AVTP_PCM_FIELD_EVT);
+    return (uint8_t)GET_FIELD(AVTP_PCM_FIELD_EVT);
 }
 
 void Avtp_Pcm_SetField(Avtp_Pcm_t* pdu, Avtp_PcmFields_t field, uint64_t value)

--- a/src/avtp/acf/custom/Vss.c
+++ b/src/avtp/acf/custom/Vss.c
@@ -79,16 +79,18 @@ void Avtp_Vss_SetField(Avtp_Vss_t* pdu,
 void Avtp_Vss_Pad(Avtp_Vss_t* vss_pdu, uint16_t vss_length) {
 
     uint8_t padSize;
+    uint16_t padded_length;
 
     // Check if padding is required
-    padSize = (AVTP_QUADLET_SIZE - (vss_length % AVTP_QUADLET_SIZE)) % AVTP_QUADLET_SIZE;
+    padSize = (uint8_t)((AVTP_QUADLET_SIZE - (vss_length % AVTP_QUADLET_SIZE)) % AVTP_QUADLET_SIZE);
     if (vss_length % AVTP_QUADLET_SIZE) {
-        memset(vss_pdu + vss_length, 0, padSize);
+        memset((uint8_t*)vss_pdu + vss_length, 0, padSize);
     }
 
     // Set the length and padding fields
+    padded_length = vss_length + padSize;
     Avtp_Vss_SetField(vss_pdu, AVTP_VSS_FIELD_ACF_MSG_LENGTH,
-                        (uint64_t) (vss_length+padSize)/AVTP_QUADLET_SIZE);
+                        (uint64_t)(padded_length / AVTP_QUADLET_SIZE));
     Avtp_Vss_SetField(vss_pdu, AVTP_VSS_FIELD_PAD, padSize);
 }
 
@@ -97,15 +99,15 @@ Avtp_AcfMsgType_t Avtp_Vss_GetAcfMsgType(const Avtp_Vss_t* const pdu) {
 }
 
 uint8_t Avtp_Vss_GetAcfMsgLength(const Avtp_Vss_t* const pdu) {
-    return GET_FIELD(AVTP_VSS_FIELD_ACF_MSG_LENGTH);
+    return (uint8_t)GET_FIELD(AVTP_VSS_FIELD_ACF_MSG_LENGTH);
 }
 
 uint8_t Avtp_Vss_GetPad(const Avtp_Vss_t* const pdu) {
-    return GET_FIELD(AVTP_VSS_FIELD_PAD);
+    return (uint8_t)GET_FIELD(AVTP_VSS_FIELD_PAD);
 }
 
 uint8_t Avtp_Vss_GetMtv(const Avtp_Vss_t* const pdu) {
-    return GET_FIELD(AVTP_VSS_FIELD_MTV);
+    return (uint8_t)GET_FIELD(AVTP_VSS_FIELD_MTV);
 }
 
 Vss_AddrMode_t Avtp_Vss_GetAddrMode(const Avtp_Vss_t* const pdu) {
@@ -179,7 +181,7 @@ uint16_t Avtp_Vss_GetVSSDataStringArrayLength(const VssDataStringArray_t* const 
              * fully-contained string. */
             break;
         }
-        ptr_idx += 2 + str_length;
+        ptr_idx += (uint16_t)(2 + str_length);
         idx++;
     }
 
@@ -200,7 +202,7 @@ void Avtp_Vss_DeserializeStringArray(const VssDataStringArray_t* const vss_data_
     const uint8_t* array_data = vss_data_string_array->data;
     uint16_t consumed = 0;
 
-    for (int i = 0; i < num_strings; i++) {
+    for (uint16_t i = 0; i < num_strings; i++) {
         if ((uint32_t)consumed + 2 > array_length) break;
 
         uint16_t str_length = Avtp_BeToCpu16(*(const uint16_t*)array_data);
@@ -212,7 +214,7 @@ void Avtp_Vss_DeserializeStringArray(const VssDataStringArray_t* const vss_data_
             memcpy(strings[i]->data, array_data + 2, str_length);
         }
         array_data += 2 + str_length;
-        consumed   += 2 + str_length;
+        consumed   += (uint16_t)(2 + str_length);
     }
 }
 
@@ -299,7 +301,7 @@ void Avtp_Vss_GetVssData(const Avtp_Vss_t* const pdu, VssData_t* val) {
             val->data_uint16_array->data_length = Avtp_BeToCpu16(*(const uint16_t*)vss_data_ptr);
             vss_data_ptr += 2;
             if (val->data_uint16_array->data != NULL) {
-                for (int i = 0; i < val->data_uint16_array->data_length/2; i++) {
+                for (uint16_t i = 0; i < (uint16_t)(val->data_uint16_array->data_length/2); i++) {
                     *(val->data_uint16_array->data + i) = Avtp_BeToCpu16(*((const uint16_t*)vss_data_ptr+i));
                 }
             }
@@ -309,7 +311,7 @@ void Avtp_Vss_GetVssData(const Avtp_Vss_t* const pdu, VssData_t* val) {
             val->data_int16_array->data_length = Avtp_BeToCpu16(*(const uint16_t*)vss_data_ptr);
             vss_data_ptr += 2;
             if (val->data_int16_array->data != NULL) {
-                for (int i = 0; i < val->data_int16_array->data_length/2; i++) {
+                for (uint16_t i = 0; i < (uint16_t)(val->data_int16_array->data_length/2); i++) {
                     *(val->data_int16_array->data + i) = (int16_t) Avtp_BeToCpu16(*((const uint16_t*)vss_data_ptr+i));
                 }
             }
@@ -319,7 +321,7 @@ void Avtp_Vss_GetVssData(const Avtp_Vss_t* const pdu, VssData_t* val) {
             val->data_uint32_array->data_length = Avtp_BeToCpu16(*(const uint16_t*)vss_data_ptr);
             vss_data_ptr += 2;
             if (val->data_uint32_array->data != NULL) {
-                for (int i = 0; i < val->data_uint32_array->data_length/4; i++) {
+                for (uint16_t i = 0; i < (uint16_t)(val->data_uint32_array->data_length/4); i++) {
                     *(val->data_uint32_array->data + i) = Avtp_BeToCpu32(*((const uint32_t*)vss_data_ptr+i));
                 }
             }
@@ -329,7 +331,7 @@ void Avtp_Vss_GetVssData(const Avtp_Vss_t* const pdu, VssData_t* val) {
             val->data_int32_array->data_length = Avtp_BeToCpu16(*(const uint16_t*)vss_data_ptr);
             vss_data_ptr += 2;
             if (val->data_int32_array->data != NULL) {
-                for (int i = 0; i < val->data_int32_array->data_length/4; i++) {
+                for (uint16_t i = 0; i < (uint16_t)(val->data_int32_array->data_length/4); i++) {
                     *(val->data_int32_array->data + i) = (int32_t) Avtp_BeToCpu32(*((const uint32_t*)vss_data_ptr+i));
                 }
             }
@@ -339,7 +341,7 @@ void Avtp_Vss_GetVssData(const Avtp_Vss_t* const pdu, VssData_t* val) {
             val->data_uint64_array->data_length = Avtp_BeToCpu16(*(const uint16_t*)vss_data_ptr);
             vss_data_ptr += 2;
             if (val->data_int64_array->data != NULL) {
-                for (int i = 0; i < val->data_uint64_array->data_length/8; i++) {
+                for (uint16_t i = 0; i < (uint16_t)(val->data_uint64_array->data_length/8); i++) {
                     *(val->data_uint64_array->data + i) = Avtp_BeToCpu64(*((const uint64_t*)vss_data_ptr+i));
                 }
             }
@@ -366,7 +368,7 @@ void Avtp_Vss_GetVssData(const Avtp_Vss_t* const pdu, VssData_t* val) {
             val->data_float_array->data_length = Avtp_BeToCpu16(*(const uint16_t*)vss_data_ptr);
             vss_data_ptr += 2;
             if (val->data_float_array->data != NULL) {
-                for (int i = 0; i < val->data_float_array->data_length/4; i++) {
+                for (uint16_t i = 0; i < (uint16_t)(val->data_float_array->data_length/4); i++) {
                     uint32_t temp_float = Avtp_BeToCpu32(*((const uint32_t*)vss_data_ptr+i));
                     memcpy(val->data_float_array->data + i, &temp_float, sizeof(float));
                 }
@@ -377,7 +379,7 @@ void Avtp_Vss_GetVssData(const Avtp_Vss_t* const pdu, VssData_t* val) {
             val->data_double_array->data_length = Avtp_BeToCpu16(*(const uint16_t*)vss_data_ptr);
             vss_data_ptr += 2;
             if (val->data_double_array->data != NULL) {
-                for (int i = 0; i < val->data_double_array->data_length/8; i++) {
+                for (uint16_t i = 0; i < (uint16_t)(val->data_double_array->data_length/8); i++) {
                     uint64_t temp_double = Avtp_BeToCpu64(*((const uint64_t*)vss_data_ptr+i));
                     memcpy(val->data_double_array->data + i, &temp_double, sizeof(double));
                 }
@@ -531,43 +533,43 @@ void Avtp_Vss_SetVssData(Avtp_Vss_t* pdu, VssData_t* val) {
 
         case VSS_UINT16_ARRAY:
             *(uint16_t*)vss_data_ptr = Avtp_CpuToBe16(val->data_uint16_array->data_length);
-            for (int i = 0; i < val->data_uint16_array->data_length/2; i++) {
+            for (uint16_t i = 0; i < (uint16_t)(val->data_uint16_array->data_length/2); i++) {
                 *((uint16_t*)(vss_data_ptr+2) + i) = Avtp_CpuToBe16(*(val->data_uint16_array->data+i));
             }
             break;
 
         case VSS_INT16_ARRAY:
             *(uint16_t*)vss_data_ptr = Avtp_CpuToBe16(val->data_int16_array->data_length);
-            for (int i = 0; i < val->data_int16_array->data_length/2; i++) {
-                *((int16_t*)(vss_data_ptr+2) + i) = Avtp_CpuToBe16(*(val->data_int16_array->data+i));
+            for (uint16_t i = 0; i < val->data_int16_array->data_length/2; i++) {
+                *((int16_t*)(vss_data_ptr+2) + i) = (int16_t)Avtp_CpuToBe16(*(uint16_t*)(val->data_int16_array->data+i));
             }
             break;
 
         case VSS_UINT32_ARRAY:
             *(uint16_t*)vss_data_ptr = Avtp_CpuToBe16(val->data_uint32_array->data_length);
-            for (int i = 0; i < val->data_uint32_array->data_length/4; i++) {
+            for (uint16_t i = 0; i < (uint16_t)(val->data_uint32_array->data_length/4); i++) {
                 *((uint32_t*)(vss_data_ptr+2) + i) = Avtp_CpuToBe32(*(val->data_uint32_array->data+i));
             }
             break;
 
         case VSS_INT32_ARRAY:
             *(uint16_t*)vss_data_ptr = Avtp_CpuToBe16(val->data_int32_array->data_length);
-            for (int i = 0; i < val->data_int32_array->data_length/4; i++) {
-                *((int32_t*)(vss_data_ptr+2) + i) = Avtp_CpuToBe32(*(val->data_int32_array->data+i));
+            for (uint16_t i = 0; i < val->data_int32_array->data_length/4; i++) {
+                *((int32_t*)(vss_data_ptr+2) + i) = (int32_t)Avtp_CpuToBe32(*(uint32_t*)(val->data_int32_array->data+i));
             }
             break;
 
         case VSS_UINT64_ARRAY:
             *(uint16_t*)vss_data_ptr = Avtp_CpuToBe16(val->data_uint64_array->data_length);
-            for (int i = 0; i < val->data_uint64_array->data_length/8; i++) {
+            for (uint16_t i = 0; i < (uint16_t)(val->data_uint64_array->data_length/8); i++) {
                 *((uint64_t*)(vss_data_ptr+2) + i) = Avtp_CpuToBe64(*(val->data_uint64_array->data+i));
             }
             break;
 
         case VSS_INT64_ARRAY:
             *(uint16_t*)vss_data_ptr = Avtp_CpuToBe16(val->data_int64_array->data_length);
-            for (int i = 0; i < val->data_int64_array->data_length/8; i++) {
-                *((int64_t*)(vss_data_ptr+2) + i) = Avtp_CpuToBe64(*(val->data_int64_array->data+i));
+            for (uint16_t i = 0; i < val->data_int64_array->data_length/8; i++) {
+                *((int64_t*)(vss_data_ptr+2) + i) = (int64_t)Avtp_CpuToBe64(*(uint64_t*)(val->data_int64_array->data+i));
             }
             break;
 
@@ -579,7 +581,7 @@ void Avtp_Vss_SetVssData(Avtp_Vss_t* pdu, VssData_t* val) {
 
         case VSS_FLOAT_ARRAY:
             *(uint16_t*)vss_data_ptr = Avtp_CpuToBe16(val->data_float_array->data_length);
-            for (int i = 0; i < val->data_float_array->data_length/4; i++) {
+            for (uint16_t i = 0; i < (uint16_t)(val->data_float_array->data_length/4); i++) {
                 uint32_t temp_float = Avtp_CpuToBe32(*(uint32_t*)(val->data_float_array->data+i));
                 memcpy((uint32_t*)(vss_data_ptr+2) + i, &temp_float, sizeof(float));
             }
@@ -587,7 +589,7 @@ void Avtp_Vss_SetVssData(Avtp_Vss_t* pdu, VssData_t* val) {
 
         case VSS_DOUBLE_ARRAY:
             *(uint16_t*)vss_data_ptr = Avtp_CpuToBe16(val->data_double_array->data_length);
-            for (int i = 0; i < val->data_double_array->data_length/8; i++) {
+            for (uint16_t i = 0; i < (uint16_t)(val->data_double_array->data_length/8); i++) {
                 uint64_t temp_double = Avtp_CpuToBe64(*(uint64_t*)(val->data_double_array->data+i));
                 memcpy((uint64_t*)(vss_data_ptr+2) + i, &temp_double, sizeof(double));
             }
@@ -611,8 +613,8 @@ void Avtp_Vss_SerializeStringArray(VssDataStringArray_t* vss_data_string_array,
 
     uint16_t total_length = 0;
     uint8_t* data = vss_data_string_array->data;
-    for (int i = 0; i < num_strings; i++) {
-        total_length += strings[i]->data_length+2;
+    for (uint16_t i = 0; i < num_strings; i++) {
+        total_length += (uint16_t)(strings[i]->data_length+2);
 
         *(uint16_t*)data = Avtp_CpuToBe16(strings[i]->data_length);
         memcpy(data+2, strings[i]->data, strings[i]->data_length);

--- a/src/avtp/cvf/Cvf.c
+++ b/src/avtp/cvf/Cvf.c
@@ -80,37 +80,37 @@ uint64_t Avtp_Cvf_GetField(const Avtp_Cvf_t* const pdu, Avtp_CvfField_t field)
 
 uint8_t Avtp_Cvf_GetSubtype(const Avtp_Cvf_t* const pdu)
 {
-    return GET_FIELD(AVTP_CVF_FIELD_SUBTYPE);
+    return (uint8_t)GET_FIELD(AVTP_CVF_FIELD_SUBTYPE);
 }
 
 uint8_t Avtp_Cvf_GetSv(const Avtp_Cvf_t* const pdu)
 {
-    return GET_FIELD(AVTP_CVF_FIELD_SV);
+    return (uint8_t)GET_FIELD(AVTP_CVF_FIELD_SV);
 }
 
 uint8_t Avtp_Cvf_GetVersion(const Avtp_Cvf_t* const pdu)
 {
-    return GET_FIELD(AVTP_CVF_FIELD_VERSION);
+    return (uint8_t)GET_FIELD(AVTP_CVF_FIELD_VERSION);
 }
 
 uint8_t Avtp_Cvf_GetMr(const Avtp_Cvf_t* const pdu)
 {
-    return GET_FIELD(AVTP_CVF_FIELD_MR);
+    return (uint8_t)GET_FIELD(AVTP_CVF_FIELD_MR);
 }
 
 uint8_t Avtp_Cvf_GetTv(const Avtp_Cvf_t* const pdu)
 {
-    return GET_FIELD(AVTP_CVF_FIELD_TV);
+    return (uint8_t)GET_FIELD(AVTP_CVF_FIELD_TV);
 }
 
 uint8_t Avtp_Cvf_GetSequenceNum(const Avtp_Cvf_t* const pdu)
 {
-    return GET_FIELD(AVTP_CVF_FIELD_SEQUENCE_NUM);
+    return (uint8_t)GET_FIELD(AVTP_CVF_FIELD_SEQUENCE_NUM);
 }
 
 uint8_t Avtp_Cvf_GetTu(const Avtp_Cvf_t* const pdu)
 {
-    return GET_FIELD(AVTP_CVF_FIELD_TU);
+    return (uint8_t)GET_FIELD(AVTP_CVF_FIELD_TU);
 }
 
 uint64_t Avtp_Cvf_GetStreamId(const Avtp_Cvf_t* const pdu)
@@ -120,37 +120,37 @@ uint64_t Avtp_Cvf_GetStreamId(const Avtp_Cvf_t* const pdu)
 
 uint32_t Avtp_Cvf_GetAvtpTimestamp(const Avtp_Cvf_t* const pdu)
 {
-    return GET_FIELD(AVTP_CVF_FIELD_AVTP_TIMESTAMP);
+    return (uint32_t)GET_FIELD(AVTP_CVF_FIELD_AVTP_TIMESTAMP);
 }
 
 Avtp_CvfFormat_t Avtp_Cvf_GetFormat(const Avtp_Cvf_t* const pdu)
 {
-    return GET_FIELD(AVTP_CVF_FIELD_FORMAT);
+    return (Avtp_CvfFormat_t)GET_FIELD(AVTP_CVF_FIELD_FORMAT);
 }
 
 Avtp_CvfFormatSubtype_t Avtp_Cvf_GetFormatSubtype(const Avtp_Cvf_t* const pdu)
 {
-    return GET_FIELD(AVTP_CVF_FIELD_FORMAT_SUBTYPE);
+    return (Avtp_CvfFormatSubtype_t)GET_FIELD(AVTP_CVF_FIELD_FORMAT_SUBTYPE);
 }
 
 uint16_t Avtp_Cvf_GetStreamDataLength(const Avtp_Cvf_t* const pdu)
 {
-    return GET_FIELD(AVTP_CVF_FIELD_STREAM_DATA_LENGTH);
+    return (uint16_t)GET_FIELD(AVTP_CVF_FIELD_STREAM_DATA_LENGTH);
 }
 
 uint8_t Avtp_Cvf_GetPtv(const Avtp_Cvf_t* const pdu)
 {
-    return GET_FIELD(AVTP_CVF_FIELD_PTV);
+    return (uint8_t)GET_FIELD(AVTP_CVF_FIELD_PTV);
 }
 
 uint8_t Avtp_Cvf_GetM(const Avtp_Cvf_t* const pdu)
 {
-    return GET_FIELD(AVTP_CVF_FIELD_M);
+    return (uint8_t)GET_FIELD(AVTP_CVF_FIELD_M);
 }
 
 uint8_t Avtp_Cvf_GetEvt(const Avtp_Cvf_t* const pdu)
 {
-    return GET_FIELD(AVTP_CVF_FIELD_EVT);
+    return (uint8_t)GET_FIELD(AVTP_CVF_FIELD_EVT);
 }
 
 void Avtp_Cvf_SetField(Avtp_Cvf_t* pdu, Avtp_CvfField_t field, uint64_t value)

--- a/src/avtp/cvf/H264.c
+++ b/src/avtp/cvf/H264.c
@@ -58,7 +58,7 @@ uint64_t Avtp_H264_GetField(const Avtp_H264_t* const pdu, Avtp_H264Field_t field
 
 uint32_t Avtp_H264_GetTimestamp(const Avtp_H264_t* const pdu)
 {
-    return GET_FIELD(AVTP_H264_FIELD_TIMESTAMP);
+    return (uint32_t)GET_FIELD(AVTP_H264_FIELD_TIMESTAMP);
 }
 
 void Avtp_H264_SetField(Avtp_H264_t* pdu, Avtp_H264Field_t field, uint64_t value)

--- a/src/avtp/cvf/Jpeg2000.c
+++ b/src/avtp/cvf/Jpeg2000.c
@@ -65,37 +65,37 @@ uint64_t Avtp_Jpeg2000_GetField(const Avtp_Jpeg2000_t* const pdu, Avtp_Jpeg2000F
 
 uint8_t Avtp_Jpeg2000_GetTp(const Avtp_Jpeg2000_t* const pdu)
 {
-    return GET_FIELD(AVTP_JPEG2000_FIELD_TP);
+    return (uint8_t)GET_FIELD(AVTP_JPEG2000_FIELD_TP);
 }
 
 uint8_t Avtp_Jpeg2000_GetMhf(const Avtp_Jpeg2000_t* const pdu)
 {
-    return GET_FIELD(AVTP_JPEG2000_FIELD_MHF);
+    return (uint8_t)GET_FIELD(AVTP_JPEG2000_FIELD_MHF);
 }
 
 uint8_t Avtp_Jpeg2000_GetMhId(const Avtp_Jpeg2000_t* const pdu)
 {
-    return GET_FIELD(AVTP_JPEG2000_FIELD_MH_ID);
+    return (uint8_t)GET_FIELD(AVTP_JPEG2000_FIELD_MH_ID);
 }
 
 uint8_t Avtp_Jpeg2000_GetT(const Avtp_Jpeg2000_t* const pdu)
 {
-    return GET_FIELD(AVTP_JPEG2000_FIELD_T);
+    return (uint8_t)GET_FIELD(AVTP_JPEG2000_FIELD_T);
 }
 
 uint8_t Avtp_Jpeg2000_GetPriority(const Avtp_Jpeg2000_t* const pdu)
 {
-    return GET_FIELD(AVTP_JPEG2000_FIELD_PRIORITY);
+    return (uint8_t)GET_FIELD(AVTP_JPEG2000_FIELD_PRIORITY);
 }
 
 uint16_t Avtp_Jpeg2000_GetTileNumber(const Avtp_Jpeg2000_t* const pdu)
 {
-    return GET_FIELD(AVTP_JPEG2000_FIELD_TILE_NUMBER);
+    return (uint16_t)GET_FIELD(AVTP_JPEG2000_FIELD_TILE_NUMBER);
 }
 
 uint32_t Avtp_Jpeg2000_GetFragmentOffset(const Avtp_Jpeg2000_t* const pdu)
 {
-    return GET_FIELD(AVTP_JPEG2000_FIELD_FRAGMENT_OFFSET);
+    return (uint32_t)GET_FIELD(AVTP_JPEG2000_FIELD_FRAGMENT_OFFSET);
 }
 
 void Avtp_Jpeg2000_SetField(Avtp_Jpeg2000_t* pdu, Avtp_Jpeg2000Field_t field, uint64_t value)

--- a/src/avtp/cvf/Mjpeg.c
+++ b/src/avtp/cvf/Mjpeg.c
@@ -63,32 +63,32 @@ uint64_t Avtp_Mjpeg_GetField(const Avtp_Mjpeg_t* const pdu, Avtp_MjpegField_t fi
 
 uint8_t Avtp_Mjpeg_GetTypeSpecific(const Avtp_Mjpeg_t* const pdu)
 {
-    return GET_FIELD(AVTP_MJPEG_FIELD_TYPE_SPECIFIC);
+    return (uint8_t)GET_FIELD(AVTP_MJPEG_FIELD_TYPE_SPECIFIC);
 }
 
 uint32_t Avtp_Mjpeg_GetFragmentOffset(const Avtp_Mjpeg_t* const pdu)
 {
-    return GET_FIELD(AVTP_MJPEG_FIELD_FRAGMENT_OFFSET);
+    return (uint32_t)GET_FIELD(AVTP_MJPEG_FIELD_FRAGMENT_OFFSET);
 }
 
 uint8_t Avtp_Mjpeg_GetType(const Avtp_Mjpeg_t* const pdu)
 {
-    return GET_FIELD(AVTP_MJPEG_FIELD_TYPE);
+    return (uint8_t)GET_FIELD(AVTP_MJPEG_FIELD_TYPE);
 }
 
 uint8_t Avtp_Mjpeg_GetQ(const Avtp_Mjpeg_t* const pdu)
 {
-    return GET_FIELD(AVTP_MJPEG_FIELD_Q);
+    return (uint8_t)GET_FIELD(AVTP_MJPEG_FIELD_Q);
 }
 
 uint8_t Avtp_Mjpeg_GetWidth(const Avtp_Mjpeg_t* const pdu)
 {
-    return GET_FIELD(AVTP_MJPEG_FIELD_WIDTH);
+    return (uint8_t)GET_FIELD(AVTP_MJPEG_FIELD_WIDTH);
 }
 
 uint8_t Avtp_Mjpeg_GetHeight(const Avtp_Mjpeg_t* const pdu)
 {
-    return GET_FIELD(AVTP_MJPEG_FIELD_HEIGHT);
+    return (uint8_t)GET_FIELD(AVTP_MJPEG_FIELD_HEIGHT);
 }
 
 void Avtp_Mjpeg_SetField(Avtp_Mjpeg_t* pdu, Avtp_MjpegField_t field, uint64_t value)


### PR DESCRIPTION
warnings.

- Set Wconversion and Wsign-conversion in cmake scripts.
- Explicit casting for getter functions of different formats.