### PR TITLE
LIN apply API guidelines

### DIFF
--- a/include/avtp/acf/Lin.h
+++ b/include/avtp/acf/Lin.h
@@ -50,11 +50,10 @@
 extern "C" {
 #endif
 
-#define GET_LIN_FIELD(field) \
-        (Avtp_GetField(Avtp_LinFieldDesc, AVTP_LIN_FIELD_MAX, (uint8_t*)pdu, field))
-#define SET_LIN_FIELD(field, value) \
-        (Avtp_SetField(Avtp_LinFieldDesc, AVTP_LIN_FIELD_MAX, (uint8_t*)pdu, field, value))
-
+#define GET_LIN_FIELD(field)                                                                       \
+    (Avtp_GetField(Avtp_LinFieldDesc, AVTP_LIN_FIELD_MAX, (uint8_t *)pdu, field))
+#define SET_LIN_FIELD(field, value)                                                                \
+    (Avtp_SetField(Avtp_LinFieldDesc, AVTP_LIN_FIELD_MAX, (uint8_t *)pdu, field, value))
 
 /** Length of ACF Lin header. */
 #define AVTP_LIN_HEADER_LEN (3 * AVTP_QUADLET_SIZE)
@@ -66,7 +65,7 @@ typedef struct {
 } __attribute__((packed)) Avtp_Lin_t;
 
 /** Fields of ACF Lin PDU. */
-typedef enum  {
+typedef enum {
     /* ACF common header fields */
     AVTP_LIN_FIELD_ACF_MSG_TYPE = 0,
     AVTP_LIN_FIELD_ACF_MSG_LENGTH,
@@ -83,116 +82,128 @@ typedef enum  {
 /**
  * This table describes all the offsets of the ACF Lin header fields.
  */
-static const Avtp_FieldDescriptor_t Avtp_LinFieldDesc[AVTP_LIN_FIELD_MAX] =
-{
+static const Avtp_FieldDescriptor_t Avtp_LinFieldDesc[AVTP_LIN_FIELD_MAX] = {
     /* ACF common header fields */
-    [AVTP_LIN_FIELD_ACF_MSG_TYPE]       = { .quadlet = 0, .offset = 0, .bits = 7 },
-    [AVTP_LIN_FIELD_ACF_MSG_LENGTH]     = { .quadlet = 0, .offset = 7, .bits = 9 },
+    [AVTP_LIN_FIELD_ACF_MSG_TYPE] = {.quadlet = 0, .offset = 0, .bits = 7},
+    [AVTP_LIN_FIELD_ACF_MSG_LENGTH] = {.quadlet = 0, .offset = 7, .bits = 9},
     /* ACF LIN header fields */
-    [AVTP_LIN_FIELD_PAD]                = { .quadlet = 0, .offset = 16, .bits = 2 },
-    [AVTP_LIN_FIELD_MTV]                = { .quadlet = 0, .offset = 18, .bits = 1 },
-    [AVTP_LIN_FIELD_LIN_BUS_ID]         = { .quadlet = 0, .offset = 19, .bits = 5 },
-    [AVTP_LIN_FIELD_LIN_IDENTIFIER]     = { .quadlet = 0, .offset = 24, .bits = 8 },
-    [AVTP_LIN_FIELD_MESSAGE_TIMESTAMP]  = { .quadlet = 1, .offset = 0, .bits = 64 },
+    [AVTP_LIN_FIELD_PAD] = {.quadlet = 0, .offset = 16, .bits = 2},
+    [AVTP_LIN_FIELD_MTV] = {.quadlet = 0, .offset = 18, .bits = 1},
+    [AVTP_LIN_FIELD_LIN_BUS_ID] = {.quadlet = 0, .offset = 19, .bits = 5},
+    [AVTP_LIN_FIELD_LIN_IDENTIFIER] = {.quadlet = 0, .offset = 24, .bits = 8},
+    [AVTP_LIN_FIELD_MESSAGE_TIMESTAMP] = {.quadlet = 1, .offset = 0, .bits = 64},
 };
 
 /**
  * Returns the value of an an ACF Message type field as specified in the IEEE 1722 Specification.
- * 
+ *
  * @param pdu Pointer to the first bit of an 1722 ACF Lin PDU.
  * @returns The value of the ACF Message Type field.
  */
-OPEN1722_INLINE uint8_t Avtp_Lin_GetAcfMsgType(const Avtp_Lin_t* const pdu) {
-    return (uint8_t) GET_LIN_FIELD(AVTP_LIN_FIELD_ACF_MSG_TYPE);
+OPEN1722_INLINE uint8_t Avtp_Lin_GetAcfMsgType(const Avtp_Lin_t *const pdu)
+{
+    return (uint8_t)GET_LIN_FIELD(AVTP_LIN_FIELD_ACF_MSG_TYPE);
 }
 
 /**
  * Returns the value of an an ACF Message Length field as specified in the IEEE 1722 Specification.
- * 
+ *
  * @param pdu Pointer to the first bit of an 1722 ACF Lin PDU.
  * @returns The value of the ACF Message Length field.
  */
-OPEN1722_INLINE uint16_t Avtp_Lin_GetAcfMsgLength(const Avtp_Lin_t* const pdu) {
-    return (uint16_t) GET_LIN_FIELD(AVTP_LIN_FIELD_ACF_MSG_LENGTH);
+OPEN1722_INLINE uint16_t Avtp_Lin_GetAcfMsgLength(const Avtp_Lin_t *const pdu)
+{
+    return (uint16_t)GET_LIN_FIELD(AVTP_LIN_FIELD_ACF_MSG_LENGTH);
 }
 
 /**
  * Returns the value of an an ACF Lin PDU Pad field as specified in the IEEE 1722 Specification.
- * 
+ *
  * @param pdu Pointer to the first bit of an 1722 ACF Lin PDU.
  * @returns The value of the ACF Lin PDU Pad field.
  */
-OPEN1722_INLINE uint8_t Avtp_Lin_GetPad(const Avtp_Lin_t* const pdu) {
-    return (uint8_t) GET_LIN_FIELD(AVTP_LIN_FIELD_PAD);
+OPEN1722_INLINE uint8_t Avtp_Lin_GetPad(const Avtp_Lin_t *const pdu)
+{
+    return (uint8_t)GET_LIN_FIELD(AVTP_LIN_FIELD_PAD);
 }
 
 /**
  * Returns the value of an an ACF Lin PDU MTV field as specified in the IEEE 1722 Specification.
- * 
+ *
  * @param pdu Pointer to the first bit of an 1722 ACF Lin PDU.
  * @returns The value of the ACF Lin PDU MTV field.
  */
-OPEN1722_INLINE bool Avtp_Lin_IsMtv(const Avtp_Lin_t* const pdu) {
-    return (bool) GET_LIN_FIELD(AVTP_LIN_FIELD_MTV);
+OPEN1722_INLINE bool Avtp_Lin_IsMtv(const Avtp_Lin_t *const pdu)
+{
+    return (bool)GET_LIN_FIELD(AVTP_LIN_FIELD_MTV);
 }
 
 /**
- * Returns the value of an an ACF Lin PDU Lin Bus ID field as specified in the IEEE 1722 Specification.
- * 
+ * Returns the value of an an ACF Lin PDU Lin Bus ID field as specified in the IEEE 1722
+ * Specification.
+ *
  * @param pdu Pointer to the first bit of an 1722 ACF Lin PDU.
  * @returns The value of the ACF Lin PDU Lin Bus ID field.
  */
-OPEN1722_INLINE uint8_t Avtp_Lin_GetLinBusId(const Avtp_Lin_t* const pdu) {
-    return (uint8_t) GET_LIN_FIELD(AVTP_LIN_FIELD_LIN_BUS_ID);
+OPEN1722_INLINE uint8_t Avtp_Lin_GetLinBusId(const Avtp_Lin_t *const pdu)
+{
+    return (uint8_t)GET_LIN_FIELD(AVTP_LIN_FIELD_LIN_BUS_ID);
 }
 
 /**
- * Returns the value of an an ACF Lin PDU Lin Identifier field as specified in the IEEE 1722 Specification.
+ * Returns the value of an an ACF Lin PDU Lin Identifier field as specified in the IEEE 1722
+ * Specification.
  *
  * @param pdu Pointer to the first bit of an 1722 ACF Lin PDU.
  * @returns The value of the ACF Lin PDU Lin Identifier field.
  */
-OPEN1722_INLINE uint8_t Avtp_Lin_GetLinIdentifier(const Avtp_Lin_t* const pdu) {
-    return (uint8_t) GET_LIN_FIELD(AVTP_LIN_FIELD_LIN_IDENTIFIER);
+OPEN1722_INLINE uint8_t Avtp_Lin_GetLinIdentifier(const Avtp_Lin_t *const pdu)
+{
+    return (uint8_t)GET_LIN_FIELD(AVTP_LIN_FIELD_LIN_IDENTIFIER);
 }
 
 /**
- * Returns the value of an an ACF Lin PDU Message Timestamp field as specified in the IEEE 1722 Specification.
+ * Returns the value of an an ACF Lin PDU Message Timestamp field as specified in the IEEE 1722
+ * Specification.
  *
  * @param pdu Pointer to the first bit of an 1722 ACF Lin PDU.
  * @returns The value of the ACF Lin PDU Message Timestamp field.
  */
-OPEN1722_INLINE uint64_t Avtp_Lin_GetMessageTimestamp(const Avtp_Lin_t* const pdu) {
-    return (uint64_t) GET_LIN_FIELD(AVTP_LIN_FIELD_MESSAGE_TIMESTAMP);
+OPEN1722_INLINE uint64_t Avtp_Lin_GetMessageTimestamp(const Avtp_Lin_t *const pdu)
+{
+    return (uint64_t)GET_LIN_FIELD(AVTP_LIN_FIELD_MESSAGE_TIMESTAMP);
 }
 
 /**
  * Sets the value of an an ACF Message type field as specified in the IEEE 1722 Specification.
- * 
+ *
  * @param pdu Pointer to the first bit of an 1722 ACF Lin PDU.
  * @param value Value to set the ACF Message Type field to.
  */
-OPEN1722_INLINE void Avtp_Lin_SetAcfMsgType(Avtp_Lin_t* pdu, uint8_t value) {
+OPEN1722_INLINE void Avtp_Lin_SetAcfMsgType(Avtp_Lin_t *pdu, uint8_t value)
+{
     SET_LIN_FIELD(AVTP_LIN_FIELD_ACF_MSG_TYPE, value);
 }
 
 /**
  * Sets the value of an an ACF Message Length field as specified in the IEEE 1722 Specification.
- * 
+ *
  * @param pdu Pointer to the first bit of an 1722 ACF Lin PDU.
  * @param value Value to set the ACF Message Length field to.
  */
-OPEN1722_INLINE void Avtp_Lin_SetAcfMsgLength(Avtp_Lin_t* pdu, uint16_t value) {
+OPEN1722_INLINE void Avtp_Lin_SetAcfMsgLength(Avtp_Lin_t *pdu, uint16_t value)
+{
     SET_LIN_FIELD(AVTP_LIN_FIELD_ACF_MSG_LENGTH, value);
 }
 
 /**
  * Sets the value of an an ACF Lin PDU Pad field as specified in the IEEE 1722 Specification.
- * 
+ *
  * @param pdu Pointer to the first bit of an 1722 ACF Lin PDU.
  * @param value Value to set the ACF Lin PDU Pad field to.
  */
-OPEN1722_INLINE void Avtp_Lin_SetPad(Avtp_Lin_t* pdu, uint8_t value) {
+OPEN1722_INLINE void Avtp_Lin_SetPad(Avtp_Lin_t *pdu, uint8_t value)
+{
     SET_LIN_FIELD(AVTP_LIN_FIELD_PAD, value);
 }
 
@@ -202,37 +213,43 @@ OPEN1722_INLINE void Avtp_Lin_SetPad(Avtp_Lin_t* pdu, uint8_t value) {
  * @param pdu Pointer to the first bit of an 1722 ACF Lin PDU.
  * @param mtv Value to set the MTV bit to.
  */
-OPEN1722_INLINE void Avtp_Lin_SetMtv(Avtp_Lin_t* pdu, bool mtv) {
+OPEN1722_INLINE void Avtp_Lin_SetMtv(Avtp_Lin_t *pdu, bool mtv)
+{
     SET_LIN_FIELD(AVTP_LIN_FIELD_MTV, mtv);
 }
 
 /**
  * Set the value of an an ACF Lin PDU Lin Bus ID field as specified in the IEEE 1722 Specification.
- * 
+ *
  * @param pdu Pointer to the first bit of an 1722 ACF Lin PDU.
  * @param value Value to set the ACF Lin PDU Lin Bus ID field to.
  */
-OPEN1722_INLINE void Avtp_Lin_SetLinBusId(Avtp_Lin_t* pdu, uint8_t value) {
+OPEN1722_INLINE void Avtp_Lin_SetLinBusId(Avtp_Lin_t *pdu, uint8_t value)
+{
     SET_LIN_FIELD(AVTP_LIN_FIELD_LIN_BUS_ID, value);
 }
 
 /**
- * Set the value of an an ACF Lin PDU Lin Identifier field as specified in the IEEE 1722 Specification.
+ * Set the value of an an ACF Lin PDU Lin Identifier field as specified in the IEEE 1722
+ * Specification.
  *
  * @param pdu Pointer to the first bit of an 1722 ACF Lin PDU.
  * @param value Value to set the ACF Lin PDU Lin Identifier field to.
  */
-OPEN1722_INLINE void Avtp_Lin_SetLinIdentifier(Avtp_Lin_t* pdu, uint8_t value) {
+OPEN1722_INLINE void Avtp_Lin_SetLinIdentifier(Avtp_Lin_t *pdu, uint8_t value)
+{
     SET_LIN_FIELD(AVTP_LIN_FIELD_LIN_IDENTIFIER, value);
 }
 
 /**
- * Set the value of an an ACF Lin PDU Message Timestamp field as specified in the IEEE 1722 Specification.
- * 
+ * Set the value of an an ACF Lin PDU Message Timestamp field as specified in the IEEE 1722
+ * Specification.
+ *
  * @param pdu Pointer to the first bit of an 1722 ACF Lin PDU.
  * @param value Value to set the ACF Lin PDU Message Timestamp field to.
  */
-OPEN1722_INLINE void Avtp_Lin_SetMessageTimestamp(Avtp_Lin_t* pdu, uint64_t value) {
+OPEN1722_INLINE void Avtp_Lin_SetMessageTimestamp(Avtp_Lin_t *pdu, uint64_t value)
+{
     SET_LIN_FIELD(AVTP_LIN_FIELD_MESSAGE_TIMESTAMP, value);
 }
 
@@ -242,7 +259,7 @@ OPEN1722_INLINE void Avtp_Lin_SetMessageTimestamp(Avtp_Lin_t* pdu, uint64_t valu
  * @param pdu Pointer to the first bit of an 1722 ACF Lin PDU.
  * @returns Length of the ACF message in bytes.
  */
-OPEN1722_INLINE uint16_t Avtp_Lin_GetAcfMsgLengthInBytes(const Avtp_Lin_t* const pdu)
+OPEN1722_INLINE uint16_t Avtp_Lin_GetAcfMsgLengthInBytes(const Avtp_Lin_t *const pdu)
 {
     return (uint16_t)GET_LIN_FIELD(AVTP_LIN_FIELD_ACF_MSG_LENGTH) * 4;
 }
@@ -269,7 +286,7 @@ void Avtp_Lin_CreateAcfMessage(Avtp_Lin_t *lin_pdu, uint8_t lin_bus_id, uint8_t 
  * @param lin_pdu Pointer to the first bit of an 1722 ACF Lin PDU.
  * @return Pointer to ACF Lin frame payload
  */
-OPEN1722_INLINE const uint8_t *Avtp_Lin_GetPayload(const Avtp_Lin_t* const lin_pdu)
+OPEN1722_INLINE const uint8_t *Avtp_Lin_GetPayload(const Avtp_Lin_t *const lin_pdu)
 {
     return lin_pdu->payload;
 }
@@ -319,7 +336,7 @@ OPEN1722_INLINE void Avtp_Lin_SetPayloadLength(Avtp_Lin_t *lin_pdu, uint16_t pay
  * @param pdu Pointer to the first bit of an 1722 ACF Lin PDU.
  * @return  Length of LIN payload in bytes
  */
-OPEN1722_INLINE uint8_t Avtp_Lin_GetPayloadLength(const Avtp_Lin_t* const pdu)
+OPEN1722_INLINE uint8_t Avtp_Lin_GetPayloadLength(const Avtp_Lin_t *const pdu)
 {
     uint8_t pad_length = Avtp_Lin_GetPad(pdu);
     uint16_t acf_length_bytes = Avtp_Lin_GetAcfMsgLengthInBytes(pdu);
@@ -328,21 +345,22 @@ OPEN1722_INLINE uint8_t Avtp_Lin_GetPayloadLength(const Avtp_Lin_t* const pdu)
 
 /**
  * Checks if the ACF Lin frame is valid by checking:
- *     1) if the length field of AVTP/ACF messages contains a value larger than the actual size of the buffer that contains the AVTP message.
- *     2) if other format specific invariants are not upheld
+ *     1) if the length field of AVTP/ACF messages contains a value larger than the actual size of
+ * the buffer that contains the AVTP message. 2) if other format specific invariants are not upheld
  * @param pdu Pointer to the first bit of an 1722 ACF Lin PDU.
  * @param bufferSize Size of the buffer containing the ACF Lin frame.
  * @return true if the ACF Lin frame is valid, false otherwise.
  */
-bool Avtp_Lin_IsValid(const Avtp_Lin_t* const pdu, size_t bufferSize);
+bool Avtp_Lin_IsValid(const Avtp_Lin_t *const pdu, size_t bufferSize);
 
 /**
  * Initializes an ACF Lin PDU.
  *
  * @param pdu Pointer to the first bit of a 1722 ACF Lin PDU.
  */
-OPEN1722_INLINE void Avtp_Lin_Init(Avtp_Lin_t* pdu) {
-    if(pdu != NULL) {
+OPEN1722_INLINE void Avtp_Lin_Init(Avtp_Lin_t *pdu)
+{
+    if (pdu != NULL) {
         memset(pdu, 0, sizeof(Avtp_Lin_t));
         Avtp_Lin_SetAcfMsgType(pdu, AVTP_ACF_TYPE_LIN);
     }

--- a/include/avtp/acf/Lin.h
+++ b/include/avtp/acf/Lin.h
@@ -35,11 +35,16 @@
 #pragma once
 #include "avtp/Inline.h"
 
+#ifdef LINUX_KERNEL1722
+#include <linux/string.h>
+#else
 #include <string.h>
+#include <stdbool.h>
+#endif
 
+#include "avtp/Utils.h"
 #include "avtp/Defines.h"
 #include "avtp/acf/AcfCommon.h"
-#include "avtp/Utils.h"
 
 #ifdef __cplusplus
 extern "C" {
@@ -58,7 +63,7 @@ extern "C" {
 typedef struct {
     uint8_t header[AVTP_LIN_HEADER_LEN];
     uint8_t payload[0];
-} Avtp_Lin_t;
+} __attribute__((packed)) Avtp_Lin_t;
 
 /** Fields of ACF Lin PDU. */
 typedef enum  {
@@ -127,8 +132,8 @@ OPEN1722_INLINE uint8_t Avtp_Lin_GetPad(const Avtp_Lin_t* const pdu) {
  * @param pdu Pointer to the first bit of an 1722 ACF Lin PDU.
  * @returns The value of the ACF Lin PDU MTV field.
  */
-OPEN1722_INLINE uint8_t Avtp_Lin_GetMtv(const Avtp_Lin_t* const pdu) {
-    return (uint8_t) GET_LIN_FIELD(AVTP_LIN_FIELD_MTV);
+OPEN1722_INLINE bool Avtp_Lin_IsMtv(const Avtp_Lin_t* const pdu) {
+    return (bool) GET_LIN_FIELD(AVTP_LIN_FIELD_MTV);
 }
 
 /**
@@ -192,21 +197,13 @@ OPEN1722_INLINE void Avtp_Lin_SetPad(Avtp_Lin_t* pdu, uint8_t value) {
 }
 
 /**
- * Enable the MTV bit in an ACF Lin frame as specified in the IEEE 1722 Specification.
+ * Set the MTV bit in an ACF Lin frame as specified in the IEEE 1722 Specification.
  *
  * @param pdu Pointer to the first bit of an 1722 ACF Lin PDU.
+ * @param mtv Value to set the MTV bit to.
  */
-OPEN1722_INLINE void Avtp_Lin_EnableMtv(Avtp_Lin_t* pdu) {
-    SET_LIN_FIELD(AVTP_LIN_FIELD_MTV, 1);
-}
-
-/**
- * Disable the MTV bit in an ACF Lin frame as specified in the IEEE 1722 Specification.
- *
- * @param pdu Pointer to the first bit of an 1722 ACF Lin PDU.
- */
-OPEN1722_INLINE void Avtp_Lin_DisableMtv(Avtp_Lin_t* pdu) {
-    SET_LIN_FIELD(AVTP_LIN_FIELD_MTV, 0);
+OPEN1722_INLINE void Avtp_Lin_SetMtv(Avtp_Lin_t* pdu, bool mtv) {
+    SET_LIN_FIELD(AVTP_LIN_FIELD_MTV, mtv);
 }
 
 /**
@@ -240,6 +237,96 @@ OPEN1722_INLINE void Avtp_Lin_SetMessageTimestamp(Avtp_Lin_t* pdu, uint64_t valu
 }
 
 /**
+ * Return the ACF message length in bytes.
+ *
+ * @param pdu Pointer to the first bit of an 1722 ACF Lin PDU.
+ * @returns Length of the ACF message in bytes.
+ */
+OPEN1722_INLINE uint16_t Avtp_Lin_GetAcfMsgLengthInBytes(const Avtp_Lin_t* const pdu)
+{
+    return (uint16_t)GET_LIN_FIELD(AVTP_LIN_FIELD_ACF_MSG_LENGTH) * 4;
+}
+
+/**
+ * Copies the payload data, LIN bus ID, LIN identifier and message timestamp into
+ * the ACF Lin frame. This function will also set the length and pad fields while
+ * inserting the padded bytes.
+ *
+ * @param lin_pdu Pointer to the first bit of an 1722 ACF Lin PDU.
+ * @param lin_bus_id LIN bus ID
+ * @param lin_identifier LIN frame identifier
+ * @param message_timestamp Message timestamp
+ * @param payload Pointer to the payload byte array
+ * @param payload_length Length of the payload.
+ */
+void Avtp_Lin_CreateAcfMessage(Avtp_Lin_t *lin_pdu, uint8_t lin_bus_id, uint8_t lin_identifier,
+                               uint64_t message_timestamp, uint8_t *payload,
+                               uint16_t payload_length);
+
+/**
+ * Returns pointer to payload of an ACF Lin frame.
+ *
+ * @param lin_pdu Pointer to the first bit of an 1722 ACF Lin PDU.
+ * @return Pointer to ACF Lin frame payload
+ */
+OPEN1722_INLINE const uint8_t *Avtp_Lin_GetPayload(const Avtp_Lin_t* const lin_pdu)
+{
+    return lin_pdu->payload;
+}
+
+/**
+ * Sets the LIN payload in an ACF Lin frame.
+ *
+ * @param lin_pdu Pointer to the first bit of an 1722 ACF Lin PDU.
+ * @param payload Pointer to the payload byte array
+ * @param payload_length Length of the payload
+ */
+OPEN1722_INLINE void Avtp_Lin_SetPayload(Avtp_Lin_t *lin_pdu, uint8_t *payload,
+                                         uint16_t payload_length)
+{
+    memcpy(lin_pdu->payload, payload, payload_length);
+}
+
+/**
+ * Finalizes the ACF Lin frame. This function will set the length and pad fields
+ * while inserting the padded bytes. This will also set padding bytes to zero if
+ * the payload length is not a multiple of 4 to avoid leaking information.
+ *
+ * @param lin_pdu Pointer to the first bit of an 1722 ACF Lin PDU.
+ * @param payload_length Length of the LIN frame payload.
+ */
+OPEN1722_INLINE void Avtp_Lin_SetPayloadLength(Avtp_Lin_t *lin_pdu, uint16_t payload_length)
+{
+    uint16_t msgLenBytes = AVTP_LIN_HEADER_LEN + payload_length;
+    uint8_t pad = (uint8_t)(4 - (msgLenBytes % 4)) % 4;
+    if (pad > 0) {
+        memset(lin_pdu->payload + payload_length, 0, pad);
+    }
+    uint16_t msgLenQuadlets = (uint16_t)((msgLenBytes + pad) / 4);
+    Avtp_Lin_SetPad(lin_pdu, pad);
+    Avtp_Lin_SetAcfMsgLength(lin_pdu, msgLenQuadlets);
+}
+
+/**
+ * Returns the length of the LIN payload without the padding bytes and the
+ * header length of the encapsulating ACF Frame.
+ *
+ * Precondition: the caller must have validated the PDU with
+ * Avtp_Lin_IsValid(). IsValid checks both buffer-size containment and the
+ * LIN payload-length invariant (<= 8 bytes). This function performs no
+ * further bounds checking and assumes those invariants already hold.
+ *
+ * @param pdu Pointer to the first bit of an 1722 ACF Lin PDU.
+ * @return  Length of LIN payload in bytes
+ */
+OPEN1722_INLINE uint8_t Avtp_Lin_GetPayloadLength(const Avtp_Lin_t* const pdu)
+{
+    uint8_t pad_length = Avtp_Lin_GetPad(pdu);
+    uint16_t acf_length_bytes = Avtp_Lin_GetAcfMsgLengthInBytes(pdu);
+    return (uint8_t)(acf_length_bytes - AVTP_LIN_HEADER_LEN - pad_length);
+}
+
+/**
  * Checks if the ACF Lin frame is valid by checking:
  *     1) if the length field of AVTP/ACF messages contains a value larger than the actual size of the buffer that contains the AVTP message.
  *     2) if other format specific invariants are not upheld
@@ -247,7 +334,7 @@ OPEN1722_INLINE void Avtp_Lin_SetMessageTimestamp(Avtp_Lin_t* pdu, uint64_t valu
  * @param bufferSize Size of the buffer containing the ACF Lin frame.
  * @return true if the ACF Lin frame is valid, false otherwise.
  */
-uint8_t Avtp_Lin_IsValid(const Avtp_Lin_t* const pdu, size_t bufferSize);
+bool Avtp_Lin_IsValid(const Avtp_Lin_t* const pdu, size_t bufferSize);
 
 /**
  * Initializes an ACF Lin PDU.

--- a/src/avtp/acf/Lin.c
+++ b/src/avtp/acf/Lin.c
@@ -29,24 +29,53 @@
 
 #include "avtp/acf/Lin.h"
 
-uint8_t Avtp_Lin_IsValid(const Avtp_Lin_t* const pdu, size_t bufferSize)
+void Avtp_Lin_CreateAcfMessage(Avtp_Lin_t *pdu, uint8_t lin_bus_id, uint8_t lin_identifier,
+                               uint64_t message_timestamp, uint8_t *payload,
+                               uint16_t payload_length)
+{
+    // Copy the payload into the LIN PDU
+    Avtp_Lin_SetPayload(pdu, payload, payload_length);
+
+    // Set the LIN bus ID, identifier and message timestamp
+    Avtp_Lin_SetLinBusId(pdu, lin_bus_id);
+    Avtp_Lin_SetLinIdentifier(pdu, lin_identifier);
+    Avtp_Lin_SetMessageTimestamp(pdu, message_timestamp);
+
+    // Finalize the AVTP LIN Frame
+    Avtp_Lin_SetPayloadLength(pdu, payload_length);
+}
+
+bool Avtp_Lin_IsValid(const Avtp_Lin_t* const pdu, size_t bufferSize)
 {
     if (pdu == NULL) {
-        return FALSE;
+        return false;
     }
 
     if (bufferSize < AVTP_LIN_HEADER_LEN) {
-        return FALSE;
+        return false;
     }
 
     if (Avtp_Lin_GetAcfMsgType(pdu) != AVTP_ACF_TYPE_LIN) {
-        return FALSE;
+        return false;
     }
 
-    // Avtp_Lin_GetAcfMsgLength returns quadlets. Convert the length field to octets
-    if (Avtp_Lin_GetAcfMsgLength(pdu) * 4 > bufferSize) {
-        return FALSE;
+    // Avtp_Lin_GetAcfMsgLength returns quadlets. Convert the length field to octets.
+    uint16_t msg_length_bytes = (uint16_t)Avtp_Lin_GetAcfMsgLength(pdu) * 4;
+    if (msg_length_bytes > bufferSize) {
+        return false;
     }
 
-    return TRUE;
+    /* LIN payload-length invariant: the encoded message length must also
+     * accommodate header + declared padding so the payload computation in
+     * Avtp_Lin_GetPayloadLength() doesn't underflow. */
+    uint8_t pad_length = Avtp_Lin_GetPad(pdu);
+    uint16_t header_and_pad = (uint16_t)AVTP_LIN_HEADER_LEN + pad_length;
+    if (msg_length_bytes < header_and_pad) {
+        return false;
+    }
+    uint16_t payload_length = msg_length_bytes - header_and_pad;
+    if (payload_length > 8u) {
+        return false;
+    }
+    return true;
 }

--- a/src/avtp/acf/Lin.c
+++ b/src/avtp/acf/Lin.c
@@ -45,7 +45,7 @@ void Avtp_Lin_CreateAcfMessage(Avtp_Lin_t *pdu, uint8_t lin_bus_id, uint8_t lin_
     Avtp_Lin_SetPayloadLength(pdu, payload_length);
 }
 
-bool Avtp_Lin_IsValid(const Avtp_Lin_t* const pdu, size_t bufferSize)
+bool Avtp_Lin_IsValid(const Avtp_Lin_t *const pdu, size_t bufferSize)
 {
     if (pdu == NULL) {
         return false;

--- a/unit/test-lin.c
+++ b/unit/test-lin.c
@@ -70,11 +70,11 @@ static void lin_get_set_fields(void **state) {
     Avtp_Lin_SetPad((Avtp_Lin_t*)pdu, 3);
     assert_int_equal(Avtp_Lin_GetPad((Avtp_Lin_t*)pdu), 3);
 
-    Avtp_Lin_EnableMtv((Avtp_Lin_t*)pdu);
-    assert_int_equal(Avtp_Lin_GetMtv((Avtp_Lin_t*)pdu), 1);
+    Avtp_Lin_SetMtv((Avtp_Lin_t*)pdu, true);
+    assert_int_equal(Avtp_Lin_IsMtv((Avtp_Lin_t*)pdu), 1);
 
-    Avtp_Lin_DisableMtv((Avtp_Lin_t*)pdu);
-    assert_int_equal(Avtp_Lin_GetMtv((Avtp_Lin_t*)pdu), 0);
+    Avtp_Lin_SetMtv((Avtp_Lin_t*)pdu, false);
+    assert_int_equal(Avtp_Lin_IsMtv((Avtp_Lin_t*)pdu), 0);
 
     Avtp_Lin_SetLinBusId((Avtp_Lin_t*)pdu, 7);
     assert_int_equal(Avtp_Lin_GetLinBusId((Avtp_Lin_t*)pdu), 7);
@@ -89,19 +89,49 @@ static void lin_get_set_fields(void **state) {
 static void lin_is_valid(void **state) {
     uint8_t pdu[MAX_PDU_SIZE];
 
+    // An Init-only PDU has AcfMsgLength == 0 - i.e. it declares a frame
+    // shorter than its own header, so IsValid must reject it.
     Avtp_Lin_Init((Avtp_Lin_t*)pdu);
-    assert_int_equal(Avtp_Lin_IsValid((Avtp_Lin_t*)pdu, MAX_PDU_SIZE), 1);
+    assert_int_equal(Avtp_Lin_IsValid((Avtp_Lin_t*)pdu, MAX_PDU_SIZE), 0);
 
+    // Not an IEEE 1722 ACF-LIN message (zero buffer, AcfMsgType != LIN).
     memset(pdu, 0, MAX_PDU_SIZE);
     assert_int_equal(Avtp_Lin_IsValid((Avtp_Lin_t*)pdu, MAX_PDU_SIZE), 0);
 
+    // Valid IEEE 1722 LIN Frame (Length 20, Buffer 25). AcfMsgLength=5
+    // quadlets = 20 bytes; payload = 20 - 12 header = 8 bytes (LIN max).
     Avtp_Lin_Init((Avtp_Lin_t*)pdu);
     Avtp_Lin_SetAcfMsgLength((Avtp_Lin_t*)pdu, 5);
     assert_int_equal(Avtp_Lin_IsValid((Avtp_Lin_t*)pdu, 25), 1);
 
+    // Invalid IEEE 1722 LIN Frame (Length 20 but buffer only 9!).
     Avtp_Lin_Init((Avtp_Lin_t*)pdu);
     Avtp_Lin_SetAcfMsgLength((Avtp_Lin_t*)pdu, 5);
     assert_int_equal(Avtp_Lin_IsValid((Avtp_Lin_t*)pdu, 9), 0);
+
+    // LIN payload bound: a frame declaring a 12-byte payload is invalid
+    // (LIN tops out at 8 bytes). AcfMsgLength=6 quadlets = 24 bytes;
+    // payload = 24 - 12 header = 12 bytes.
+    Avtp_Lin_Init((Avtp_Lin_t*)pdu);
+    Avtp_Lin_SetAcfMsgLength((Avtp_Lin_t*)pdu, 6);
+    assert_int_equal(Avtp_Lin_IsValid((Avtp_Lin_t*)pdu, MAX_PDU_SIZE), 0);
+}
+
+static void lin_create_message(void **state) {
+    uint8_t pdu[MAX_PDU_SIZE];
+    uint8_t payload[8] = {0,1,2,3,4,5,6,7};
+
+    Avtp_Lin_Init((Avtp_Lin_t*)pdu);
+    Avtp_Lin_CreateAcfMessage((Avtp_Lin_t*)pdu, 7, 0x3F, 0x123456789ABCULL,
+                              payload, sizeof(payload));
+
+    assert_int_equal(Avtp_Lin_GetLinBusId((Avtp_Lin_t*)pdu), 7);
+    assert_int_equal(Avtp_Lin_GetLinIdentifier((Avtp_Lin_t*)pdu), 0x3F);
+    assert_int_equal(Avtp_Lin_GetMessageTimestamp((Avtp_Lin_t*)pdu), 0x123456789ABCULL);
+    assert_memory_equal(payload, pdu+AVTP_LIN_HEADER_LEN, sizeof(payload));
+    assert_int_equal(Avtp_Lin_GetPayloadLength((Avtp_Lin_t*)pdu), 8);
+    assert_int_equal(Avtp_Lin_GetAcfMsgLength((Avtp_Lin_t*)pdu), 5);
+    assert_int_equal(Avtp_Lin_IsValid((Avtp_Lin_t*)pdu, MAX_PDU_SIZE), 1);
 }
 
 int main(void)
@@ -110,6 +140,7 @@ int main(void)
         cmocka_unit_test(lin_init),
         cmocka_unit_test(lin_get_set_fields),
         cmocka_unit_test(lin_is_valid),
+        cmocka_unit_test(lin_create_message),
     };
 
     return cmocka_run_group_tests(tests, NULL, NULL);

--- a/unit/test-lin.c
+++ b/unit/test-lin.c
@@ -44,94 +44,98 @@ extern "C" {
 
 #define MAX_PDU_SIZE 1500
 
-static void lin_init(void **state) {
+static void lin_init(void **state)
+{
     uint8_t pdu[MAX_PDU_SIZE];
     uint8_t init_pdu[AVTP_LIN_HEADER_LEN];
 
     Avtp_Lin_Init(NULL);
 
-    Avtp_Lin_Init((Avtp_Lin_t*)pdu);
+    Avtp_Lin_Init((Avtp_Lin_t *)pdu);
     memset(init_pdu, 0, AVTP_LIN_HEADER_LEN);
     init_pdu[0] = AVTP_ACF_TYPE_LIN << 1;
     assert_memory_equal(init_pdu, pdu, AVTP_LIN_HEADER_LEN);
 }
 
-static void lin_get_set_fields(void **state) {
+static void lin_get_set_fields(void **state)
+{
     uint8_t pdu[MAX_PDU_SIZE];
-    
-    Avtp_Lin_Init((Avtp_Lin_t*)pdu);
 
-    Avtp_Lin_SetAcfMsgType((Avtp_Lin_t*)pdu, AVTP_ACF_TYPE_LIN);
-    assert_int_equal(Avtp_Lin_GetAcfMsgType((Avtp_Lin_t*)pdu), AVTP_ACF_TYPE_LIN);
+    Avtp_Lin_Init((Avtp_Lin_t *)pdu);
 
-    Avtp_Lin_SetAcfMsgLength((Avtp_Lin_t*)pdu, 50);
-    assert_int_equal(Avtp_Lin_GetAcfMsgLength((Avtp_Lin_t*)pdu), 50);
+    Avtp_Lin_SetAcfMsgType((Avtp_Lin_t *)pdu, AVTP_ACF_TYPE_LIN);
+    assert_int_equal(Avtp_Lin_GetAcfMsgType((Avtp_Lin_t *)pdu), AVTP_ACF_TYPE_LIN);
 
-    Avtp_Lin_SetPad((Avtp_Lin_t*)pdu, 3);
-    assert_int_equal(Avtp_Lin_GetPad((Avtp_Lin_t*)pdu), 3);
+    Avtp_Lin_SetAcfMsgLength((Avtp_Lin_t *)pdu, 50);
+    assert_int_equal(Avtp_Lin_GetAcfMsgLength((Avtp_Lin_t *)pdu), 50);
 
-    Avtp_Lin_SetMtv((Avtp_Lin_t*)pdu, true);
-    assert_int_equal(Avtp_Lin_IsMtv((Avtp_Lin_t*)pdu), 1);
+    Avtp_Lin_SetPad((Avtp_Lin_t *)pdu, 3);
+    assert_int_equal(Avtp_Lin_GetPad((Avtp_Lin_t *)pdu), 3);
 
-    Avtp_Lin_SetMtv((Avtp_Lin_t*)pdu, false);
-    assert_int_equal(Avtp_Lin_IsMtv((Avtp_Lin_t*)pdu), 0);
+    Avtp_Lin_SetMtv((Avtp_Lin_t *)pdu, true);
+    assert_int_equal(Avtp_Lin_IsMtv((Avtp_Lin_t *)pdu), 1);
 
-    Avtp_Lin_SetLinBusId((Avtp_Lin_t*)pdu, 7);
-    assert_int_equal(Avtp_Lin_GetLinBusId((Avtp_Lin_t*)pdu), 7);
+    Avtp_Lin_SetMtv((Avtp_Lin_t *)pdu, false);
+    assert_int_equal(Avtp_Lin_IsMtv((Avtp_Lin_t *)pdu), 0);
 
-    Avtp_Lin_SetLinIdentifier((Avtp_Lin_t*)pdu, 0x3F);
-    assert_int_equal(Avtp_Lin_GetLinIdentifier((Avtp_Lin_t*)pdu), 0x3F);
+    Avtp_Lin_SetLinBusId((Avtp_Lin_t *)pdu, 7);
+    assert_int_equal(Avtp_Lin_GetLinBusId((Avtp_Lin_t *)pdu), 7);
 
-    Avtp_Lin_SetMessageTimestamp((Avtp_Lin_t*)pdu, 0x123456789ABCULL);
-    assert_int_equal(Avtp_Lin_GetMessageTimestamp((Avtp_Lin_t*)pdu), 0x123456789ABCULL);
+    Avtp_Lin_SetLinIdentifier((Avtp_Lin_t *)pdu, 0x3F);
+    assert_int_equal(Avtp_Lin_GetLinIdentifier((Avtp_Lin_t *)pdu), 0x3F);
+
+    Avtp_Lin_SetMessageTimestamp((Avtp_Lin_t *)pdu, 0x123456789ABCULL);
+    assert_int_equal(Avtp_Lin_GetMessageTimestamp((Avtp_Lin_t *)pdu), 0x123456789ABCULL);
 }
 
-static void lin_is_valid(void **state) {
+static void lin_is_valid(void **state)
+{
     uint8_t pdu[MAX_PDU_SIZE];
 
     // An Init-only PDU has AcfMsgLength == 0 - i.e. it declares a frame
     // shorter than its own header, so IsValid must reject it.
-    Avtp_Lin_Init((Avtp_Lin_t*)pdu);
-    assert_int_equal(Avtp_Lin_IsValid((Avtp_Lin_t*)pdu, MAX_PDU_SIZE), 0);
+    Avtp_Lin_Init((Avtp_Lin_t *)pdu);
+    assert_int_equal(Avtp_Lin_IsValid((Avtp_Lin_t *)pdu, MAX_PDU_SIZE), 0);
 
     // Not an IEEE 1722 ACF-LIN message (zero buffer, AcfMsgType != LIN).
     memset(pdu, 0, MAX_PDU_SIZE);
-    assert_int_equal(Avtp_Lin_IsValid((Avtp_Lin_t*)pdu, MAX_PDU_SIZE), 0);
+    assert_int_equal(Avtp_Lin_IsValid((Avtp_Lin_t *)pdu, MAX_PDU_SIZE), 0);
 
     // Valid IEEE 1722 LIN Frame (Length 20, Buffer 25). AcfMsgLength=5
     // quadlets = 20 bytes; payload = 20 - 12 header = 8 bytes (LIN max).
-    Avtp_Lin_Init((Avtp_Lin_t*)pdu);
-    Avtp_Lin_SetAcfMsgLength((Avtp_Lin_t*)pdu, 5);
-    assert_int_equal(Avtp_Lin_IsValid((Avtp_Lin_t*)pdu, 25), 1);
+    Avtp_Lin_Init((Avtp_Lin_t *)pdu);
+    Avtp_Lin_SetAcfMsgLength((Avtp_Lin_t *)pdu, 5);
+    assert_int_equal(Avtp_Lin_IsValid((Avtp_Lin_t *)pdu, 25), 1);
 
     // Invalid IEEE 1722 LIN Frame (Length 20 but buffer only 9!).
-    Avtp_Lin_Init((Avtp_Lin_t*)pdu);
-    Avtp_Lin_SetAcfMsgLength((Avtp_Lin_t*)pdu, 5);
-    assert_int_equal(Avtp_Lin_IsValid((Avtp_Lin_t*)pdu, 9), 0);
+    Avtp_Lin_Init((Avtp_Lin_t *)pdu);
+    Avtp_Lin_SetAcfMsgLength((Avtp_Lin_t *)pdu, 5);
+    assert_int_equal(Avtp_Lin_IsValid((Avtp_Lin_t *)pdu, 9), 0);
 
     // LIN payload bound: a frame declaring a 12-byte payload is invalid
     // (LIN tops out at 8 bytes). AcfMsgLength=6 quadlets = 24 bytes;
     // payload = 24 - 12 header = 12 bytes.
-    Avtp_Lin_Init((Avtp_Lin_t*)pdu);
-    Avtp_Lin_SetAcfMsgLength((Avtp_Lin_t*)pdu, 6);
-    assert_int_equal(Avtp_Lin_IsValid((Avtp_Lin_t*)pdu, MAX_PDU_SIZE), 0);
+    Avtp_Lin_Init((Avtp_Lin_t *)pdu);
+    Avtp_Lin_SetAcfMsgLength((Avtp_Lin_t *)pdu, 6);
+    assert_int_equal(Avtp_Lin_IsValid((Avtp_Lin_t *)pdu, MAX_PDU_SIZE), 0);
 }
 
-static void lin_create_message(void **state) {
+static void lin_create_message(void **state)
+{
     uint8_t pdu[MAX_PDU_SIZE];
-    uint8_t payload[8] = {0,1,2,3,4,5,6,7};
+    uint8_t payload[8] = {0, 1, 2, 3, 4, 5, 6, 7};
 
-    Avtp_Lin_Init((Avtp_Lin_t*)pdu);
-    Avtp_Lin_CreateAcfMessage((Avtp_Lin_t*)pdu, 7, 0x3F, 0x123456789ABCULL,
-                              payload, sizeof(payload));
+    Avtp_Lin_Init((Avtp_Lin_t *)pdu);
+    Avtp_Lin_CreateAcfMessage((Avtp_Lin_t *)pdu, 7, 0x3F, 0x123456789ABCULL, payload,
+                              sizeof(payload));
 
-    assert_int_equal(Avtp_Lin_GetLinBusId((Avtp_Lin_t*)pdu), 7);
-    assert_int_equal(Avtp_Lin_GetLinIdentifier((Avtp_Lin_t*)pdu), 0x3F);
-    assert_int_equal(Avtp_Lin_GetMessageTimestamp((Avtp_Lin_t*)pdu), 0x123456789ABCULL);
-    assert_memory_equal(payload, pdu+AVTP_LIN_HEADER_LEN, sizeof(payload));
-    assert_int_equal(Avtp_Lin_GetPayloadLength((Avtp_Lin_t*)pdu), 8);
-    assert_int_equal(Avtp_Lin_GetAcfMsgLength((Avtp_Lin_t*)pdu), 5);
-    assert_int_equal(Avtp_Lin_IsValid((Avtp_Lin_t*)pdu, MAX_PDU_SIZE), 1);
+    assert_int_equal(Avtp_Lin_GetLinBusId((Avtp_Lin_t *)pdu), 7);
+    assert_int_equal(Avtp_Lin_GetLinIdentifier((Avtp_Lin_t *)pdu), 0x3F);
+    assert_int_equal(Avtp_Lin_GetMessageTimestamp((Avtp_Lin_t *)pdu), 0x123456789ABCULL);
+    assert_memory_equal(payload, pdu + AVTP_LIN_HEADER_LEN, sizeof(payload));
+    assert_int_equal(Avtp_Lin_GetPayloadLength((Avtp_Lin_t *)pdu), 8);
+    assert_int_equal(Avtp_Lin_GetAcfMsgLength((Avtp_Lin_t *)pdu), 5);
+    assert_int_equal(Avtp_Lin_IsValid((Avtp_Lin_t *)pdu, MAX_PDU_SIZE), 1);
 }
 
 int main(void)


### PR DESCRIPTION
Changes to LIN

- include/avtp/acf/Lin.h: packed struct, stdbool.h/kernel include guard, Avtp_Lin_IsMtv/Avtp_Lin_SetMtv(bool) (replacing GetMtv/EnableMtv/DisableMtv), bool IsValid, plus GetAcfMsgLengthInBytes, GetPayload, SetPayload, SetPayloadLength, GetPayloadLength, and CreateAcfMessage declaration.
- src/avtp/acf/Lin.c: IsValid now returns bool.  Has header+pad underflow guard and 8-byte payload limit. Added CreateAcfMessage implementation.
- unit/test-lin.c: updated for the renamed MTV API, init-only now invalid, and added payload-bound and CreateAcfMessage round-trip coverage.


Due to format requirements many lines have changed. To see the actual _functional_ changes see first commit:

https://github.com/COVESA/Open1722/pull/167/changes/3c0a95fd62c00a7bf89e2de5e6c5dc72ae013e93
