### PR TITLE
feat(examples): add ACF-LIN talker/listener example

### DIFF
--- a/examples/acf-lin/CMakeLists.txt
+++ b/examples/acf-lin/CMakeLists.txt
@@ -27,46 +27,18 @@
 # SPDX-License-Identifier: BSD-3-Clause
 #
 
+add_executable(acf-lin-talker EXCLUDE_FROM_ALL acf-lin-talker.c)
+target_link_libraries(acf-lin-talker open1722 open1722examples)
+target_include_directories(acf-lin-talker PUBLIC ${CMAKE_SOURCE_DIR}/include ../)
 
-add_library(open1722examples STATIC "common/common.c")
-target_include_directories(open1722examples PRIVATE
-    $<INSTALL_INTERFACE:include>
-    ${CMAKE_CURRENT_SOURCE_DIR})
-if (DEFINED ENV{ZEPHYR_BASE})
-    add_dependencies(open1722examples zephyr_generated_headers)
-    target_link_libraries(open1722examples PRIVATE zephyr_interface)
-endif()
-add_dependencies(examples open1722examples)
+add_executable(acf-lin-listener EXCLUDE_FROM_ALL acf-lin-listener.c)
+target_link_libraries(acf-lin-listener open1722 open1722examples)
+target_include_directories(acf-lin-listener PUBLIC ${CMAKE_SOURCE_DIR}/include ../)
 
-# These examples can be also built for Zephyr
-add_subdirectory(acf-can)
+add_dependencies(examples acf-lin-talker acf-lin-listener)
 
-# These examples are currently exclusively for Linux
-if(${CMAKE_SYSTEM_NAME} STREQUAL "Linux")
-    execute_process(
-    COMMAND ldd --version
-    OUTPUT_VARIABLE LDD_OUT
-    ERROR_VARIABLE LDD_ERROR
-    OUTPUT_STRIP_TRAILING_WHITESPACE
-    )
-
-    message(STATUS "LDD version err: ${LDD_ERROR}")
-    message(STATUS "LDD version out: ${LDD_OUT}")
-
-    ## MUSL ldd will output to stderr, while glibc ldd will output to stdout
-    if ("${LDD_ERROR}" MATCHES "musl")
-        message(STATUS "musl detected via ldd — linking argp")
-        target_link_libraries(open1722examples /usr/lib/libargp.a)
-    else()
-        message(STATUS "musl not detected via ldd — not linking argp")
-    endif()
-
-    add_subdirectory(aaf)
-    add_subdirectory(acf-lin)
-    add_subdirectory(crf)
-    add_subdirectory(cvf)
-    add_subdirectory(hello-world)
-    add_subdirectory(acf-vss)
-endif()
-
-
+install(TARGETS
+    acf-lin-talker
+    acf-lin-listener
+    RUNTIME DESTINATION bin
+    OPTIONAL)

--- a/examples/acf-lin/acf-lin-listener.c
+++ b/examples/acf-lin/acf-lin-listener.c
@@ -1,0 +1,192 @@
+/*
+ * Copyright (c) 2024, COVESA
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ *    * Redistributions of source code must retain the above copyright notice,
+ *      this list of conditions and the following disclaimer.
+ *    * Redistributions in binary form must reproduce the above copyright
+ *      notice, this list of conditions and the following disclaimer in the
+ *      documentation and/or other materials provided with the distribution.
+ *    * Neither the name of COVESA nor the names of its contributors may be
+ *      used to endorse or promote products derived from this software without
+ *      specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+/* ACF-LIN Listener example.
+ *
+ * This example implements a simple ACF-LIN listener that receives LIN frames
+ * encapsulated in ACF-LIN PDUs (IEEE Std. 1722-2016, chapter 9.4.5) carried
+ * inside NTSCF or TSCF control format packets over Ethernet or UDP.
+ *
+ * For each received LIN frame the listener prints the LIN bus ID, identifier,
+ * message timestamp, and raw payload bytes to stdout.
+ *
+ * Run 'acf-lin-listener --help' for usage information.
+ */
+
+#include <argp.h>
+#include <stdlib.h>
+#include <linux/if_ether.h>
+#include <linux/if_packet.h>
+#include <linux/if.h>
+#include <stdint.h>
+#include <string.h>
+#include <unistd.h>
+#include <inttypes.h>
+
+#include "common/common.h"
+#include "avtp/Udp.h"
+#include "avtp/acf/Ntscf.h"
+#include "avtp/acf/Tscf.h"
+#include "avtp/acf/AcfCommon.h"
+#include "avtp/acf/Lin.h"
+#include "avtp/CommonHeader.h"
+
+#define MAX_PDU_SIZE        1500
+
+static char ifname[IFNAMSIZ];
+static uint8_t macaddr[ETH_ALEN];
+static uint8_t use_udp;
+static uint32_t udp_port = 17220;
+
+static struct argp_option options[] = {
+    {"udp", 'u', 0, 0, "Use UDP (default: Ethernet)"},
+    {"ifname", 'i', "IFNAME", 0, "Network interface (if Ethernet)"},
+    {"dst-addr", 'd', "MACADDR", 0, "Stream destination MAC address (if Ethernet)"},
+    {"udp-port", 'p', "UDP_PORT", 0, "UDP port to listen on (if UDP, default: 17220)"},
+    { 0 }
+};
+
+static error_t parser(int key, char *arg, struct argp_state *state)
+{
+    int res;
+
+    switch (key) {
+    case 'p':
+        udp_port = (uint32_t) atoi(arg);
+        break;
+    case 'u':
+        use_udp = 1;
+        break;
+    case 'i':
+        strncpy(ifname, arg, sizeof(ifname) - 1);
+        break;
+    case 'd':
+        res = sscanf(arg, "%hhx:%hhx:%hhx:%hhx:%hhx:%hhx",
+                &macaddr[0], &macaddr[1], &macaddr[2],
+                &macaddr[3], &macaddr[4], &macaddr[5]);
+        if (res != 6) {
+            fprintf(stderr, "Invalid MAC address\n");
+            exit(EXIT_FAILURE);
+        }
+        break;
+    }
+
+    return 0;
+}
+
+static struct argp argp = { options, parser, 0, 0 };
+
+int main(int argc, char *argv[])
+{
+    int sk_fd, res;
+    uint32_t proc_bytes;
+    uint16_t msg_length, acf_msg_length_quadlets;
+    uint8_t subtype, acf_type;
+    uint8_t pdu[MAX_PDU_SIZE];
+    uint8_t *cf_pdu, *acf_pdu;
+
+    argp_parse(&argp, argc, argv, 0, NULL, NULL);
+
+    if (use_udp) {
+        sk_fd = create_listener_socket_udp(udp_port);
+    } else {
+        sk_fd = create_listener_socket(ifname, macaddr, ETH_P_TSN);
+    }
+
+    if (sk_fd < 0)
+        return 1;
+
+    printf("acf-lin-listener: waiting for LIN frames...\n");
+
+    while (1) {
+        proc_bytes = 0;
+
+        res = recv(sk_fd, pdu, MAX_PDU_SIZE, 0);
+        if (res < 0 || res > MAX_PDU_SIZE) {
+            perror("Failed to receive data");
+            goto err;
+        }
+
+        /* Skip optional UDP encapsulation header */
+        if (use_udp) {
+            proc_bytes += AVTP_UDP_HEADER_LEN;
+        }
+
+        /* Determine control format (NTSCF or TSCF) and get payload length */
+        cf_pdu = pdu + proc_bytes;
+        subtype = Avtp_CommonHeader_GetSubtype((Avtp_CommonHeader_t *) cf_pdu);
+        if (subtype == AVTP_SUBTYPE_TSCF) {
+            proc_bytes += AVTP_TSCF_HEADER_LEN;
+            msg_length = Avtp_Tscf_GetStreamDataLength((Avtp_Tscf_t *) cf_pdu);
+        } else if (subtype == AVTP_SUBTYPE_NTSCF) {
+            proc_bytes += AVTP_NTSCF_HEADER_LEN;
+            msg_length = Avtp_Ntscf_GetNtscfDataLength((Avtp_Ntscf_t *) cf_pdu);
+        } else {
+            continue;
+        }
+
+        /* Validate and parse ACF-LIN PDU */
+        acf_pdu = pdu + proc_bytes;
+        acf_type = Avtp_AcfCommon_GetAcfMsgType((Avtp_AcfCommon_t *) acf_pdu);
+        if (acf_type != AVTP_ACF_TYPE_LIN) {
+            fprintf(stderr, "ACF type mismatch: expected LIN (%u), got %u\n",
+                    AVTP_ACF_TYPE_LIN, acf_type);
+            continue;
+        }
+
+        Avtp_Lin_t *lin_pdu = (Avtp_Lin_t *) acf_pdu;
+        if (!Avtp_Lin_IsValid(lin_pdu, (size_t)(res - proc_bytes))) {
+            fprintf(stderr, "Invalid ACF-LIN PDU\n");
+            continue;
+        }
+
+        acf_msg_length_quadlets = Avtp_Lin_GetAcfMsgLength(lin_pdu);
+        uint8_t bus_id = Avtp_Lin_GetLinBusId(lin_pdu);
+        uint8_t lin_id = Avtp_Lin_GetLinIdentifier(lin_pdu);
+        uint64_t timestamp = Avtp_Lin_GetMessageTimestamp(lin_pdu);
+
+        uint16_t payload_len = acf_msg_length_quadlets * 4 - AVTP_LIN_HEADER_LEN;
+        uint8_t *payload = acf_pdu + AVTP_LIN_HEADER_LEN;
+
+        printf("LIN frame: bus=%u id=0x%02X ts=0x%016" PRIx64 " payload[%u]=",
+               bus_id, lin_id, timestamp, payload_len);
+        for (uint16_t i = 0; i < payload_len; i++) {
+            printf("%02X ", payload[i]);
+        }
+        printf("\n");
+
+        (void) msg_length;
+    }
+
+    return 0;
+
+err:
+    close(sk_fd);
+    return 1;
+}

--- a/examples/acf-lin/acf-lin-talker.c
+++ b/examples/acf-lin/acf-lin-talker.c
@@ -1,0 +1,300 @@
+/*
+ * Copyright (c) 2024, COVESA
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ *    * Redistributions of source code must retain the above copyright notice,
+ *      this list of conditions and the following disclaimer.
+ *    * Redistributions in binary form must reproduce the above copyright
+ *      notice, this list of conditions and the following disclaimer in the
+ *      documentation and/or other materials provided with the distribution.
+ *    * Neither the name of COVESA nor the names of its contributors may be
+ *      used to endorse or promote products derived from this software without
+ *      specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+/* ACF-LIN Talker example.
+ *
+ * This example implements a simple ACF-LIN talker that sends simulated LIN
+ * frames over Ethernet (raw TSN) or UDP using the ACF-LIN PDU format defined
+ * in IEEE Std. 1722-2016, chapter 9.4.5.
+ *
+ * LIN frames are carried inside NTSCF or TSCF control format packets.
+ * The talker sends one LIN frame per second containing a single-byte counter
+ * payload on the configured LIN bus/identifier.
+ *
+ * TSN stream parameters are passed via command-line arguments.
+ * Run 'acf-lin-talker --help' for more information.
+ */
+
+#include <linux/if_packet.h>
+#include <linux/if.h>
+#include <linux/if_ether.h>
+#include <time.h>
+
+#include <arpa/inet.h>
+#include <stdlib.h>
+#include <argp.h>
+#include <string.h>
+#include <unistd.h>
+#include <stdio.h>
+
+#include "common/common.h"
+#include "avtp/Udp.h"
+#include "avtp/acf/Ntscf.h"
+#include "avtp/acf/Tscf.h"
+#include "avtp/acf/Lin.h"
+#include "avtp/CommonHeader.h"
+
+#define MAX_PDU_SIZE                1500
+#define LIN_PAYLOAD_MAX_SIZE        8
+#define STREAM_ID                   0xAABBCCDDEEFF0001
+#define ARGPARSE_LIN_BUS_ID_OPTION  500
+#define ARGPARSE_LIN_ID_OPTION      501
+
+static char ifname[IFNAMSIZ];
+static uint8_t macaddr[ETH_ALEN];
+static uint8_t ip_addr[sizeof(struct in_addr)];
+static uint32_t udp_port = 17220;
+static int priority = -1;
+static uint8_t seq_num = 0;
+static uint32_t udp_seq_num = 0;
+static uint8_t use_tscf = 0;
+static uint8_t use_udp = 0;
+static uint8_t lin_bus_id = 0;
+static uint8_t lin_identifier = 0x01;
+
+static char doc[] =
+        "\nacf-lin-talker -- a program to send simulated LIN frames over"
+        " Ethernet using Open1722 (ACF-LIN)."
+        "\vEXAMPLES\n"
+        "  acf-lin-talker -i eth0 -d aa:bb:cc:dd:ee:ff\n"
+        "    (send LIN frames over Ethernet)\n"
+        "  acf-lin-talker -u -n 10.0.0.2:17220\n"
+        "    (send LIN frames over UDP)\n";
+
+static struct argp_option options[] = {
+    {"tscf", 't', 0, 0, "Use TSCF (default: NTSCF)"},
+    {"udp", 'u', 0, 0, "Use UDP (default: Ethernet)"},
+    {"ifname", 'i', "IFNAME", 0, "Network interface (if Ethernet)"},
+    {"dst-addr", 'd', "MACADDR", 0, "Stream destination MAC address (if Ethernet)"},
+    {"dst-nw-addr", 'n', "NW_ADDR", 0, "Stream destination network address and port (if UDP)"},
+    {"lin-bus-id", ARGPARSE_LIN_BUS_ID_OPTION, "BUS_ID", 0, "LIN bus ID (0-31, default: 0)"},
+    {"lin-id", ARGPARSE_LIN_ID_OPTION, "LIN_ID", 0, "LIN frame identifier (0-63, default: 1)"},
+    { 0 }
+};
+
+static error_t parser(int key, char *arg, struct argp_state *state)
+{
+    int res;
+    char ip_addr_str[100];
+
+    switch (key) {
+    case 't':
+        use_tscf = 1;
+        break;
+    case 'u':
+        use_udp = 1;
+        break;
+    case 'i':
+        strncpy(ifname, arg, sizeof(ifname) - 1);
+        break;
+    case 'd':
+        res = sscanf(arg, "%hhx:%hhx:%hhx:%hhx:%hhx:%hhx",
+                &macaddr[0], &macaddr[1], &macaddr[2],
+                &macaddr[3], &macaddr[4], &macaddr[5]);
+        if (res != 6) {
+            fprintf(stderr, "Invalid MAC address\n");
+            exit(EXIT_FAILURE);
+        }
+        break;
+    case 'n':
+        res = sscanf(arg, "%[^:]:%d", ip_addr_str, &udp_port);
+        if (!res) {
+            fprintf(stderr, "Invalid IP address or port\n");
+            exit(EXIT_FAILURE);
+        }
+        res = inet_pton(AF_INET, ip_addr_str, ip_addr);
+        if (!res) {
+            fprintf(stderr, "Invalid IP address\n");
+            exit(EXIT_FAILURE);
+        }
+        break;
+    case ARGPARSE_LIN_BUS_ID_OPTION:
+        lin_bus_id = (uint8_t) atoi(arg);
+        if (lin_bus_id > 31) {
+            fprintf(stderr, "LIN bus ID must be in range 0-31\n");
+            exit(EXIT_FAILURE);
+        }
+        break;
+    case ARGPARSE_LIN_ID_OPTION:
+        lin_identifier = (uint8_t) atoi(arg);
+        if (lin_identifier > 63) {
+            fprintf(stderr, "LIN identifier must be in range 0-63\n");
+            exit(EXIT_FAILURE);
+        }
+        break;
+    }
+
+    return 0;
+}
+
+static struct argp argp = { options, parser, 0, doc };
+
+static int init_cf_pdu(uint8_t *pdu)
+{
+    int res;
+    if (use_tscf) {
+        Avtp_Tscf_t *tscf_pdu = (Avtp_Tscf_t *) pdu;
+        memset(tscf_pdu, 0, AVTP_TSCF_HEADER_LEN);
+        Avtp_Tscf_Init(tscf_pdu);
+        Avtp_Tscf_DisableTu(tscf_pdu);
+        Avtp_Tscf_SetSequenceNum(tscf_pdu, seq_num++);
+        Avtp_Tscf_SetStreamId(tscf_pdu, STREAM_ID);
+        res = AVTP_TSCF_HEADER_LEN;
+    } else {
+        Avtp_Ntscf_t *ntscf_pdu = (Avtp_Ntscf_t *) pdu;
+        memset(ntscf_pdu, 0, AVTP_NTSCF_HEADER_LEN);
+        Avtp_Ntscf_Init(ntscf_pdu);
+        Avtp_Ntscf_SetSequenceNum(ntscf_pdu, seq_num++);
+        Avtp_Ntscf_SetStreamId(ntscf_pdu, STREAM_ID);
+        res = AVTP_NTSCF_HEADER_LEN;
+    }
+    return res;
+}
+
+static int update_cf_length(uint8_t *cf_pdu, uint64_t length)
+{
+    if (use_tscf) {
+        uint64_t payloadLen = length - AVTP_TSCF_HEADER_LEN;
+        Avtp_Tscf_SetStreamDataLength((Avtp_Tscf_t *) cf_pdu, payloadLen);
+    } else {
+        uint64_t payloadLen = length - AVTP_NTSCF_HEADER_LEN;
+        Avtp_Ntscf_SetNtscfDataLength((Avtp_Ntscf_t *) cf_pdu, payloadLen);
+    }
+    return 0;
+}
+
+static int prepare_lin_pdu(uint8_t *acf_pdu, uint8_t bus_id, uint8_t lin_id,
+                           uint8_t *payload, uint8_t payload_len)
+{
+    Avtp_Lin_t *lin_pdu = (Avtp_Lin_t *) acf_pdu;
+    uint8_t acf_length_quadlets;
+
+    memset(lin_pdu, 0, AVTP_LIN_HEADER_LEN);
+    Avtp_Lin_Init(lin_pdu);
+    Avtp_Lin_SetLinBusId(lin_pdu, bus_id);
+    Avtp_Lin_SetLinIdentifier(lin_pdu, lin_id);
+
+    memcpy(acf_pdu + AVTP_LIN_HEADER_LEN, payload, payload_len);
+
+    /* ACF message length is in quadlets; round up to next quadlet */
+    acf_length_quadlets = (AVTP_LIN_HEADER_LEN + payload_len + 3) / 4;
+    Avtp_Lin_SetAcfMsgLength(lin_pdu, acf_length_quadlets);
+
+    /* Zero-pad to quadlet boundary */
+    memset(acf_pdu + AVTP_LIN_HEADER_LEN + payload_len, 0,
+           acf_length_quadlets * 4 - AVTP_LIN_HEADER_LEN - payload_len);
+
+    return acf_length_quadlets * 4;
+}
+
+int main(int argc, char *argv[])
+{
+    int fd, res;
+    struct sockaddr_ll sk_ll_addr;
+    struct sockaddr_in sk_udp_addr;
+    uint8_t pdu[MAX_PDU_SIZE];
+    uint16_t pdu_length, cf_length;
+    uint8_t lin_payload = 0;
+
+    argp_parse(&argp, argc, argv, 0, NULL, NULL);
+
+    printf("acf-lin-talker configuration:\n");
+    printf("\tLIN bus ID     : %u\n", lin_bus_id);
+    printf("\tLIN identifier : 0x%02X\n", lin_identifier);
+    if (use_udp) {
+        printf("\tTransport      : UDP port %u\n", udp_port);
+    } else {
+        printf("\tTransport      : Ethernet, interface %s\n", ifname);
+    }
+
+    if (use_udp) {
+        fd = create_talker_socket_udp(priority);
+        if (fd < 0)
+            return 1;
+        res = setup_udp_socket_address((struct in_addr *) ip_addr,
+                                       udp_port, &sk_udp_addr);
+    } else {
+        fd = create_talker_socket(priority);
+        if (fd < 0)
+            return 1;
+        res = setup_socket_address(fd, ifname, macaddr,
+                                   ETH_P_TSN, &sk_ll_addr);
+    }
+    if (res < 0)
+        goto err;
+
+    for (;;) {
+        pdu_length = 0;
+        cf_length = 0;
+
+        if (use_udp) {
+            Avtp_Udp_t *udp_pdu = (Avtp_Udp_t *) pdu;
+            Avtp_Udp_SetEncapsulationSeqNo(udp_pdu, udp_seq_num++);
+            pdu_length += sizeof(Avtp_Udp_t);
+        }
+
+        uint8_t *cf_pdu = pdu + pdu_length;
+        res = init_cf_pdu(cf_pdu);
+        if (res < 0)
+            goto err;
+        pdu_length += res;
+        cf_length += res;
+
+        uint8_t *acf_pdu = pdu + pdu_length;
+        res = prepare_lin_pdu(acf_pdu, lin_bus_id, lin_identifier,
+                              &lin_payload, sizeof(lin_payload));
+        if (res < 0)
+            goto err;
+        pdu_length += res;
+        cf_length += res;
+
+        update_cf_length(cf_pdu, cf_length);
+
+        if (use_udp) {
+            res = sendto(fd, pdu, pdu_length, 0,
+                    (struct sockaddr *) &sk_udp_addr, sizeof(sk_udp_addr));
+        } else {
+            res = sendto(fd, pdu, pdu_length, 0,
+                         (struct sockaddr *) &sk_ll_addr, sizeof(sk_ll_addr));
+        }
+        if (res < 0) {
+            perror("Failed to send data");
+            goto err;
+        }
+
+        printf("Sent LIN frame: bus=%u id=0x%02X payload=0x%02X\n",
+               lin_bus_id, lin_identifier, lin_payload);
+        lin_payload++;
+        sleep(1);
+    }
+
+err:
+    close(fd);
+    return 1;
+}


### PR DESCRIPTION
Closes #21

## Summary

Adds a pair of Linux example applications for the **ACF-LIN** PDU format (IEEE Std. 1722-2016, chapter 9.4.5):

| File | Description |
|---|---|
| `examples/acf-lin/acf-lin-talker.c` | Sends simulated LIN frames at 1 Hz over Ethernet or UDP |
| `examples/acf-lin/acf-lin-listener.c` | Receives ACF-LIN frames and prints bus ID / identifier / payload |
| `examples/acf-lin/CMakeLists.txt` | Build rules (mirrors `hello-world` pattern) |

`examples/CMakeLists.txt` gains an `add_subdirectory(acf-lin)` inside the existing Linux-only block.

## Design

Since LIN has no standard Linux socket API (unlike SocketCAN for CAN), the talker simulates LIN data — an incrementing single-byte counter — sent periodically.  Both tools follow the CLI conventions of the other examples:

**Talker options**
- `-t/--tscf` — use TSCF instead of NTSCF
- `-u/--udp` — use UDP instead of Ethernet
- `-i/--ifname IFNAME` — Ethernet interface
- `-d/--dst-addr MACADDR` — destination MAC
- `-n/--dst-nw-addr HOST:PORT` — UDP destination
- `--lin-bus-id N` — LIN bus ID (0-31, default 0)
- `--lin-id N` — LIN frame identifier (0-63, default 1)

**Listener options**
- `-u/--udp`, `-i/--ifname`, `-d/--dst-addr`, `-p/--udp-port`

## Test plan

```sh
# Build
cmake -B build && cmake --build build --target acf-lin-talker acf-lin-listener

# Run on loopback (two terminals)
./build/examples/acf-lin/acf-lin-listener -i lo -d 00:00:00:00:00:00
./build/examples/acf-lin/acf-lin-talker   -i lo -d 00:00:00:00:00:00 --lin-id 5

# UDP mode
./build/examples/acf-lin/acf-lin-listener -u -p 17220
./build/examples/acf-lin/acf-lin-talker   -u -n 127.0.0.1:17220
```