### PR TITLE
Removed inclusion of math.h

### DIFF
--- a/examples/acf-can/ebpf-benchmarking-extensive/eBPF/bpf.c
+++ b/examples/acf-can/ebpf-benchmarking-extensive/eBPF/bpf.c
@@ -33,7 +33,6 @@
 #include <bpf/bpf_tracing.h>
 #include <bpf/bpf_core_read.h>
 #include <string.h>
-#include <math.h>
 #include "utils.h"
 
 struct config


### PR DESCRIPTION
- math.h functions are not available in the Kernel context where ebpf is used.
- Removal of inclusion was required to get the code compiled on the latest version of golang modules anf glibc.