### PR TITLE
FIX oob reads in ACF-VSS

### DIFF
--- a/src/avtp/acf/custom/Vss.c
+++ b/src/avtp/acf/custom/Vss.c
@@ -62,25 +62,62 @@ static const Avtp_FieldDescriptor_t Avtp_VssFieldDesc[AVTP_VSS_FIELD_MAX] =
  * quadlets × 4).  When msg_length is 0 (PDU not framed yet) the wire
  * length is returned unchanged.
  *
- * The arithmetic is done in uint32_t to prevent overflow when the wire
- * value approaches UINT16_MAX. */
+ * The prefix is only dereferenced when offset + 2 ≤ declared so that an
+ * out‑of‑frame data pointer never produces an OOB read before clamping.
+ * All offset arithmetic uses uint32_t to avoid wrap when ptr is far
+ * past the PDU start. */
 static uint16_t vss_read_clamped_length(const Avtp_Vss_t* pdu,
                                          const uint8_t* ptr)
 {
     uint16_t declared = (uint16_t)Avtp_Vss_GetAcfMsgLength(pdu) * AVTP_QUADLET_SIZE;
+    uint32_t offset   = (uint32_t)(ptr - (const uint8_t*)pdu);
+
+    /* The 2‑byte length prefix must fit within the declared PDU. */
+    if (offset + 2 > declared)
+        return 0;
+
     uint16_t wire_len = Avtp_BeToCpu16(*(const uint16_t*)ptr);
 
-    if (declared == 0)
-        return wire_len;
-
-    uint16_t offset = (uint16_t)(ptr - (const uint8_t*)pdu);
-
-    if ((uint32_t)offset + 2 + wire_len > declared) {
-        if (offset + 2 < declared)
-            return declared - offset - 2;
-        return 0;
+    if (offset + 2 + wire_len > declared) {
+        /* Prefix fits but the payload it describes is too long → clamp. */
+        return declared - (uint16_t)offset - 2;
     }
     return wire_len;
+}
+
+/* Getter‑side path length in bytes, clamped so that
+ * AVTP_VSS_FIXED_HEADER_LEN + path_length ≤ declared PDU size.
+ * Setters use CalcVssPathLength (raw) instead; this helper is for the
+ * read path only so that the data‑pointer computation never leaves the
+ * frame.  Unframed PDUs (msg_length == 0) keep the legacy raw value. */
+static uint16_t vss_get_clamped_path_length(const Avtp_Vss_t* pdu)
+{
+    uint16_t declared = (uint16_t)Avtp_Vss_GetAcfMsgLength(pdu) * AVTP_QUADLET_SIZE;
+    Vss_AddrMode_t mode = Avtp_Vss_GetAddrMode(pdu);
+
+    if (mode == VSS_STATIC_ID_MODE) {
+        /* Fixed 4‑byte path: only count it when the frame is large enough. */
+        return (declared >= AVTP_VSS_FIXED_HEADER_LEN + 4) ? 4
+             : (declared >  AVTP_VSS_FIXED_HEADER_LEN)
+                   ? declared - AVTP_VSS_FIXED_HEADER_LEN : 0;
+    }
+    if (mode == VSS_INTEROP_MODE) {
+        const uint8_t* path_ptr = (const uint8_t*)pdu + AVTP_VSS_FIXED_HEADER_LEN;
+        /* The 2‑byte prefix itself must fit before any path bytes count. */
+        if (declared < AVTP_VSS_FIXED_HEADER_LEN + 2)
+            return 0;
+        return vss_read_clamped_length(pdu, path_ptr) + 2;
+    }
+    return 0;
+}
+
+/* True when there are at least `size` bytes available starting at `ptr`
+ * within the declared frame.  Used to guard fixed‑size scalar reads in
+ * GetVssData when the data pointer sits at or past the frame end. */
+static int vss_readable(const Avtp_Vss_t* pdu, const uint8_t* ptr,
+                         uint16_t declared, uint16_t size)
+{
+    return (uint32_t)(ptr - (const uint8_t*)pdu) + size <= declared;
 }
 
 void Avtp_Vss_Init(Avtp_Vss_t* vss_pdu) {
@@ -155,12 +192,17 @@ uint64_t Avtp_Vss_GetMsgTimestamp(const Avtp_Vss_t* const pdu) {
 void Avtp_Vss_GetVssPath(const Avtp_Vss_t* const pdu, VssPath_t* val) {
 
     const uint8_t* vss_path_ptr = (const uint8_t* const) pdu + AVTP_VSS_FIXED_HEADER_LEN;
+    uint16_t declared = (uint16_t)Avtp_Vss_GetAcfMsgLength(pdu) * AVTP_QUADLET_SIZE;
 
     // Check the used VSS addressing mode
     Vss_AddrMode_t addr_mode = Avtp_Vss_GetAddrMode(pdu);
 
     if (addr_mode == VSS_STATIC_ID_MODE) {
-        val->vss_static_id_path = Avtp_BeToCpu32(*(const uint32_t*)vss_path_ptr);
+        /* Fixed 4‑byte path: only read it when the frame is large enough. */
+        if (vss_readable(pdu, vss_path_ptr, declared, 4))
+            val->vss_static_id_path = Avtp_BeToCpu32(*(const uint32_t*)vss_path_ptr);
+        else
+            val->vss_static_id_path = 0;
     } else if (addr_mode == VSS_INTEROP_MODE) {
         val->vss_interop_path.path_length =
             vss_read_clamped_length(pdu, vss_path_ptr);
@@ -248,9 +290,13 @@ void Avtp_Vss_DeserializeStringArray(const VssDataStringArray_t* const vss_data_
 
 void Avtp_Vss_GetVssData(const Avtp_Vss_t* const pdu, VssData_t* val) {
 
-    // Get a pointer to the start of the VSS data
+    /* Declared PDU size in bytes (0 → unframed, skip all bounds checks). */
+    uint16_t declared = (uint16_t)Avtp_Vss_GetAcfMsgLength(pdu) * AVTP_QUADLET_SIZE;
+
+    /* Compute the data pointer using the clamped getter‑side path length
+     * so that the pointer itself never leaves the declared frame. */
     const uint8_t* vss_data_ptr = (const uint8_t* const) pdu + AVTP_VSS_FIXED_HEADER_LEN +
-                                Avtp_Vss_CalcVssPathLength(pdu);
+                                vss_get_clamped_path_length(pdu);
     Vss_Datatype_t datatype = Avtp_Vss_GetDatatype(pdu);
 
     uint32_t temp_float;
@@ -259,49 +305,62 @@ void Avtp_Vss_GetVssData(const Avtp_Vss_t* const pdu, VssData_t* val) {
     // Check VSS Datatype
     switch (datatype) {
         case VSS_UINT8:
-            val->data_uint8 = *vss_data_ptr;
+            if (vss_readable(pdu, vss_data_ptr, declared, 1))
+                val->data_uint8 = *vss_data_ptr;
             break;
 
         case VSS_INT8:
-            val->data_int8 = *(const int8_t*) vss_data_ptr;
+            if (vss_readable(pdu, vss_data_ptr, declared, 1))
+                val->data_int8 = *(const int8_t*) vss_data_ptr;
             break;
 
         case VSS_UINT16:
-            val->data_uint16 = Avtp_BeToCpu16(*(const uint16_t*) vss_data_ptr);
+            if (vss_readable(pdu, vss_data_ptr, declared, 2))
+                val->data_uint16 = Avtp_BeToCpu16(*(const uint16_t*) vss_data_ptr);
             break;
 
         case VSS_INT16:
-            val->data_int16 =  (int16_t) Avtp_BeToCpu16(*(const uint16_t*) vss_data_ptr);
+            if (vss_readable(pdu, vss_data_ptr, declared, 2))
+                val->data_int16 =  (int16_t) Avtp_BeToCpu16(*(const uint16_t*) vss_data_ptr);
             break;
 
         case VSS_UINT32:
-            val->data_uint32 = Avtp_BeToCpu32(*(const uint32_t*) vss_data_ptr);
+            if (vss_readable(pdu, vss_data_ptr, declared, 4))
+                val->data_uint32 = Avtp_BeToCpu32(*(const uint32_t*) vss_data_ptr);
             break;
 
         case VSS_INT32:
-            val->data_int32 = (int32_t) Avtp_BeToCpu32(*(const uint32_t*) vss_data_ptr);
+            if (vss_readable(pdu, vss_data_ptr, declared, 4))
+                val->data_int32 = (int32_t) Avtp_BeToCpu32(*(const uint32_t*) vss_data_ptr);
             break;
 
         case VSS_UINT64:
-            val->data_uint64 = Avtp_BeToCpu64(*(const uint64_t*) vss_data_ptr);
+            if (vss_readable(pdu, vss_data_ptr, declared, 8))
+                val->data_uint64 = Avtp_BeToCpu64(*(const uint64_t*) vss_data_ptr);
             break;
 
         case VSS_INT64:
-            val->data_int64 = (int64_t) Avtp_BeToCpu64(*(const uint64_t*) vss_data_ptr);
+            if (vss_readable(pdu, vss_data_ptr, declared, 8))
+                val->data_int64 = (int64_t) Avtp_BeToCpu64(*(const uint64_t*) vss_data_ptr);
             break;
 
         case VSS_BOOL:
-            val->data_bool = *vss_data_ptr;
+            if (vss_readable(pdu, vss_data_ptr, declared, 1))
+                val->data_bool = *vss_data_ptr;
             break;
 
         case VSS_FLOAT:
-            temp_float =  Avtp_BeToCpu32(*(const uint32_t*) vss_data_ptr);
-            memcpy(&(val->data_float), &temp_float, sizeof(float));
+            if (vss_readable(pdu, vss_data_ptr, declared, 4)) {
+                temp_float =  Avtp_BeToCpu32(*(const uint32_t*) vss_data_ptr);
+                memcpy(&(val->data_float), &temp_float, sizeof(float));
+            }
             break;
 
         case VSS_DOUBLE:
-            temp_double = Avtp_BeToCpu64(*(const uint64_t*) vss_data_ptr);
-            memcpy(&(val->data_double), &temp_double, sizeof(double));
+            if (vss_readable(pdu, vss_data_ptr, declared, 8)) {
+                temp_double = Avtp_BeToCpu64(*(const uint64_t*) vss_data_ptr);
+                memcpy(&(val->data_double), &temp_double, sizeof(double));
+            }
             break;
 
         case VSS_STRING:

--- a/src/avtp/acf/custom/Vss.c
+++ b/src/avtp/acf/custom/Vss.c
@@ -94,7 +94,7 @@ static uint16_t vss_read_clamped_length(const Avtp_Vss_t* pdu,
  * AVTP_VSS_FIXED_HEADER_LEN + path_length ≤ declared PDU size.
  * Setters use CalcVssPathLength (raw) instead; this helper is for the
  * read path only so that the data‑pointer computation never leaves the
- * frame.  Unframed PDUs (msg_length == 0) keep the legacy raw value. */
+ * frame.  */
 static uint16_t vss_get_clamped_path_length(const Avtp_Vss_t* pdu)
 {
     uint16_t declared = (uint16_t)Avtp_Vss_GetAcfMsgLength(pdu) * AVTP_QUADLET_SIZE;
@@ -198,21 +198,22 @@ uint64_t Avtp_Vss_GetMsgTimestamp(const Avtp_Vss_t* const pdu) {
 void Avtp_Vss_GetVssPath(const Avtp_Vss_t* const pdu, VssPath_t* val) {
 
     const uint8_t* vss_path_ptr = (const uint8_t* const) pdu + AVTP_VSS_FIXED_HEADER_LEN;
-
-    // Check the used VSS addressing mode
     Vss_AddrMode_t addr_mode = Avtp_Vss_GetAddrMode(pdu);
+    uint16_t clamped_len = vss_get_clamped_path_length(pdu);
 
     if (addr_mode == VSS_STATIC_ID_MODE) {
         /* Fixed 4‑byte path: only read it when the frame is large enough. */
-        if (vss_has_bytes(pdu, vss_path_ptr, 4))
+        if (clamped_len >= 4)
             val->vss_static_id_path = Avtp_BeToCpu32(*(const uint32_t*)vss_path_ptr);
         else
             val->vss_static_id_path = 0;
     } else if (addr_mode == VSS_INTEROP_MODE) {
-        val->vss_interop_path.path_length =
-            vss_read_clamped_length(pdu, vss_path_ptr);
-        memcpy(val->vss_interop_path.path, vss_path_ptr+2,
-               val->vss_interop_path.path_length);
+        if (clamped_len >= 2) {
+            val->vss_interop_path.path_length = (uint16_t)(clamped_len - 2);
+            memcpy(val->vss_interop_path.path, vss_path_ptr + 2, clamped_len - 2);
+        } else {
+            val->vss_interop_path.path_length = 0;
+        }
     }
 }
 

--- a/src/avtp/acf/custom/Vss.c
+++ b/src/avtp/acf/custom/Vss.c
@@ -57,6 +57,32 @@ static const Avtp_FieldDescriptor_t Avtp_VssFieldDesc[AVTP_VSS_FIELD_MAX] =
     [AVTP_VSS_FIELD_MSG_TIMESTAMP]      = { .quadlet = 1, .offset =  0, .bits = 64 }
 };
 
+/* Read a 16‑bit big‑endian length prefix at *ptr and clamp it so that
+ * ptr + 2 + length does not exceed the declared PDU size (msg_length in
+ * quadlets × 4).  When msg_length is 0 (PDU not framed yet) the wire
+ * length is returned unchanged.
+ *
+ * The arithmetic is done in uint32_t to prevent overflow when the wire
+ * value approaches UINT16_MAX. */
+static uint16_t vss_read_clamped_length(const Avtp_Vss_t* pdu,
+                                         const uint8_t* ptr)
+{
+    uint16_t declared = (uint16_t)Avtp_Vss_GetAcfMsgLength(pdu) * AVTP_QUADLET_SIZE;
+    uint16_t wire_len = Avtp_BeToCpu16(*(const uint16_t*)ptr);
+
+    if (declared == 0)
+        return wire_len;
+
+    uint16_t offset = (uint16_t)(ptr - (const uint8_t*)pdu);
+
+    if ((uint32_t)offset + 2 + wire_len > declared) {
+        if (offset + 2 < declared)
+            return declared - offset - 2;
+        return 0;
+    }
+    return wire_len;
+}
+
 void Avtp_Vss_Init(Avtp_Vss_t* vss_pdu) {
 
     if(vss_pdu != NULL) {
@@ -136,8 +162,10 @@ void Avtp_Vss_GetVssPath(const Avtp_Vss_t* const pdu, VssPath_t* val) {
     if (addr_mode == VSS_STATIC_ID_MODE) {
         val->vss_static_id_path = Avtp_BeToCpu32(*(const uint32_t*)vss_path_ptr);
     } else if (addr_mode == VSS_INTEROP_MODE) {
-        val->vss_interop_path.path_length = Avtp_BeToCpu16(*(const uint16_t*)vss_path_ptr);
-        memcpy(val->vss_interop_path.path, vss_path_ptr+2, val->vss_interop_path.path_length);
+        val->vss_interop_path.path_length =
+            vss_read_clamped_length(pdu, vss_path_ptr);
+        memcpy(val->vss_interop_path.path, vss_path_ptr+2,
+               val->vss_interop_path.path_length);
     }
 }
 
@@ -277,28 +305,28 @@ void Avtp_Vss_GetVssData(const Avtp_Vss_t* const pdu, VssData_t* val) {
             break;
 
         case VSS_STRING:
-            val->data_string->data_length = Avtp_BeToCpu16(*(const uint16_t*)vss_data_ptr);
+            val->data_string->data_length = vss_read_clamped_length(pdu, vss_data_ptr);
             if (val->data_string->data != NULL) {
                 memcpy(val->data_string->data, vss_data_ptr+2, val->data_string->data_length);
             }
             break;
 
         case VSS_UINT8_ARRAY:
-            val->data_uint8_array->data_length = Avtp_BeToCpu16(*(const uint16_t*)vss_data_ptr);
+            val->data_uint8_array->data_length = vss_read_clamped_length(pdu, vss_data_ptr);
             if (val->data_uint8_array->data != NULL) {
                 memcpy(val->data_uint8_array->data, vss_data_ptr+2, val->data_uint8_array->data_length);
             }
             break;
 
         case VSS_INT8_ARRAY:
-            val->data_int8_array->data_length = Avtp_BeToCpu16(*(const uint16_t*)vss_data_ptr);
+            val->data_int8_array->data_length = vss_read_clamped_length(pdu, vss_data_ptr);
             if (val->data_int8_array->data != NULL) {
                 memcpy(val->data_int8_array->data, vss_data_ptr+2, val->data_int8_array->data_length);
             }
             break;
 
         case VSS_UINT16_ARRAY:
-            val->data_uint16_array->data_length = Avtp_BeToCpu16(*(const uint16_t*)vss_data_ptr);
+            val->data_uint16_array->data_length = vss_read_clamped_length(pdu, vss_data_ptr);
             vss_data_ptr += 2;
             if (val->data_uint16_array->data != NULL) {
                 for (uint16_t i = 0; i < (uint16_t)(val->data_uint16_array->data_length/2); i++) {
@@ -308,7 +336,7 @@ void Avtp_Vss_GetVssData(const Avtp_Vss_t* const pdu, VssData_t* val) {
             break;
 
         case VSS_INT16_ARRAY:
-            val->data_int16_array->data_length = Avtp_BeToCpu16(*(const uint16_t*)vss_data_ptr);
+            val->data_int16_array->data_length = vss_read_clamped_length(pdu, vss_data_ptr);
             vss_data_ptr += 2;
             if (val->data_int16_array->data != NULL) {
                 for (uint16_t i = 0; i < (uint16_t)(val->data_int16_array->data_length/2); i++) {
@@ -318,7 +346,7 @@ void Avtp_Vss_GetVssData(const Avtp_Vss_t* const pdu, VssData_t* val) {
             break;
 
         case VSS_UINT32_ARRAY:
-            val->data_uint32_array->data_length = Avtp_BeToCpu16(*(const uint16_t*)vss_data_ptr);
+            val->data_uint32_array->data_length = vss_read_clamped_length(pdu, vss_data_ptr);
             vss_data_ptr += 2;
             if (val->data_uint32_array->data != NULL) {
                 for (uint16_t i = 0; i < (uint16_t)(val->data_uint32_array->data_length/4); i++) {
@@ -328,7 +356,7 @@ void Avtp_Vss_GetVssData(const Avtp_Vss_t* const pdu, VssData_t* val) {
             break;
 
         case VSS_INT32_ARRAY:
-            val->data_int32_array->data_length = Avtp_BeToCpu16(*(const uint16_t*)vss_data_ptr);
+            val->data_int32_array->data_length = vss_read_clamped_length(pdu, vss_data_ptr);
             vss_data_ptr += 2;
             if (val->data_int32_array->data != NULL) {
                 for (uint16_t i = 0; i < (uint16_t)(val->data_int32_array->data_length/4); i++) {
@@ -338,9 +366,9 @@ void Avtp_Vss_GetVssData(const Avtp_Vss_t* const pdu, VssData_t* val) {
             break;
 
         case VSS_UINT64_ARRAY:
-            val->data_uint64_array->data_length = Avtp_BeToCpu16(*(const uint16_t*)vss_data_ptr);
+            val->data_uint64_array->data_length = vss_read_clamped_length(pdu, vss_data_ptr);
             vss_data_ptr += 2;
-            if (val->data_int64_array->data != NULL) {
+            if (val->data_uint64_array->data != NULL) {
                 for (uint16_t i = 0; i < (uint16_t)(val->data_uint64_array->data_length/8); i++) {
                     *(val->data_uint64_array->data + i) = Avtp_BeToCpu64(*((const uint64_t*)vss_data_ptr+i));
                 }
@@ -348,7 +376,7 @@ void Avtp_Vss_GetVssData(const Avtp_Vss_t* const pdu, VssData_t* val) {
             break;
 
         case VSS_INT64_ARRAY:
-            val->data_int64_array->data_length = Avtp_BeToCpu16(*(const uint16_t*)vss_data_ptr);
+            val->data_int64_array->data_length = vss_read_clamped_length(pdu, vss_data_ptr);
             vss_data_ptr += 2;
             if (val->data_int64_array->data != NULL) {
                 for (int i = 0; i < val->data_int64_array->data_length/8; i++) {
@@ -358,14 +386,14 @@ void Avtp_Vss_GetVssData(const Avtp_Vss_t* const pdu, VssData_t* val) {
             break;
 
         case VSS_BOOL_ARRAY:
-            val->data_bool_array->data_length = Avtp_BeToCpu16(*(const uint16_t*)vss_data_ptr);
+            val->data_bool_array->data_length = vss_read_clamped_length(pdu, vss_data_ptr);
             if (val->data_bool_array->data != NULL) {
                 memcpy(val->data_bool_array->data, vss_data_ptr+2, val->data_bool_array->data_length);
             }
             break;
 
         case VSS_FLOAT_ARRAY:
-            val->data_float_array->data_length = Avtp_BeToCpu16(*(const uint16_t*)vss_data_ptr);
+            val->data_float_array->data_length = vss_read_clamped_length(pdu, vss_data_ptr);
             vss_data_ptr += 2;
             if (val->data_float_array->data != NULL) {
                 for (uint16_t i = 0; i < (uint16_t)(val->data_float_array->data_length/4); i++) {
@@ -376,7 +404,7 @@ void Avtp_Vss_GetVssData(const Avtp_Vss_t* const pdu, VssData_t* val) {
             break;
 
         case VSS_DOUBLE_ARRAY:
-            val->data_double_array->data_length = Avtp_BeToCpu16(*(const uint16_t*)vss_data_ptr);
+            val->data_double_array->data_length = vss_read_clamped_length(pdu, vss_data_ptr);
             vss_data_ptr += 2;
             if (val->data_double_array->data != NULL) {
                 for (uint16_t i = 0; i < (uint16_t)(val->data_double_array->data_length/8); i++) {
@@ -387,7 +415,7 @@ void Avtp_Vss_GetVssData(const Avtp_Vss_t* const pdu, VssData_t* val) {
             break;
 
         case VSS_STRING_ARRAY:
-            val->data_string_array->data_length = Avtp_BeToCpu16(*(const uint16_t*)vss_data_ptr);
+            val->data_string_array->data_length = vss_read_clamped_length(pdu, vss_data_ptr);
             vss_data_ptr += 2;
             if (val->data_string_array->data != NULL) {
                 memcpy(val->data_string_array->data, vss_data_ptr, val->data_string_array->data_length);

--- a/src/avtp/acf/custom/Vss.c
+++ b/src/avtp/acf/custom/Vss.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024, COVESA
+ * Copyright (c) 2024-2026 COVESA
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:
@@ -28,6 +28,7 @@
  */
 
 #include <errno.h>
+#include <stdbool.h>
 #include <string.h>
 
 #include "avtp/acf/AcfCommon.h"
@@ -111,13 +112,14 @@ static uint16_t vss_get_clamped_path_length(const Avtp_Vss_t* pdu)
     return 0;
 }
 
-/* True when there are at least `size` bytes available starting at `ptr`
+/* True when there are at least `num_bytes` bytes available starting at `ptr`
  * within the declared frame.  Used to guard fixed‑size scalar reads in
  * GetVssData when the data pointer sits at or past the frame end. */
-static int vss_readable(const Avtp_Vss_t* pdu, const uint8_t* ptr,
-                         uint16_t declared, uint16_t size)
+static bool vss_has_bytes(const Avtp_Vss_t* pdu, const uint8_t* ptr,
+                          uint16_t num_bytes)
 {
-    return (uint32_t)(ptr - (const uint8_t*)pdu) + size <= declared;
+    uint16_t declared = (uint16_t)Avtp_Vss_GetAcfMsgLength(pdu) * AVTP_QUADLET_SIZE;
+    return (uint32_t)(ptr - (const uint8_t*)pdu) + num_bytes <= declared;
 }
 
 void Avtp_Vss_Init(Avtp_Vss_t* vss_pdu) {
@@ -192,14 +194,13 @@ uint64_t Avtp_Vss_GetMsgTimestamp(const Avtp_Vss_t* const pdu) {
 void Avtp_Vss_GetVssPath(const Avtp_Vss_t* const pdu, VssPath_t* val) {
 
     const uint8_t* vss_path_ptr = (const uint8_t* const) pdu + AVTP_VSS_FIXED_HEADER_LEN;
-    uint16_t declared = (uint16_t)Avtp_Vss_GetAcfMsgLength(pdu) * AVTP_QUADLET_SIZE;
 
     // Check the used VSS addressing mode
     Vss_AddrMode_t addr_mode = Avtp_Vss_GetAddrMode(pdu);
 
     if (addr_mode == VSS_STATIC_ID_MODE) {
         /* Fixed 4‑byte path: only read it when the frame is large enough. */
-        if (vss_readable(pdu, vss_path_ptr, declared, 4))
+        if (vss_has_bytes(pdu, vss_path_ptr, 4))
             val->vss_static_id_path = Avtp_BeToCpu32(*(const uint32_t*)vss_path_ptr);
         else
             val->vss_static_id_path = 0;
@@ -290,9 +291,6 @@ void Avtp_Vss_DeserializeStringArray(const VssDataStringArray_t* const vss_data_
 
 void Avtp_Vss_GetVssData(const Avtp_Vss_t* const pdu, VssData_t* val) {
 
-    /* Declared PDU size in bytes (0 → unframed, skip all bounds checks). */
-    uint16_t declared = (uint16_t)Avtp_Vss_GetAcfMsgLength(pdu) * AVTP_QUADLET_SIZE;
-
     /* Compute the data pointer using the clamped getter‑side path length
      * so that the pointer itself never leaves the declared frame. */
     const uint8_t* vss_data_ptr = (const uint8_t* const) pdu + AVTP_VSS_FIXED_HEADER_LEN +
@@ -305,59 +303,59 @@ void Avtp_Vss_GetVssData(const Avtp_Vss_t* const pdu, VssData_t* val) {
     // Check VSS Datatype
     switch (datatype) {
         case VSS_UINT8:
-            if (vss_readable(pdu, vss_data_ptr, declared, 1))
+            if (vss_has_bytes(pdu, vss_data_ptr, 1))
                 val->data_uint8 = *vss_data_ptr;
             break;
 
         case VSS_INT8:
-            if (vss_readable(pdu, vss_data_ptr, declared, 1))
+            if (vss_has_bytes(pdu, vss_data_ptr, 1))
                 val->data_int8 = *(const int8_t*) vss_data_ptr;
             break;
 
         case VSS_UINT16:
-            if (vss_readable(pdu, vss_data_ptr, declared, 2))
+            if (vss_has_bytes(pdu, vss_data_ptr, 2))
                 val->data_uint16 = Avtp_BeToCpu16(*(const uint16_t*) vss_data_ptr);
             break;
 
         case VSS_INT16:
-            if (vss_readable(pdu, vss_data_ptr, declared, 2))
+            if (vss_has_bytes(pdu, vss_data_ptr, 2))
                 val->data_int16 =  (int16_t) Avtp_BeToCpu16(*(const uint16_t*) vss_data_ptr);
             break;
 
         case VSS_UINT32:
-            if (vss_readable(pdu, vss_data_ptr, declared, 4))
+            if (vss_has_bytes(pdu, vss_data_ptr, 4))
                 val->data_uint32 = Avtp_BeToCpu32(*(const uint32_t*) vss_data_ptr);
             break;
 
         case VSS_INT32:
-            if (vss_readable(pdu, vss_data_ptr, declared, 4))
+            if (vss_has_bytes(pdu, vss_data_ptr, 4))
                 val->data_int32 = (int32_t) Avtp_BeToCpu32(*(const uint32_t*) vss_data_ptr);
             break;
 
         case VSS_UINT64:
-            if (vss_readable(pdu, vss_data_ptr, declared, 8))
+            if (vss_has_bytes(pdu, vss_data_ptr, 8))
                 val->data_uint64 = Avtp_BeToCpu64(*(const uint64_t*) vss_data_ptr);
             break;
 
         case VSS_INT64:
-            if (vss_readable(pdu, vss_data_ptr, declared, 8))
+            if (vss_has_bytes(pdu, vss_data_ptr, 8))
                 val->data_int64 = (int64_t) Avtp_BeToCpu64(*(const uint64_t*) vss_data_ptr);
             break;
 
         case VSS_BOOL:
-            if (vss_readable(pdu, vss_data_ptr, declared, 1))
+            if (vss_has_bytes(pdu, vss_data_ptr, 1))
                 val->data_bool = *vss_data_ptr;
             break;
 
         case VSS_FLOAT:
-            if (vss_readable(pdu, vss_data_ptr, declared, 4)) {
+            if (vss_has_bytes(pdu, vss_data_ptr, 4)) {
                 temp_float =  Avtp_BeToCpu32(*(const uint32_t*) vss_data_ptr);
                 memcpy(&(val->data_float), &temp_float, sizeof(float));
             }
             break;
 
         case VSS_DOUBLE:
-            if (vss_readable(pdu, vss_data_ptr, declared, 8)) {
+            if (vss_has_bytes(pdu, vss_data_ptr, 8)) {
                 temp_double = Avtp_BeToCpu64(*(const uint64_t*) vss_data_ptr);
                 memcpy(&(val->data_double), &temp_double, sizeof(double));
             }

--- a/src/avtp/acf/custom/Vss.c
+++ b/src/avtp/acf/custom/Vss.c
@@ -80,9 +80,13 @@ static uint16_t vss_read_clamped_length(const Avtp_Vss_t* pdu,
     uint16_t wire_len = Avtp_BeToCpu16(*(const uint16_t*)ptr);
 
     if (offset + 2 + wire_len > declared) {
-        /* Prefix fits but the payload it describes is too long → clamp. */
+        /* Prefix fits but the payload it describes is too long → clamp. 
+         * Can never be negative, returns the maximum nuber of bytes that can 
+         * be read
+         */
         return declared - (uint16_t)offset - 2;
     }
+    /* The normal case: All bytes declared fit in frame and can be read. */
     return wire_len;
 }
 

--- a/unit/test-vss.c
+++ b/unit/test-vss.c
@@ -108,6 +108,8 @@ static void vss_interop_path(void **state) {
 
     uint8_t pdu[MAX_PDU_SIZE];
     Avtp_Vss_t* vss_pdu = (Avtp_Vss_t*) pdu;
+    Avtp_Vss_Init(vss_pdu);
+    Avtp_Vss_SetAcfMsgLength(vss_pdu, 10);
 
     char path[] = "Vehicle.Speed";
     uint32_t path_length = strlen(path);
@@ -1070,6 +1072,400 @@ static void vss_data_string_array_malformed(void **state) {
     assert_int_equal(s3.data_length, 0);
 }
 
+/* ──────────────────────────────────────────────────────────────────────────
+ * OOB / Bounds Truncation Tests
+ *
+ * Each test constructs a PDU whose ACF msg_length is deliberately smaller
+ * than the wire data_length field (0xFFFF).  The parser must
+ * clamp the field to the bytes actually available within the declared
+ * message length.  Without clamping it would attempt to memcpy or iterate
+ * 65535 bytes from a 24‑byte buffer.
+ *
+ * All data‑type tests use STATIC_ID mode (4‑byte path) so the data payload
+ * always starts at PDU offset 16.  Declared PDU size = msg_quadlets × 4.
+ * ────────────────────────────────────────────────────────────────────────── */
+
+/* Helper: build a VSS PDU with STATIC_ID path, given msg_quadlets, datatype,
+ * and plant 0xFFFF as the on‑wire data_length followed by fill_data.
+ * Available data bytes = msg_quadlets × 4 − 16 (header+path) − 2 (prefix). */
+static Avtp_Vss_t* vss_build_data_oob_pdu(uint8_t *buf, size_t buf_size,
+                                            uint8_t msg_quadlets,
+                                            Vss_Datatype_t datatype,
+                                            const uint8_t *fill_data,
+                                            uint16_t fill_len)
+{
+    memset(buf, 0, buf_size);
+    Avtp_Vss_t *pdu = (Avtp_Vss_t *)buf;
+    Avtp_Vss_Init(pdu);
+    Avtp_Vss_SetAddrMode(pdu, VSS_STATIC_ID_MODE);
+    Avtp_Vss_SetAcfMsgLength(pdu, msg_quadlets);
+    Avtp_Vss_SetDatatype(pdu, datatype);
+
+    /* Inflated wire data_length at offset 16 (payload start) */
+    buf[16] = 0xFF;
+    buf[17] = 0xFF;
+
+    uint16_t max_data = (uint16_t)msg_quadlets * 4 - 16 - 2;
+    uint16_t copy_len = fill_len < max_data ? fill_len : max_data;
+    if (copy_len > 0 && fill_data != NULL)
+        memcpy(buf + 18, fill_data, copy_len);
+
+    return pdu;
+}
+
+/* ── Avtp_Vss_GetVssPath  –  INTEROP mode ────────────────────────────── */
+
+static void vss_path_interop_oob(void **state)
+{
+    uint8_t buf[32];
+    Avtp_Vss_t *pdu = (Avtp_Vss_t *)buf;
+    memset(buf, 0, sizeof(buf));
+
+    /* 5 quadlets = 20 bytes. Path at offset 12, 2‑byte prefix →
+     * 6 bytes available for path data after the length prefix. */
+    Avtp_Vss_Init(pdu);
+    Avtp_Vss_SetAddrMode(pdu, VSS_INTEROP_MODE);
+    Avtp_Vss_SetAcfMsgLength(pdu, 5);
+
+    buf[12] = 0xFF; buf[13] = 0xFF;    /* wire path_length = 0xFFFF */
+    buf[14] = 'A';  buf[15] = 'B';     /* only 2 bytes of real path data
+                                         * (bytes 16‑17 are zero from memset) */
+
+    char path_buf[16];
+    memset(path_buf, 0x5A, sizeof(path_buf));
+    VssPath_t get_path;
+    get_path.vss_interop_path.path = path_buf;
+    Avtp_Vss_GetVssPath(pdu, &get_path);
+
+    /* path_length must be clamped to 6 (20 − 12 − 2 = 6) */
+    assert_int_equal(get_path.vss_interop_path.path_length, 6);
+    assert_memory_equal(path_buf, "AB\0\0\0\0", 6);
+
+    /* CalcVssPathLength returns the raw wire value (0xFFFF + 2 = 1 in
+     * uint16_t arithmetic).  It is intentionally not clamped — setters
+     * (SetVssPath, SetVssData, Pad) use it and need the real on‑wire
+     * length.  Only the getters apply vss_read_clamped_length. */
+    assert_int_equal(Avtp_Vss_CalcVssPathLength(pdu), 1);
+}
+
+/* ── Avtp_Vss_GetVssData  –  memcpy group (wire length→memcpy) ──────── */
+
+static void vss_data_string_oob(void **state)
+{
+    uint8_t buf[64];
+    uint8_t fill[] = {0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08};
+    Avtp_Vss_t *pdu = vss_build_data_oob_pdu(buf, sizeof(buf), 6,
+                                               VSS_STRING, fill, sizeof(fill));
+
+    VssDataString_t str = { .data = NULL };
+    VssData_t vd;
+    memset(&vd, 0, sizeof(vd));
+    vd.data_string = &str;
+    Avtp_Vss_GetVssData(pdu, &vd);
+    assert_int_equal(str.data_length, 6);
+
+    char out[16];
+    memset(out, 0x5A, sizeof(out));
+    str.data = out;
+    Avtp_Vss_GetVssData(pdu, &vd);
+    assert_memory_equal(out, fill, 6);
+    /* byte 6 untouched → no past‑buffer write */
+    assert_int_equal((uint8_t)out[6], 0x5A);
+}
+
+static void vss_data_uint8_array_oob(void **state)
+{
+    uint8_t buf[64];
+    uint8_t fill[] = {0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08};
+    Avtp_Vss_t *pdu = vss_build_data_oob_pdu(buf, sizeof(buf), 6,
+                                               VSS_UINT8_ARRAY, fill, sizeof(fill));
+
+    VssDataUint8Array_t arr = { .data = NULL };
+    VssData_t vd;
+    memset(&vd, 0, sizeof(vd));
+    vd.data_uint8_array = &arr;
+    Avtp_Vss_GetVssData(pdu, &vd);
+    assert_int_equal(arr.data_length, 6);
+
+    uint8_t out[16];
+    memset(out, 0x5A, sizeof(out));
+    arr.data = out;
+    Avtp_Vss_GetVssData(pdu, &vd);
+    assert_memory_equal(out, fill, 6);
+    assert_int_equal(out[6], 0x5A);
+}
+
+static void vss_data_int8_array_oob(void **state)
+{
+    uint8_t buf[64];
+    uint8_t fill[] = {0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08};
+    Avtp_Vss_t *pdu = vss_build_data_oob_pdu(buf, sizeof(buf), 6,
+                                               VSS_INT8_ARRAY, fill, sizeof(fill));
+
+    VssDataInt8Array_t arr = { .data = NULL };
+    VssData_t vd;
+    memset(&vd, 0, sizeof(vd));
+    vd.data_int8_array = &arr;
+    Avtp_Vss_GetVssData(pdu, &vd);
+    assert_int_equal(arr.data_length, 6);
+
+    int8_t out[16];
+    memset(out, 0x5A, sizeof(out));
+    arr.data = out;
+    Avtp_Vss_GetVssData(pdu, &vd);
+    assert_memory_equal(out, fill, 6);
+    assert_int_equal((uint8_t)out[6], 0x5A);
+}
+
+static void vss_data_bool_array_oob(void **state)
+{
+    uint8_t buf[64];
+    uint8_t fill[] = {0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08};
+    Avtp_Vss_t *pdu = vss_build_data_oob_pdu(buf, sizeof(buf), 6,
+                                               VSS_BOOL_ARRAY, fill, sizeof(fill));
+
+    VssDataBoolArray_t arr = { .data = NULL };
+    VssData_t vd;
+    memset(&vd, 0, sizeof(vd));
+    vd.data_bool_array = &arr;
+    Avtp_Vss_GetVssData(pdu, &vd);
+    assert_int_equal(arr.data_length, 6);
+
+    uint8_t out[16];
+    memset(out, 0x5A, sizeof(out));
+    arr.data = out;
+    Avtp_Vss_GetVssData(pdu, &vd);
+    assert_memory_equal(out, fill, 6);
+    assert_int_equal(out[6], 0x5A);
+}
+
+/* STRING_ARRAY advances vss_data_ptr by 2 past the prefix, then memcpy's
+ * from the same position. Behaviour identical to the cases above. */
+static void vss_data_string_array_oob(void **state)
+{
+    uint8_t buf[64];
+    uint8_t fill[] = {0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08};
+    Avtp_Vss_t *pdu = vss_build_data_oob_pdu(buf, sizeof(buf), 6,
+                                               VSS_STRING_ARRAY, fill, sizeof(fill));
+
+    VssDataStringArray_t arr = { .data = NULL };
+    VssData_t vd;
+    memset(&vd, 0, sizeof(vd));
+    vd.data_string_array = &arr;
+    Avtp_Vss_GetVssData(pdu, &vd);
+    assert_int_equal(arr.data_length, 6);
+
+    uint8_t out[16];
+    memset(out, 0x5A, sizeof(out));
+    arr.data = out;
+    Avtp_Vss_GetVssData(pdu, &vd);
+    assert_memory_equal(out, fill, 6);
+    assert_int_equal(out[6], 0x5A);
+}
+
+/* ── Avtp_Vss_GetVssData  –  loop/iteration group (wire length→loop) ── */
+
+static void vss_data_uint16_array_oob(void **state)
+{
+    uint8_t buf[64];
+    uint8_t fill[] = {0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08};
+    Avtp_Vss_t *pdu = vss_build_data_oob_pdu(buf, sizeof(buf), 6,
+                                               VSS_UINT16_ARRAY, fill, sizeof(fill));
+
+    VssDataUint16Array_t arr = { .data = NULL };
+    VssData_t vd;
+    memset(&vd, 0, sizeof(vd));
+    vd.data_uint16_array = &arr;
+    Avtp_Vss_GetVssData(pdu, &vd);
+    assert_int_equal(arr.data_length, 6);
+
+    /* 6 bytes → 3 uint16 elements: {0x0102, 0x0304, 0x0506} */
+    uint16_t out[8];
+    memset(out, 0x5A, sizeof(out));
+    arr.data = out;
+    Avtp_Vss_GetVssData(pdu, &vd);
+    assert_int_equal(out[0], 0x0102);
+    assert_int_equal(out[1], 0x0304);
+    assert_int_equal(out[2], 0x0506);
+    assert_int_equal(out[3], 0x5A5A);
+}
+
+static void vss_data_int16_array_oob(void **state)
+{
+    uint8_t buf[64];
+    uint8_t fill[] = {0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08};
+    Avtp_Vss_t *pdu = vss_build_data_oob_pdu(buf, sizeof(buf), 6,
+                                               VSS_INT16_ARRAY, fill, sizeof(fill));
+
+    VssDataInt16Array_t arr = { .data = NULL };
+    VssData_t vd;
+    memset(&vd, 0, sizeof(vd));
+    vd.data_int16_array = &arr;
+    Avtp_Vss_GetVssData(pdu, &vd);
+    assert_int_equal(arr.data_length, 6);
+
+    /* 6 bytes → 3 int16 elements: {0x0102, 0x0304, 0x0506} */
+    int16_t out[8];
+    memset(out, 0x5A, sizeof(out));
+    arr.data = out;
+    Avtp_Vss_GetVssData(pdu, &vd);
+    assert_int_equal(out[0], 0x0102);
+    assert_int_equal(out[1], 0x0304);
+    assert_int_equal(out[2], 0x0506);
+    assert_int_equal(out[3], 0x5A5A);
+}
+
+static void vss_data_uint32_array_oob(void **state)
+{
+    uint8_t buf[64];
+    uint8_t fill[] = {0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08};
+    Avtp_Vss_t *pdu = vss_build_data_oob_pdu(buf, sizeof(buf), 6,
+                                               VSS_UINT32_ARRAY, fill, sizeof(fill));
+
+    VssDataUint32Array_t arr = { .data = NULL };
+    VssData_t vd;
+    memset(&vd, 0, sizeof(vd));
+    vd.data_uint32_array = &arr;
+    Avtp_Vss_GetVssData(pdu, &vd);
+    assert_int_equal(arr.data_length, 6);
+
+    /* 6 bytes → 1 uint32 element: {0x01020304} */
+    uint32_t out[4];
+    memset(out, 0x5A, sizeof(out));
+    arr.data = out;
+    Avtp_Vss_GetVssData(pdu, &vd);
+    assert_int_equal(out[0], 0x01020304);
+    assert_int_equal(out[1], 0x5A5A5A5A);
+}
+
+static void vss_data_int32_array_oob(void **state)
+{
+    uint8_t buf[64];
+    uint8_t fill[] = {0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08};
+    Avtp_Vss_t *pdu = vss_build_data_oob_pdu(buf, sizeof(buf), 6,
+                                               VSS_INT32_ARRAY, fill, sizeof(fill));
+
+    VssDataInt32Array_t arr = { .data = NULL };
+    VssData_t vd;
+    memset(&vd, 0, sizeof(vd));
+    vd.data_int32_array = &arr;
+    Avtp_Vss_GetVssData(pdu, &vd);
+    assert_int_equal(arr.data_length, 6);
+
+    /* 6 bytes → 1 int32 element: {0x01020304} */
+    int32_t out[4];
+    memset(out, 0x5A, sizeof(out));
+    arr.data = out;
+    Avtp_Vss_GetVssData(pdu, &vd);
+    assert_int_equal(out[0], 0x01020304);
+    assert_int_equal(out[1], 0x5A5A5A5A);
+}
+
+/* msg_quadlets=7 (28 bytes) → 10 bytes available for data payload,
+ * enough for one 8‑byte element. */
+static void vss_data_uint64_array_oob(void **state)
+{
+    uint8_t buf[64];
+    uint8_t fill[] = {0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08};
+    Avtp_Vss_t *pdu = vss_build_data_oob_pdu(buf, sizeof(buf), 7,
+                                               VSS_UINT64_ARRAY, fill, sizeof(fill));
+
+    VssDataUint64Array_t arr = { .data = NULL };
+    VssData_t vd;
+    memset(&vd, 0, sizeof(vd));
+    vd.data_uint64_array = &arr;
+    Avtp_Vss_GetVssData(pdu, &vd);
+    assert_int_equal(arr.data_length, 10);
+
+    /* 10 bytes → 1 uint64 element: {0x0102030405060708} */
+    uint64_t out[4];
+    memset(out, 0x5A, sizeof(out));
+    arr.data = out;
+    Avtp_Vss_GetVssData(pdu, &vd);
+    assert_int_equal(out[0], 0x0102030405060708ull);
+    assert_int_equal(out[1], 0x5A5A5A5A5A5A5A5Aull);
+}
+
+static void vss_data_int64_array_oob(void **state)
+{
+    uint8_t buf[64];
+    uint8_t fill[] = {0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08};
+    Avtp_Vss_t *pdu = vss_build_data_oob_pdu(buf, sizeof(buf), 7,
+                                               VSS_INT64_ARRAY, fill, sizeof(fill));
+
+    VssDataInt64Array_t arr = { .data = NULL };
+    VssData_t vd;
+    memset(&vd, 0, sizeof(vd));
+    vd.data_int64_array = &arr;
+    Avtp_Vss_GetVssData(pdu, &vd);
+    assert_int_equal(arr.data_length, 10);
+
+    /* 10 bytes → 1 int64 element: {0x0102030405060708} */
+    int64_t out[4];
+    memset(out, 0x5A, sizeof(out));
+    arr.data = out;
+    Avtp_Vss_GetVssData(pdu, &vd);
+    assert_int_equal(out[0], 0x0102030405060708ull);
+    assert_int_equal(out[1], 0x5A5A5A5A5A5A5A5Aull);
+}
+
+static void vss_data_float_array_oob(void **state)
+{
+    uint8_t buf[64];
+    uint8_t fill[] = {0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08};
+    Avtp_Vss_t *pdu = vss_build_data_oob_pdu(buf, sizeof(buf), 6,
+                                               VSS_FLOAT_ARRAY, fill, sizeof(fill));
+
+    VssDataFloatArray_t arr = { .data = NULL };
+    VssData_t vd;
+    memset(&vd, 0, sizeof(vd));
+    vd.data_float_array = &arr;
+    Avtp_Vss_GetVssData(pdu, &vd);
+    assert_int_equal(arr.data_length, 6);
+
+    /* 6 bytes → 1 float element (4 bytes read).
+     * Wire {0x01,0x02,0x03,0x04} as BE uint32 → Avtp_BeToCpu32 →
+     * 0x01020304, stored on LE as {0x04,0x03,0x02,0x01}. */
+    float out[4];
+    memset(out, 0x5A, sizeof(out));
+    arr.data = out;
+    Avtp_Vss_GetVssData(pdu, &vd);
+    {
+        uint8_t exp[] = {0x04, 0x03, 0x02, 0x01};
+        assert_memory_equal(out, exp, 4);
+    }
+    /* Second float slot still holds the sentinel */
+    assert_memory_equal(&out[1], "\x5A\x5A\x5A\x5A", 4);
+}
+
+static void vss_data_double_array_oob(void **state)
+{
+    uint8_t buf[64];
+    uint8_t fill[] = {0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08};
+    Avtp_Vss_t *pdu = vss_build_data_oob_pdu(buf, sizeof(buf), 7,
+                                               VSS_DOUBLE_ARRAY, fill, sizeof(fill));
+
+    VssDataDoubleArray_t arr = { .data = NULL };
+    VssData_t vd;
+    memset(&vd, 0, sizeof(vd));
+    vd.data_double_array = &arr;
+    Avtp_Vss_GetVssData(pdu, &vd);
+    assert_int_equal(arr.data_length, 10);
+
+    /* 10 bytes → 1 double element (8 bytes read).
+     * Wire {0x01..0x08} as BE uint64 → Avtp_BeToCpu64 →
+     * 0x0102030405060708, stored on LE as {0x08..0x01}. */
+    double out[4];
+    memset(out, 0x5A, sizeof(out));
+    arr.data = out;
+    Avtp_Vss_GetVssData(pdu, &vd);
+    {
+        uint8_t exp[] = {0x08, 0x07, 0x06, 0x05, 0x04, 0x03, 0x02, 0x01};
+        assert_memory_equal(out, exp, 8);
+    }
+    assert_memory_equal(&out[1], "\x5A\x5A\x5A\x5A\x5A\x5A\x5A\x5A", 8);
+}
+
 int main(void)
 {
     const struct CMUnitTest tests[] = {
@@ -1102,6 +1498,20 @@ int main(void)
         cmocka_unit_test(vss_data_double_array),
         cmocka_unit_test(vss_data_string_array),
         cmocka_unit_test(vss_data_string_array_malformed),
+        cmocka_unit_test(vss_path_interop_oob),
+        cmocka_unit_test(vss_data_string_oob),
+        cmocka_unit_test(vss_data_uint8_array_oob),
+        cmocka_unit_test(vss_data_int8_array_oob),
+        cmocka_unit_test(vss_data_bool_array_oob),
+        cmocka_unit_test(vss_data_string_array_oob),
+        cmocka_unit_test(vss_data_uint16_array_oob),
+        cmocka_unit_test(vss_data_int16_array_oob),
+        cmocka_unit_test(vss_data_uint32_array_oob),
+        cmocka_unit_test(vss_data_int32_array_oob),
+        cmocka_unit_test(vss_data_uint64_array_oob),
+        cmocka_unit_test(vss_data_int64_array_oob),
+        cmocka_unit_test(vss_data_float_array_oob),
+        cmocka_unit_test(vss_data_double_array_oob),
     };
 
     return cmocka_run_group_tests(tests, NULL, NULL);

--- a/unit/test-vss.c
+++ b/unit/test-vss.c
@@ -1466,6 +1466,114 @@ static void vss_data_double_array_oob(void **state)
     assert_memory_equal(&out[1], "\x5A\x5A\x5A\x5A\x5A\x5A\x5A\x5A", 8);
 }
 
+/* Helper for the inflated-path tests: build an INTEROP-mode PDU where the
+ * on‑wire path_length (0xFFFD) claims far more path bytes than the declared
+ * msg_length allows.  CalcVssPathLength would return 0xFFFD + 2 = 0xFFFF
+ * (65535 — no uint16_t wrap), pushing the computed data pointer 65547 bytes
+ * past the PDU start — well beyond any plausible frame. */
+static Avtp_Vss_t* vss_build_inflated_path_pdu(uint8_t *buf, size_t buf_size,
+                                                uint8_t msg_quadlets,
+                                                Vss_Datatype_t datatype)
+{
+    memset(buf, 0, buf_size);
+    Avtp_Vss_t *pdu = (Avtp_Vss_t *)buf;
+    Avtp_Vss_Init(pdu);
+    Avtp_Vss_SetAddrMode(pdu, VSS_INTEROP_MODE);
+    Avtp_Vss_SetAcfMsgLength(pdu, msg_quadlets);
+    Avtp_Vss_SetDatatype(pdu, datatype);
+
+    /* Inflated path_length at offset 12 (INTEROP length prefix).
+     * 0xFFFD was chosen because 0xFFFD + 2 = 0xFFFF without wrapping. */
+    buf[12] = 0xFF;
+    buf[13] = 0xFD;
+
+    return pdu;
+}
+
+/* ── Regression tests for inflated-path → data-pointer OOB ─────────────
+ * When a crafted INTEROP
+ * path_length pushes the data pointer beyond the declared PDU, the
+ * getters must treat the data area as empty and avoid any dereference.
+
+/* VSS_STRING: the length-prefix dereference inside vss_read_clamped_length
+ * must be guarded so it is never reached when the data pointer sits at or
+ * past the frame end.  Correct behavior: data_length is 0, output untouched. */
+static void vss_data_string_inflated_path_oob(void **state)
+{
+    uint8_t buf[64];
+    Avtp_Vss_t *pdu = vss_build_inflated_path_pdu(buf, sizeof(buf), 6,
+                                                    VSS_STRING);
+
+    VssDataString_t str = { .data = NULL };
+    VssData_t vd;
+    memset(&vd, 0, sizeof(vd));
+    vd.data_string = &str;
+    Avtp_Vss_GetVssData(pdu, &vd);
+    assert_int_equal(str.data_length, 0);
+
+    char out[16];
+    memset(out, 0x5A, sizeof(out));
+    str.data = out;
+    Avtp_Vss_GetVssData(pdu, &vd);
+    assert_int_equal((uint8_t)out[0], 0x5A);
+}
+
+/* Scalar VSS_UINT8: the raw dereference of *vss_data_ptr must be guarded
+ * so that an out‑of‑frame data pointer is never read.  
+ * Correct behavior: Avtp_Vss_GetVssData is noop, pre‑set sentinel survives. */
+static void vss_data_uint8_inflated_path_oob(void **state)
+{
+    uint8_t buf[64];
+    Avtp_Vss_t *pdu = vss_build_inflated_path_pdu(buf, sizeof(buf), 6,
+                                                    VSS_UINT8);
+
+    VssData_t vd;
+    memset(&vd, 0xAA, sizeof(vd));
+    Avtp_Vss_GetVssData(pdu, &vd);
+    assert_int_equal(vd.data_uint8, 0xAA);
+}
+
+/* VSS_UINT8_ARRAY: like the string case but exercises the array path
+ * through vss_read_clamped_length (prefix, then memcpy). */
+static void vss_data_uint8_array_inflated_path_oob(void **state)
+{
+    uint8_t buf[64];
+    Avtp_Vss_t *pdu = vss_build_inflated_path_pdu(buf, sizeof(buf), 6,
+                                                    VSS_UINT8_ARRAY);
+
+    VssDataUint8Array_t arr = { .data = NULL };
+    VssData_t vd;
+    memset(&vd, 0, sizeof(vd));
+    vd.data_uint8_array = &arr;
+    Avtp_Vss_GetVssData(pdu, &vd);
+    assert_int_equal(arr.data_length, 0);
+
+    uint8_t out[16];
+    memset(out, 0x5A, sizeof(out));
+    arr.data = out;
+    Avtp_Vss_GetVssData(pdu, &vd);
+    assert_int_equal(out[0], 0x5A);
+}
+
+/* STATIC_ID with a frame that is too short for the 4‑byte path: the
+ * path must be treated as empty, and the scalar read skipped because
+ * the data pointer still exceeds the declared frame. */
+static void vss_data_static_id_truncated_oob(void **state)
+{
+    uint8_t buf[64];
+    Avtp_Vss_t *pdu = (Avtp_Vss_t *)buf;
+    memset(buf, 0, sizeof(buf));
+    Avtp_Vss_Init(pdu);
+    Avtp_Vss_SetAddrMode(pdu, VSS_STATIC_ID_MODE);
+    Avtp_Vss_SetAcfMsgLength(pdu, 3);  /* 12 bytes — header only */
+    Avtp_Vss_SetDatatype(pdu, VSS_UINT8);
+
+    VssData_t vd;
+    memset(&vd, 0xAA, sizeof(vd));
+    Avtp_Vss_GetVssData(pdu, &vd);
+    assert_int_equal(vd.data_uint8, 0xAA);
+}
+
 int main(void)
 {
     const struct CMUnitTest tests[] = {
@@ -1512,6 +1620,10 @@ int main(void)
         cmocka_unit_test(vss_data_int64_array_oob),
         cmocka_unit_test(vss_data_float_array_oob),
         cmocka_unit_test(vss_data_double_array_oob),
+        cmocka_unit_test(vss_data_string_inflated_path_oob),
+        cmocka_unit_test(vss_data_uint8_inflated_path_oob),
+        cmocka_unit_test(vss_data_uint8_array_inflated_path_oob),
+        cmocka_unit_test(vss_data_static_id_truncated_oob),
     };
 
     return cmocka_run_group_tests(tests, NULL, NULL);

--- a/unit/test-vss.c
+++ b/unit/test-vss.c
@@ -67,6 +67,8 @@ static void vss_pad(void **state) {
 
     uint8_t pdu[MAX_PDU_SIZE];
     Avtp_Vss_t* vss_pdu = (Avtp_Vss_t*) pdu;
+    Avtp_Vss_Init(vss_pdu);
+    Avtp_Vss_SetAcfMsgLength(vss_pdu, 20);
 
     // Check if the function is initializing properly
     Avtp_Vss_Init(vss_pdu);
@@ -87,6 +89,8 @@ static void vss_static_path(void **state) {
 
     uint8_t pdu[MAX_PDU_SIZE];
     Avtp_Vss_t* vss_pdu = (Avtp_Vss_t*) pdu;
+    Avtp_Vss_Init(vss_pdu);
+    Avtp_Vss_SetAcfMsgLength(vss_pdu, 20);
 
     VssPath_t path_id = {
         .vss_static_id_path = 0x01020304
@@ -109,7 +113,7 @@ static void vss_interop_path(void **state) {
     uint8_t pdu[MAX_PDU_SIZE];
     Avtp_Vss_t* vss_pdu = (Avtp_Vss_t*) pdu;
     Avtp_Vss_Init(vss_pdu);
-    Avtp_Vss_SetAcfMsgLength(vss_pdu, 10);
+    Avtp_Vss_SetAcfMsgLength(vss_pdu, 20);
 
     char path[] = "Vehicle.Speed";
     uint32_t path_length = strlen(path);
@@ -138,6 +142,8 @@ static void vss_data_uint8(void **state) {
 
     uint8_t pdu[MAX_PDU_SIZE];
     Avtp_Vss_t* vss_pdu = (Avtp_Vss_t*) pdu;
+    Avtp_Vss_Init(vss_pdu);
+    Avtp_Vss_SetAcfMsgLength(vss_pdu, 20);
     char path[] = "Vehicle.Speed";
     uint32_t path_length = strlen(path);
 
@@ -166,6 +172,8 @@ static void vss_data_int8(void **state) {
 
     uint8_t pdu[MAX_PDU_SIZE];
     Avtp_Vss_t* vss_pdu = (Avtp_Vss_t*) pdu;
+    Avtp_Vss_Init(vss_pdu);
+    Avtp_Vss_SetAcfMsgLength(vss_pdu, 20);
     char path[] = "Vehicle.Speed";
     uint32_t path_length = strlen(path);
 
@@ -194,6 +202,8 @@ static void vss_data_uint16(void **state) {
 
     uint8_t pdu[MAX_PDU_SIZE];
     Avtp_Vss_t* vss_pdu = (Avtp_Vss_t*) pdu;
+    Avtp_Vss_Init(vss_pdu);
+    Avtp_Vss_SetAcfMsgLength(vss_pdu, 20);
     char path[] = "Vehicle.Speed";
     uint32_t path_length = strlen(path);
 
@@ -222,6 +232,8 @@ static void vss_data_int16(void **state) {
 
     uint8_t pdu[MAX_PDU_SIZE];
     Avtp_Vss_t* vss_pdu = (Avtp_Vss_t*) pdu;
+    Avtp_Vss_Init(vss_pdu);
+    Avtp_Vss_SetAcfMsgLength(vss_pdu, 20);
     char path[] = "Vehicle.Speed";
     uint32_t path_length = strlen(path);
 
@@ -250,6 +262,8 @@ static void vss_data_uint32(void **state) {
 
     uint8_t pdu[MAX_PDU_SIZE];
     Avtp_Vss_t* vss_pdu = (Avtp_Vss_t*) pdu;
+    Avtp_Vss_Init(vss_pdu);
+    Avtp_Vss_SetAcfMsgLength(vss_pdu, 20);
     char path[] = "Vehicle.Speed";
     uint32_t path_length = strlen(path);
 
@@ -278,6 +292,8 @@ static void vss_data_int32(void **state) {
 
     uint8_t pdu[MAX_PDU_SIZE];
     Avtp_Vss_t* vss_pdu = (Avtp_Vss_t*) pdu;
+    Avtp_Vss_Init(vss_pdu);
+    Avtp_Vss_SetAcfMsgLength(vss_pdu, 20);
     char path[] = "Vehicle.Speed";
     uint32_t path_length = strlen(path);
 
@@ -305,6 +321,8 @@ static void vss_data_uint64(void **state) {
 
     uint8_t pdu[MAX_PDU_SIZE];
     Avtp_Vss_t* vss_pdu = (Avtp_Vss_t*) pdu;
+    Avtp_Vss_Init(vss_pdu);
+    Avtp_Vss_SetAcfMsgLength(vss_pdu, 20);
     char path[] = "Vehicle.Speed";
     uint32_t path_length = strlen(path);
 
@@ -334,6 +352,8 @@ static void vss_data_int64(void **state) {
 
     uint8_t pdu[MAX_PDU_SIZE];
     Avtp_Vss_t* vss_pdu = (Avtp_Vss_t*) pdu;
+    Avtp_Vss_Init(vss_pdu);
+    Avtp_Vss_SetAcfMsgLength(vss_pdu, 20);
     char path[] = "Vehicle.Speed";
     uint32_t path_length = strlen(path);
 
@@ -363,6 +383,8 @@ static void vss_data_bool(void **state) {
 
     uint8_t pdu[MAX_PDU_SIZE];
     Avtp_Vss_t* vss_pdu = (Avtp_Vss_t*) pdu;
+    Avtp_Vss_Init(vss_pdu);
+    Avtp_Vss_SetAcfMsgLength(vss_pdu, 20);
     char path[] = "Vehicle.Speed";
     uint32_t path_length = strlen(path);
 
@@ -391,6 +413,8 @@ static void vss_data_float(void **state) {
 
     uint8_t pdu[MAX_PDU_SIZE];
     Avtp_Vss_t* vss_pdu = (Avtp_Vss_t*) pdu;
+    Avtp_Vss_Init(vss_pdu);
+    Avtp_Vss_SetAcfMsgLength(vss_pdu, 20);
     char path[] = "Vehicle.Speed";
     uint32_t path_length = strlen(path);
 
@@ -419,6 +443,8 @@ static void vss_data_double(void **state) {
 
     uint8_t pdu[MAX_PDU_SIZE];
     Avtp_Vss_t* vss_pdu = (Avtp_Vss_t*) pdu;
+    Avtp_Vss_Init(vss_pdu);
+    Avtp_Vss_SetAcfMsgLength(vss_pdu, 20);
     char path[] = "Vehicle.Speed";
     uint32_t path_length = strlen(path);
 
@@ -447,6 +473,8 @@ static void vss_data_string(void **state) {
 
     uint8_t pdu[MAX_PDU_SIZE];
     Avtp_Vss_t* vss_pdu = (Avtp_Vss_t*) pdu;
+    Avtp_Vss_Init(vss_pdu);
+    Avtp_Vss_SetAcfMsgLength(vss_pdu, 20);
     char path[] = "Vehicle.Speed";
     uint32_t path_length = strlen(path);
 
@@ -487,6 +515,8 @@ static void vss_data_uint8_array(void **state) {
 
     uint8_t pdu[MAX_PDU_SIZE];
     Avtp_Vss_t* vss_pdu = (Avtp_Vss_t*) pdu;
+    Avtp_Vss_Init(vss_pdu);
+    Avtp_Vss_SetAcfMsgLength(vss_pdu, 20);
     char path[] = "Vehicle.Speed";
     uint32_t path_length = strlen(path);
 
@@ -527,6 +557,8 @@ static void vss_data_int8_array(void **state) {
 
     uint8_t pdu[MAX_PDU_SIZE];
     Avtp_Vss_t* vss_pdu = (Avtp_Vss_t*) pdu;
+    Avtp_Vss_Init(vss_pdu);
+    Avtp_Vss_SetAcfMsgLength(vss_pdu, 20);
     char path[] = "Vehicle.Speed";
     uint32_t path_length = strlen(path);
 
@@ -566,6 +598,8 @@ static void vss_data_uint16_array(void **state) {
 
     uint8_t pdu[MAX_PDU_SIZE];
     Avtp_Vss_t* vss_pdu = (Avtp_Vss_t*) pdu;
+    Avtp_Vss_Init(vss_pdu);
+    Avtp_Vss_SetAcfMsgLength(vss_pdu, 20);
     char path[] = "Vehicle.Speed";
     uint32_t path_length = strlen(path);
 
@@ -606,6 +640,8 @@ static void vss_data_int16_array(void **state) {
 
     uint8_t pdu[MAX_PDU_SIZE];
     Avtp_Vss_t* vss_pdu = (Avtp_Vss_t*) pdu;
+    Avtp_Vss_Init(vss_pdu);
+    Avtp_Vss_SetAcfMsgLength(vss_pdu, 20);
     char path[] = "Vehicle.Speed";
     uint32_t path_length = strlen(path);
 
@@ -646,6 +682,8 @@ static void vss_data_uint32_array(void **state) {
 
     uint8_t pdu[MAX_PDU_SIZE];
     Avtp_Vss_t* vss_pdu = (Avtp_Vss_t*) pdu;
+    Avtp_Vss_Init(vss_pdu);
+    Avtp_Vss_SetAcfMsgLength(vss_pdu, 20);
     char path[] = "Vehicle.Speed";
     uint32_t path_length = strlen(path);
 
@@ -686,6 +724,8 @@ static void vss_data_int32_array(void **state) {
 
     uint8_t pdu[MAX_PDU_SIZE];
     Avtp_Vss_t* vss_pdu = (Avtp_Vss_t*) pdu;
+    Avtp_Vss_Init(vss_pdu);
+    Avtp_Vss_SetAcfMsgLength(vss_pdu, 20);
     char path[] = "Vehicle.Speed";
     uint32_t path_length = strlen(path);
 
@@ -730,6 +770,8 @@ static void vss_data_uint64_array(void **state) {
 
     uint8_t pdu[MAX_PDU_SIZE];
     Avtp_Vss_t* vss_pdu = (Avtp_Vss_t*) pdu;
+    Avtp_Vss_Init(vss_pdu);
+    Avtp_Vss_SetAcfMsgLength(vss_pdu, 20);
     char path[] = "Vehicle.Speed";
     uint32_t path_length = strlen(path);
 
@@ -773,6 +815,8 @@ static void vss_data_int64_array(void **state) {
 
     uint8_t pdu[MAX_PDU_SIZE];
     Avtp_Vss_t* vss_pdu = (Avtp_Vss_t*) pdu;
+    Avtp_Vss_Init(vss_pdu);
+    Avtp_Vss_SetAcfMsgLength(vss_pdu, 20);
     char path[] = "Vehicle.Speed";
     uint32_t path_length = strlen(path);
 
@@ -818,6 +862,8 @@ static void vss_data_bool_array(void **state) {
 
     uint8_t pdu[MAX_PDU_SIZE];
     Avtp_Vss_t* vss_pdu = (Avtp_Vss_t*) pdu;
+    Avtp_Vss_Init(vss_pdu);
+    Avtp_Vss_SetAcfMsgLength(vss_pdu, 20);
     char path[] = "Vehicle.Speed";
     uint32_t path_length = strlen(path);
 
@@ -858,6 +904,8 @@ static void vss_data_float_array(void **state) {
 
     uint8_t pdu[MAX_PDU_SIZE];
     Avtp_Vss_t* vss_pdu = (Avtp_Vss_t*) pdu;
+    Avtp_Vss_Init(vss_pdu);
+    Avtp_Vss_SetAcfMsgLength(vss_pdu, 20);
     char path[] = "Vehicle.Speed";
     uint32_t path_length = strlen(path);
 
@@ -903,6 +951,8 @@ static void vss_data_double_array(void **state) {
 
     uint8_t pdu[MAX_PDU_SIZE];
     Avtp_Vss_t* vss_pdu = (Avtp_Vss_t*) pdu;
+    Avtp_Vss_Init(vss_pdu);
+    Avtp_Vss_SetAcfMsgLength(vss_pdu, 20);
     char path[] = "Vehicle.Speed";
     uint32_t path_length = strlen(path);
 
@@ -946,6 +996,8 @@ static void vss_data_string_array(void **state) {
 
     uint8_t pdu[MAX_PDU_SIZE];
     Avtp_Vss_t* vss_pdu = (Avtp_Vss_t*) pdu;
+    Avtp_Vss_Init(vss_pdu);
+    Avtp_Vss_SetAcfMsgLength(vss_pdu, 20);
     char path[] = "Vehicle.Speed";
     uint32_t path_length = strlen(path);
 
@@ -1570,8 +1622,58 @@ static void vss_data_static_id_truncated_oob(void **state)
 
     VssData_t vd;
     memset(&vd, 0xAA, sizeof(vd));
-    Avtp_Vss_GetVssData(pdu, &vd);
+     Avtp_Vss_GetVssData(pdu, &vd);
     assert_int_equal(vd.data_uint8, 0xAA);
+}
+
+/* ACF msg_length == 0 means the declared PDU size is 0 bytes.  
+ * This is testing for a regression: There used to be a 
+ * legacy bypass where the lentghts in ACF-VSS frames where trusted
+ * when the ACF length was set to 0.
+ * Correct behavior:: A zero‑msg‑length frame is treated as empty
+ * (all getters no‑op). */
+
+/* INTEROP path with msg_length == 0: the inflated path length must be
+ * clamped to 0, memcpy must copy 0 bytes, and the output buffer must
+ * survive untouched. */
+static void vss_path_interop_zero_msg_length_oob(void **state)
+{
+    uint8_t buf[64];
+    /* msg_quadlets = 0 → declared PDU = 0 bytes */
+    Avtp_Vss_t *pdu = vss_build_inflated_path_pdu(buf, sizeof(buf), 0,
+                                                    VSS_UINT8);
+
+    char path_buf[16];
+    memset(path_buf, 0x5A, sizeof(path_buf));
+    VssPath_t get_path;
+    get_path.vss_interop_path.path = path_buf;
+    Avtp_Vss_GetVssPath(pdu, &get_path);
+
+    assert_int_equal(get_path.vss_interop_path.path_length, 0);
+    assert_int_equal((uint8_t)path_buf[0], 0x5A);
+}
+
+/* VSS_STRING data with msg_length == 0 (via inflated‑path helper):
+ * data_length must be 0, output buffer untouched. */
+static void vss_data_string_zero_msg_length_oob(void **state)
+{
+    uint8_t buf[64];
+    /* msg_quadlets = 0 → declared PDU = 0 bytes */
+    Avtp_Vss_t *pdu = vss_build_inflated_path_pdu(buf, sizeof(buf), 0,
+                                                    VSS_STRING);
+
+    VssDataString_t str = { .data = NULL };
+    VssData_t vd;
+    memset(&vd, 0, sizeof(vd));
+    vd.data_string = &str;
+    Avtp_Vss_GetVssData(pdu, &vd);
+    assert_int_equal(str.data_length, 0);
+
+    char out[16];
+    memset(out, 0x5A, sizeof(out));
+    str.data = out;
+    Avtp_Vss_GetVssData(pdu, &vd);
+    assert_int_equal((uint8_t)out[0], 0x5A);
 }
 
 int main(void)
@@ -1624,6 +1726,8 @@ int main(void)
         cmocka_unit_test(vss_data_uint8_inflated_path_oob),
         cmocka_unit_test(vss_data_uint8_array_inflated_path_oob),
         cmocka_unit_test(vss_data_static_id_truncated_oob),
+        cmocka_unit_test(vss_path_interop_zero_msg_length_oob),
+        cmocka_unit_test(vss_data_string_zero_msg_length_oob),
     };
 
     return cmocka_run_group_tests(tests, NULL, NULL);


### PR DESCRIPTION
The experimental ACF-VSS implementation was basically trusting length fields on-wire, so it is easy to provoke reads that went over the frame boundary

This has been fixed. There are also new unit tests (those will segfault if ran against current main)

In case a length field is invalid this fix opts to truncate the read (instead of just returning nothing). I thought this was most in spirit with the the credo of "be generous in what you accept)

Therefore, different to e.g. CAN there is not a single "isValid" function that checks everything beforehand. Doing so would basically mean parsing the frame completely, before the app actually parses it, On the other hand, the indivudual checks (basically a clamp on any read length) care cheap. As VSS data can be more complex than just "8 byts of CAN", I figured for this ACF that is the better approach. (Also might be handy to have both approaches in the code base, to learn the advantages/disadvantages)


