### PR TITLE
Fixing some warnings

### DIFF
--- a/include/avtp/Udp.h
+++ b/include/avtp/Udp.h
@@ -83,7 +83,7 @@ static const Avtp_FieldDescriptor_t Avtp_UdpFieldDesc[AVTP_UDP_FIELD_MAX] = {
  * @param value Pointer to location to store the value.
  */
 OPEN1722_INLINE uint32_t Avtp_Udp_GetEncapsulationSeqNo(const Avtp_Udp_t* const pdu) {
-    return GET_UDP_FIELD(AVTP_UDP_FIELD_ENCAPSULATION_SEQ_NO);
+    return (uint32_t) GET_UDP_FIELD(AVTP_UDP_FIELD_ENCAPSULATION_SEQ_NO);
 }
 
 /**

--- a/include/avtp/acf/Abb.h
+++ b/include/avtp/acf/Abb.h
@@ -430,8 +430,8 @@ OPEN1722_INLINE void Avtp_Abb_SetSegmentNum(Avtp_Abb_t* msg, uint16_t segmentNum
  */
 OPEN1722_INLINE void Avtp_Abb_SetPayloadLen(Avtp_Abb_t* msg, uint16_t payloadLen) {
     uint16_t msgLenBytes = AVTP_ABB_HEADER_LEN + payloadLen;
-    uint8_t pad = (4 - (msgLenBytes % 4)) % 4;
-    uint16_t msgLenQuadlets = (msgLenBytes + pad) / 4;
+    uint8_t pad = (uint8_t)(4 - (msgLenBytes % 4)) % 4;
+    uint16_t msgLenQuadlets = (uint16_t)((msgLenBytes + pad) / 4);
     __Avtp_Abb_SetField(AVTP_ABB_FIELD_ACF_MSG_LENGTH, msgLenQuadlets);
     __Avtp_Abb_SetField(AVTP_ABB_FIELD_PAD, pad);
 }

--- a/include/avtp/acf/CanBriefV2.h
+++ b/include/avtp/acf/CanBriefV2.h
@@ -341,8 +341,8 @@ OPEN1722_INLINE void Avtp_CanBriefV2_SetCanIdentifier(Avtp_CanBriefV2_t* msg, ui
  */
 OPEN1722_INLINE void Avtp_CanBriefV2_SetPayloadLen(Avtp_CanBriefV2_t* msg, uint16_t payloadLen) {
     uint16_t msgLenBytes = AVTP_CAN_BRIEF_V2_HEADER_LEN + payloadLen;
-    uint8_t pad = (4 - (msgLenBytes % 4)) % 4;
-    uint16_t msgLenQuadlets = (msgLenBytes + pad) / 4;
+    uint8_t pad = (uint8_t)(4 - (msgLenBytes % 4)) % 4;
+    uint16_t msgLenQuadlets = (uint16_t) ((msgLenBytes + pad) / 4);
     __Avtp_CanBriefV2_SetField(AVTP_CAN_BRIEF_V2_FIELD_ACF_MSG_LENGTH, msgLenQuadlets);
     __Avtp_CanBriefV2_SetField(AVTP_CAN_BRIEF_V2_FIELD_PAD, pad);
 }

--- a/include/avtp/acf/CanV2.h
+++ b/include/avtp/acf/CanV2.h
@@ -364,8 +364,8 @@ OPEN1722_INLINE void Avtp_CanV2_SetCanIdentifier(Avtp_CanV2_t* msg, uint32_t can
  */
 OPEN1722_INLINE void Avtp_CanV2_SetPayloadLen(Avtp_CanV2_t* msg, uint16_t payloadLen) {
     uint16_t msgLenBytes = AVTP_CAN_V2_HEADER_LEN + payloadLen;
-    uint8_t pad = (4 - (msgLenBytes % 4)) % 4;
-    uint16_t msgLenQuadlets = (msgLenBytes + pad) / 4;
+    uint8_t pad = (uint8_t) (4 - (msgLenBytes % 4)) % 4;
+    uint16_t msgLenQuadlets = (uint16_t) ((msgLenBytes + pad) / 4);
     __Avtp_CanV2_SetField(AVTP_CAN_V2_FIELD_ACF_MSG_LENGTH, msgLenQuadlets);
     __Avtp_CanV2_SetField(AVTP_CAN_V2_FIELD_PAD, pad);
 }

--- a/include/avtp/acf/CanXl.h
+++ b/include/avtp/acf/CanXl.h
@@ -429,8 +429,8 @@ OPEN1722_INLINE void Avtp_CanXl_SetSegmentNum(Avtp_CanXl_t* msg, uint16_t segmen
  */
 OPEN1722_INLINE void Avtp_CanXl_SetPayloadLen(Avtp_CanXl_t* msg, uint16_t payloadLen) {
     uint16_t msgLenBytes = AVTP_CANXL_HEADER_LEN + payloadLen;
-    uint8_t pad = (4 - (msgLenBytes % 4)) % 4;
-    uint16_t msgLenQuadlets = (msgLenBytes + pad) / 4;
+    uint8_t pad = (uint8_t) (4 - (msgLenBytes % 4)) % 4;
+    uint16_t msgLenQuadlets = (uint16_t) ((msgLenBytes + pad) / 4);
     __Avtp_CanXl_SetField(AVTP_CANXL_FIELD_ACF_MSG_LENGTH, msgLenQuadlets);
     __Avtp_CanXl_SetField(AVTP_CANXL_FIELD_PAD, pad);
 }

--- a/include/avtp/acf/CanXlBrief.h
+++ b/include/avtp/acf/CanXlBrief.h
@@ -408,8 +408,8 @@ OPEN1722_INLINE void Avtp_CanXlBrief_SetSegmentNum(Avtp_CanXlBrief_t* msg, uint1
  */
 OPEN1722_INLINE void Avtp_CanXlBrief_SetPayloadLen(Avtp_CanXlBrief_t* msg, uint16_t payloadLen) {
     uint16_t msgLenBytes = AVTP_CANXL_BRIEF_HEADER_LEN + payloadLen;
-    uint8_t pad = (4 - (msgLenBytes % 4)) % 4;
-    uint16_t msgLenQuadlets = (msgLenBytes + pad) / 4;
+    uint8_t pad = (uint8_t) (4 - (msgLenBytes % 4)) % 4;
+    uint16_t msgLenQuadlets = (uint16_t) ((msgLenBytes + pad) / 4);
     __Avtp_CanXlBrief_SetField(AVTP_CANXL_BRIEF_FIELD_ACF_MSG_LENGTH, msgLenQuadlets);
     __Avtp_CanXlBrief_SetField(AVTP_CANXL_BRIEF_FIELD_PAD, pad);
 }

--- a/include/avtp/acf/Gbb.h
+++ b/include/avtp/acf/Gbb.h
@@ -453,8 +453,8 @@ OPEN1722_INLINE void Avtp_Gbb_SetSegmentNum(Avtp_Gbb_t* msg, uint16_t segmentNum
  */
 OPEN1722_INLINE void Avtp_Gbb_SetPayloadLen(Avtp_Gbb_t* msg, uint16_t payloadLen) {
     uint16_t msgLenBytes = AVTP_GBB_HEADER_LEN + payloadLen;
-    uint8_t pad = (4 - (msgLenBytes % 4)) % 4;
-    uint16_t msgLenQuadlets = (msgLenBytes + pad) / 4;
+    uint8_t pad = (uint8_t) (4 - (msgLenBytes % 4)) % 4;
+    uint16_t msgLenQuadlets = (uint16_t) ((msgLenBytes + pad) / 4);
     __Avtp_Gbb_SetField(AVTP_GBB_FIELD_ACF_MSG_LENGTH, msgLenQuadlets);
     __Avtp_Gbb_SetField(AVTP_GBB_FIELD_PAD, pad);
 }

--- a/include/avtp/acf/Gisf.h
+++ b/include/avtp/acf/Gisf.h
@@ -435,8 +435,8 @@ OPEN1722_INLINE void Avtp_Gisf_SetLineNumber(Avtp_Gisf_t* msg, uint16_t lineNumb
  */
 OPEN1722_INLINE void Avtp_Gisf_SetPayloadLen(Avtp_Gisf_t* msg, uint16_t payloadLen) {
     uint16_t msgLenBytes = AVTP_GISF_HEADER_LEN + payloadLen;
-    uint8_t pad = (4 - (msgLenBytes % 4)) % 4;
-    uint16_t msgLenQuadlets = (msgLenBytes + pad) / 4;
+    uint8_t pad = (uint8_t) (4 - (msgLenBytes % 4)) % 4;
+    uint16_t msgLenQuadlets = (uint16_t) ((msgLenBytes + pad) / 4);
     __Avtp_Gisf_SetField(AVTP_GISF_FIELD_ACF_MSG_LENGTH, msgLenQuadlets);
     __Avtp_Gisf_SetField(AVTP_GISF_FIELD_PAD, pad);
 }

--- a/src/avtp/acf/custom/Vss.c
+++ b/src/avtp/acf/custom/Vss.c
@@ -81,10 +81,11 @@ static uint16_t vss_read_clamped_length(const Avtp_Vss_t* pdu,
 
     if (offset + 2 + wire_len > declared) {
         /* Prefix fits but the payload it describes is too long → clamp. 
-         * Can never be negative, returns the maximum nuber of bytes that can 
-         * be read
-         */
-        return declared - (uint16_t)offset - 2;
+        * Clamp to the bytes available after the 2‑byte prefix.  The
+        * earlier guard ensures offset + 2 <= declared, so the result is
+        * non‑negative and fits uint16_t 
+        */
+        return (uint16_t) ((uint32_t) declared - offset - 2);
     }
     /* The normal case: All bytes declared fit in frame and can be read. */
     return wire_len;


### PR DESCRIPTION
Fixes some warnings about signed/unsigned comparisions (basically from C type promotion that sometimes lead to expressions being promoted to signed)




