### PR TITLE
Fixed the out-of-bounds memory access in ACF-CAN examples.

### DIFF
--- a/examples/acf-can/acf-can-common.c
+++ b/examples/acf-can/acf-can-common.c
@@ -331,6 +331,11 @@ int avtp_to_can(uint8_t* pdu, frame_t* can_frames, Avtp_CanVariant_t can_variant
         uint16_t acf_msg_length = Avtp_Can_GetAcfMsgLength((Avtp_Can_t*)acf_pdu)*4;
         uint16_t can_payload_length = Avtp_Can_GetCanPayloadLength((Avtp_Can_t*)acf_pdu);
         proc_bytes += acf_msg_length;
+        
+        if (i >= MAX_CAN_FRAMES_IN_ACF) {
+            LOG_ERR("Error: Number of CAN frames in ACF exceeds maximum allowed.\n");
+            return -1;
+        }
         frame_t* frame = &(can_frames[i++]);
 
         // Handle EFF Flag

--- a/examples/acf-can/linux/acf-can-listener.c
+++ b/examples/acf-can/linux/acf-can-listener.c
@@ -130,7 +130,7 @@ int main(int argc, char *argv[])
     struct sockaddr_can can_addr;
     struct ifreq ifr;
     uint16_t pdu_length = 0, cf_length = 0;
-    uint8_t num_can_msgs = 0;
+    int8_t num_can_msgs = 0;
     uint8_t exp_cf_seqnum = 0;
     uint32_t exp_udp_seqnum = 0;
     uint8_t pdu[MAX_ETH_PDU_SIZE];
@@ -177,10 +177,13 @@ int main(int argc, char *argv[])
 
         num_can_msgs = avtp_to_can(pdu, can_frames, can_variant, use_udp,
                              listener_stream_id, &exp_cf_seqnum, &exp_udp_seqnum);
+        if (num_can_msgs < 0) {
+            continue;
+        }
         exp_cf_seqnum++;
         exp_udp_seqnum++;
 
-        for (int i = 0; i < num_can_msgs; i++) {
+        for (int i = 0; i < num_can_msgs && i < MAX_CAN_FRAMES_IN_ACF; i++) {
             int res;
             if (can_variant == AVTP_CAN_FD)
                 res = write(can_socket, &can_frames[i].fd, sizeof(struct canfd_frame));


### PR DESCRIPTION
This should fix #154 