### PR TITLE
CanBrief apply API guidelines

### DIFF
--- a/include/avtp/acf/CanBrief.h
+++ b/include/avtp/acf/CanBrief.h
@@ -151,7 +151,8 @@ OPEN1722_INLINE uint8_t Avtp_CanBrief_GetPad(const Avtp_CanBrief_t *const pdu)
 }
 
 /**
- * Return the value of an an ACF CAN Brief PDU MTV field as specified in the IEEE 1722 Specification.
+ * Return the value of an an ACF CAN Brief PDU MTV field as specified in the IEEE 1722
+ * Specification.
  *
  * @param pdu Pointer to the first bit of an 1722 ACF CAN Brief PDU.
  * @returns Value of the ACF CAN Brief PDU MTV field.
@@ -162,7 +163,8 @@ OPEN1722_INLINE bool Avtp_CanBrief_IsMtv(const Avtp_CanBrief_t *const pdu)
 }
 
 /**
- * Return the value of an an ACF CAN Brief PDU RTR field as specified in the IEEE 1722 Specification.
+ * Return the value of an an ACF CAN Brief PDU RTR field as specified in the IEEE 1722
+ * Specification.
  *
  * @param pdu Pointer to the first bit of an 1722 ACF CAN Brief PDU.
  * @returns Value of the ACF CAN Brief PDU RTR field.
@@ -173,7 +175,8 @@ OPEN1722_INLINE bool Avtp_CanBrief_IsRtr(const Avtp_CanBrief_t *const pdu)
 }
 
 /**
- * Return the value of an an ACF CAN Brief PDU EFF field as specified in the IEEE 1722 Specification.
+ * Return the value of an an ACF CAN Brief PDU EFF field as specified in the IEEE 1722
+ * Specification.
  *
  * @param pdu Pointer to the first bit of an 1722 ACF CAN Brief PDU.
  * @returns Value of the ACF CAN Brief PDU EFF field.
@@ -184,7 +187,8 @@ OPEN1722_INLINE bool Avtp_CanBrief_IsEff(const Avtp_CanBrief_t *const pdu)
 }
 
 /**
- * Return the value of an an ACF CAN Brief PDU BRS field as specified in the IEEE 1722 Specification.
+ * Return the value of an an ACF CAN Brief PDU BRS field as specified in the IEEE 1722
+ * Specification.
  *
  * @param pdu Pointer to the first bit of an 1722 ACF CAN Brief PDU.
  * @returns Value of the ACF CAN Brief PDU BRS field.
@@ -195,7 +199,8 @@ OPEN1722_INLINE bool Avtp_CanBrief_IsBrs(const Avtp_CanBrief_t *const pdu)
 }
 
 /**
- * Return the value of an an ACF CAN Brief PDU FDF field as specified in the IEEE 1722 Specification.
+ * Return the value of an an ACF CAN Brief PDU FDF field as specified in the IEEE 1722
+ * Specification.
  *
  * @param pdu Pointer to the first bit of an 1722 ACF CAN Brief PDU.
  * @returns Value of the ACF CAN Brief PDU FDF field.
@@ -206,7 +211,8 @@ OPEN1722_INLINE bool Avtp_CanBrief_IsFdf(const Avtp_CanBrief_t *const pdu)
 }
 
 /**
- * Return the value of an an ACF CAN Brief PDU ESI field as specified in the IEEE 1722 Specification.
+ * Return the value of an an ACF CAN Brief PDU ESI field as specified in the IEEE 1722
+ * Specification.
  *
  * @param pdu Pointer to the first bit of an 1722 ACF CAN Brief PDU.
  * @returns Value of the ACF CAN Brief PDU ESI field.
@@ -217,7 +223,8 @@ OPEN1722_INLINE bool Avtp_CanBrief_IsEsi(const Avtp_CanBrief_t *const pdu)
 }
 
 /**
- * Return the value of an an ACF CAN Brief PDU CAN Bus ID field as specified in the IEEE 1722 Specification.
+ * Return the value of an an ACF CAN Brief PDU CAN Bus ID field as specified in the IEEE 1722
+ * Specification.
  *
  * @param pdu Pointer to the first bit of an 1722 ACF CAN Brief PDU.
  * @returns Value of the ACF CAN Brief PDU CAN Bus ID field.
@@ -228,7 +235,8 @@ OPEN1722_INLINE uint8_t Avtp_CanBrief_GetCanBusId(const Avtp_CanBrief_t *const p
 }
 
 /**
- * Return the value of an an ACF CAN Brief PDU CAN Identifier field as specified in the IEEE 1722 Specification.
+ * Return the value of an an ACF CAN Brief PDU CAN Identifier field as specified in the IEEE 1722
+ * Specification.
  *
  * @param pdu Pointer to the first bit of an 1722 ACF CAN Brief PDU.
  * @returns Value of the ACF CAN Brief PDU CAN Identifier field.
@@ -341,7 +349,8 @@ OPEN1722_INLINE void Avtp_CanBrief_SetEsi(Avtp_CanBrief_t *pdu, bool esi)
 }
 
 /**
- * Set the value of an an ACF CAN Brief PDU CAN Bus ID field as specified in the IEEE 1722 Specification.
+ * Set the value of an an ACF CAN Brief PDU CAN Bus ID field as specified in the IEEE 1722
+ * Specification.
  *
  * @param pdu Pointer to the first bit of an 1722 ACF CAN Brief PDU.
  * @param value Value to set the ACF CAN Brief PDU CAN Bus ID field to.
@@ -352,7 +361,8 @@ OPEN1722_INLINE void Avtp_CanBrief_SetCanBusId(Avtp_CanBrief_t *pdu, uint8_t val
 }
 
 /**
- * Set the value of an an ACF CAN Brief PDU CAN Identifier field as specified in the IEEE 1722 Specification.
+ * Set the value of an an ACF CAN Brief PDU CAN Identifier field as specified in the IEEE 1722
+ * Specification.
  *
  * @param pdu Pointer to the first bit of an 1722 ACF CAN Brief PDU.
  * @param value Value to set the ACF CAN Brief PDU CAN Identifier field to.
@@ -408,7 +418,8 @@ OPEN1722_INLINE void Avtp_CanBrief_SetPayload(Avtp_CanBrief_t *can_pdu, uint8_t 
  * @param can_pdu Pointer to the first bit of an 1722 ACF CAN Brief PDU.
  * @param payload_length Length of the CAN frame payload.
  */
-OPEN1722_INLINE void Avtp_CanBrief_SetPayloadLength(Avtp_CanBrief_t *can_pdu, uint16_t payload_length)
+OPEN1722_INLINE void Avtp_CanBrief_SetPayloadLength(Avtp_CanBrief_t *can_pdu,
+                                                    uint16_t payload_length)
 {
     uint16_t msgLenBytes = AVTP_CAN_BRIEF_HEADER_LEN + payload_length;
     uint8_t pad = (uint8_t)(4 - (msgLenBytes % 4)) % 4;

--- a/include/avtp/acf/CanBrief.h
+++ b/include/avtp/acf/CanBrief.h
@@ -40,6 +40,7 @@
 #include <linux/string.h>
 #else
 #include <string.h>
+#include <stdbool.h>
 #endif
 
 #include "avtp/Utils.h"
@@ -50,17 +51,17 @@
 extern "C" {
 #endif
 
-#define GET_CAN_BRIEF_FIELD(field) \
-        (Avtp_GetField(Avtp_CanBriefFieldDesc, AVTP_CAN_BRIEF_FIELD_MAX, (uint8_t*)pdu, field))
-#define SET_CAN_BRIEF_FIELD(field, value) \
-        (Avtp_SetField(Avtp_CanBriefFieldDesc, AVTP_CAN_BRIEF_FIELD_MAX, (uint8_t*)pdu, field, value))
+#define GET_CAN_BRIEF_FIELD(field)                                                                 \
+    (Avtp_GetField(Avtp_CanBriefFieldDesc, AVTP_CAN_BRIEF_FIELD_MAX, (uint8_t *)pdu, field))
+#define SET_CAN_BRIEF_FIELD(field, value)                                                          \
+    (Avtp_SetField(Avtp_CanBriefFieldDesc, AVTP_CAN_BRIEF_FIELD_MAX, (uint8_t *)pdu, field, value))
 
-#define AVTP_CAN_BRIEF_HEADER_LEN         (2 * AVTP_QUADLET_SIZE)
+#define AVTP_CAN_BRIEF_HEADER_LEN (2 * AVTP_QUADLET_SIZE)
 
 typedef struct {
     uint8_t header[AVTP_CAN_BRIEF_HEADER_LEN];
     uint8_t payload[0];
-} Avtp_CanBrief_t;
+} __attribute__((packed)) Avtp_CanBrief_t;
 
 typedef enum {
 
@@ -86,33 +87,21 @@ typedef enum {
 /**
  * This table maps all IEEE 1722 ACF Abbreviated CAN header fields to a descriptor.
  */
-static const Avtp_FieldDescriptor_t Avtp_CanBriefFieldDesc[AVTP_CAN_BRIEF_FIELD_MAX] =
-{
+static const Avtp_FieldDescriptor_t Avtp_CanBriefFieldDesc[AVTP_CAN_BRIEF_FIELD_MAX] = {
     /* ACF common header fields */
-    [AVTP_CAN_BRIEF_FIELD_ACF_MSG_TYPE]           = { .quadlet = 0, .offset =  0, .bits = 7 },
-    [AVTP_CAN_BRIEF_FIELD_ACF_MSG_LENGTH]         = { .quadlet = 0, .offset =  7, .bits = 9 },
+    [AVTP_CAN_BRIEF_FIELD_ACF_MSG_TYPE] = {.quadlet = 0, .offset = 0, .bits = 7},
+    [AVTP_CAN_BRIEF_FIELD_ACF_MSG_LENGTH] = {.quadlet = 0, .offset = 7, .bits = 9},
     /* ACF Abbreviated CAN header fields */
-    [AVTP_CAN_BRIEF_FIELD_PAD]                   = { .quadlet = 0, .offset = 16, .bits =  2 },
-    [AVTP_CAN_BRIEF_FIELD_MTV]                   = { .quadlet = 0, .offset = 18, .bits =  1 },
-    [AVTP_CAN_BRIEF_FIELD_RTR]                   = { .quadlet = 0, .offset = 19, .bits =  1 },
-    [AVTP_CAN_BRIEF_FIELD_EFF]                   = { .quadlet = 0, .offset = 20, .bits =  1 },
-    [AVTP_CAN_BRIEF_FIELD_BRS]                   = { .quadlet = 0, .offset = 21, .bits =  1 },
-    [AVTP_CAN_BRIEF_FIELD_FDF]                   = { .quadlet = 0, .offset = 22, .bits =  1 },
-    [AVTP_CAN_BRIEF_FIELD_ESI]                   = { .quadlet = 0, .offset = 23, .bits =  1 },
-    [AVTP_CAN_BRIEF_FIELD_CAN_BUS_ID]            = { .quadlet = 0, .offset = 27, .bits =  5 },
-    [AVTP_CAN_BRIEF_FIELD_CAN_IDENTIFIER]        = { .quadlet = 1, .offset =  3, .bits = 29 },
+    [AVTP_CAN_BRIEF_FIELD_PAD] = {.quadlet = 0, .offset = 16, .bits = 2},
+    [AVTP_CAN_BRIEF_FIELD_MTV] = {.quadlet = 0, .offset = 18, .bits = 1},
+    [AVTP_CAN_BRIEF_FIELD_RTR] = {.quadlet = 0, .offset = 19, .bits = 1},
+    [AVTP_CAN_BRIEF_FIELD_EFF] = {.quadlet = 0, .offset = 20, .bits = 1},
+    [AVTP_CAN_BRIEF_FIELD_BRS] = {.quadlet = 0, .offset = 21, .bits = 1},
+    [AVTP_CAN_BRIEF_FIELD_FDF] = {.quadlet = 0, .offset = 22, .bits = 1},
+    [AVTP_CAN_BRIEF_FIELD_ESI] = {.quadlet = 0, .offset = 23, .bits = 1},
+    [AVTP_CAN_BRIEF_FIELD_CAN_BUS_ID] = {.quadlet = 0, .offset = 27, .bits = 5},
+    [AVTP_CAN_BRIEF_FIELD_CAN_IDENTIFIER] = {.quadlet = 1, .offset = 3, .bits = 29},
 };
-
-/**
- * Returns the value of an an ACF Abbreviated CAN PDU field as specified in the IEEE 1722 Specification.
- *
- * @param pdu Pointer to the first bit of an 1722 ACF Abbreviated CAN PDU.
- * @param field Specifies the position of the data field to be read
- * @returns Field of CAN Brief PDU.
- */
-OPEN1722_INLINE uint64_t Avtp_CanBrief_GetField(const Avtp_CanBrief_t* const pdu, Avtp_CanBriefFields_t field) {
-    return GET_CAN_BRIEF_FIELD(field);
-}
 
 /**
  * Return the value of an an ACF message type field as specified in the IEEE 1722 Specification.
@@ -120,17 +109,34 @@ OPEN1722_INLINE uint64_t Avtp_CanBrief_GetField(const Avtp_CanBrief_t* const pdu
  * @param pdu Pointer to the first bit of an 1722 ACF CAN Brief PDU.
  * @returns Value of the ACF message type field.
  */
-OPEN1722_INLINE uint8_t Avtp_CanBrief_GetAcfMsgType(const Avtp_CanBrief_t* const pdu) {
-    return (uint8_t) GET_CAN_BRIEF_FIELD(AVTP_CAN_BRIEF_FIELD_ACF_MSG_TYPE);
+OPEN1722_INLINE uint8_t Avtp_CanBrief_GetAcfMsgType(const Avtp_CanBrief_t *const pdu)
+{
+    return (uint8_t)GET_CAN_BRIEF_FIELD(AVTP_CAN_BRIEF_FIELD_ACF_MSG_TYPE);
 }
+
 /**
  * Return the value of an an ACF message length field as specified in the IEEE 1722 Specification.
+ * This returns the length in Quadlets as specified in the IEEE 1722 Specification.
+ *
+ * You can use Avtp_CanBrief_GetPayloadLength to get the length in bytes without padding.
  *
  * @param pdu Pointer to the first bit of an 1722 ACF CAN Brief PDU.
  * @returns Value of the ACF message length field.
  */
-OPEN1722_INLINE uint16_t Avtp_CanBrief_GetAcfMsgLength(const Avtp_CanBrief_t* const pdu) {
-    return (uint16_t) GET_CAN_BRIEF_FIELD(AVTP_CAN_BRIEF_FIELD_ACF_MSG_LENGTH);
+OPEN1722_INLINE uint16_t Avtp_CanBrief_GetAcfMsgLength(const Avtp_CanBrief_t *const pdu)
+{
+    return (uint16_t)GET_CAN_BRIEF_FIELD(AVTP_CAN_BRIEF_FIELD_ACF_MSG_LENGTH);
+}
+
+/**
+ * Return the ACF message length in bytes.
+ *
+ * @param pdu Pointer to the first bit of an 1722 ACF CAN Brief PDU.
+ * @returns Length of the ACF message in bytes.
+ */
+OPEN1722_INLINE uint16_t Avtp_CanBrief_GetAcfMsgLengthInBytes(const Avtp_CanBrief_t *const pdu)
+{
+    return (uint16_t)GET_CAN_BRIEF_FIELD(AVTP_CAN_BRIEF_FIELD_ACF_MSG_LENGTH) * 4;
 }
 
 /**
@@ -139,78 +145,86 @@ OPEN1722_INLINE uint16_t Avtp_CanBrief_GetAcfMsgLength(const Avtp_CanBrief_t* co
  * @param pdu Pointer to the first bit of an 1722 ACF CAN Brief PDU.
  * @returns Value of the ACF padding field.
  */
-OPEN1722_INLINE uint8_t Avtp_CanBrief_GetPad(const Avtp_CanBrief_t* const pdu) {
-    return (uint8_t) GET_CAN_BRIEF_FIELD(AVTP_CAN_BRIEF_FIELD_PAD);
+OPEN1722_INLINE uint8_t Avtp_CanBrief_GetPad(const Avtp_CanBrief_t *const pdu)
+{
+    return (uint8_t)GET_CAN_BRIEF_FIELD(AVTP_CAN_BRIEF_FIELD_PAD);
 }
 
-/** 
+/**
  * Return the value of an an ACF CAN Brief PDU MTV field as specified in the IEEE 1722 Specification.
- * 
+ *
  * @param pdu Pointer to the first bit of an 1722 ACF CAN Brief PDU.
  * @returns Value of the ACF CAN Brief PDU MTV field.
  */
-OPEN1722_INLINE uint8_t Avtp_CanBrief_GetMtv(const Avtp_CanBrief_t* const pdu) {
-    return (uint8_t) GET_CAN_BRIEF_FIELD(AVTP_CAN_BRIEF_FIELD_MTV);
+OPEN1722_INLINE bool Avtp_CanBrief_IsMtv(const Avtp_CanBrief_t *const pdu)
+{
+    return (bool)GET_CAN_BRIEF_FIELD(AVTP_CAN_BRIEF_FIELD_MTV);
 }
 
 /**
  * Return the value of an an ACF CAN Brief PDU RTR field as specified in the IEEE 1722 Specification.
- * 
+ *
  * @param pdu Pointer to the first bit of an 1722 ACF CAN Brief PDU.
  * @returns Value of the ACF CAN Brief PDU RTR field.
  */
-OPEN1722_INLINE uint8_t Avtp_CanBrief_GetRtr(const Avtp_CanBrief_t* const pdu) {
-    return (uint8_t) GET_CAN_BRIEF_FIELD(AVTP_CAN_BRIEF_FIELD_RTR);
+OPEN1722_INLINE bool Avtp_CanBrief_IsRtr(const Avtp_CanBrief_t *const pdu)
+{
+    return (bool)GET_CAN_BRIEF_FIELD(AVTP_CAN_BRIEF_FIELD_RTR);
 }
 
 /**
  * Return the value of an an ACF CAN Brief PDU EFF field as specified in the IEEE 1722 Specification.
- * 
+ *
  * @param pdu Pointer to the first bit of an 1722 ACF CAN Brief PDU.
  * @returns Value of the ACF CAN Brief PDU EFF field.
  */
-OPEN1722_INLINE uint8_t Avtp_CanBrief_GetEff(const Avtp_CanBrief_t* const pdu) {
-    return (uint8_t) GET_CAN_BRIEF_FIELD(AVTP_CAN_BRIEF_FIELD_EFF);
+OPEN1722_INLINE bool Avtp_CanBrief_IsEff(const Avtp_CanBrief_t *const pdu)
+{
+    return (bool)GET_CAN_BRIEF_FIELD(AVTP_CAN_BRIEF_FIELD_EFF);
 }
 
-/** 
+/**
  * Return the value of an an ACF CAN Brief PDU BRS field as specified in the IEEE 1722 Specification.
- * 
+ *
  * @param pdu Pointer to the first bit of an 1722 ACF CAN Brief PDU.
  * @returns Value of the ACF CAN Brief PDU BRS field.
  */
-OPEN1722_INLINE uint8_t Avtp_CanBrief_GetBrs(const Avtp_CanBrief_t* const pdu) {
-    return (uint8_t) GET_CAN_BRIEF_FIELD(AVTP_CAN_BRIEF_FIELD_BRS);
+OPEN1722_INLINE bool Avtp_CanBrief_IsBrs(const Avtp_CanBrief_t *const pdu)
+{
+    return (bool)GET_CAN_BRIEF_FIELD(AVTP_CAN_BRIEF_FIELD_BRS);
 }
 
 /**
  * Return the value of an an ACF CAN Brief PDU FDF field as specified in the IEEE 1722 Specification.
- * 
+ *
  * @param pdu Pointer to the first bit of an 1722 ACF CAN Brief PDU.
  * @returns Value of the ACF CAN Brief PDU FDF field.
  */
-OPEN1722_INLINE uint8_t Avtp_CanBrief_GetFdf(const Avtp_CanBrief_t* const pdu) {
-    return (uint8_t) GET_CAN_BRIEF_FIELD(AVTP_CAN_BRIEF_FIELD_FDF);
+OPEN1722_INLINE bool Avtp_CanBrief_IsFdf(const Avtp_CanBrief_t *const pdu)
+{
+    return (bool)GET_CAN_BRIEF_FIELD(AVTP_CAN_BRIEF_FIELD_FDF);
 }
 
 /**
  * Return the value of an an ACF CAN Brief PDU ESI field as specified in the IEEE 1722 Specification.
- * 
+ *
  * @param pdu Pointer to the first bit of an 1722 ACF CAN Brief PDU.
  * @returns Value of the ACF CAN Brief PDU ESI field.
  */
-OPEN1722_INLINE uint8_t Avtp_CanBrief_GetEsi(const Avtp_CanBrief_t* const pdu) {
-    return (uint8_t) GET_CAN_BRIEF_FIELD(AVTP_CAN_BRIEF_FIELD_ESI);
+OPEN1722_INLINE bool Avtp_CanBrief_IsEsi(const Avtp_CanBrief_t *const pdu)
+{
+    return (bool)GET_CAN_BRIEF_FIELD(AVTP_CAN_BRIEF_FIELD_ESI);
 }
 
 /**
  * Return the value of an an ACF CAN Brief PDU CAN Bus ID field as specified in the IEEE 1722 Specification.
- * 
+ *
  * @param pdu Pointer to the first bit of an 1722 ACF CAN Brief PDU.
  * @returns Value of the ACF CAN Brief PDU CAN Bus ID field.
  */
-OPEN1722_INLINE uint8_t Avtp_CanBrief_GetCanBusId(const Avtp_CanBrief_t* const pdu) {
-    return (uint8_t) GET_CAN_BRIEF_FIELD(AVTP_CAN_BRIEF_FIELD_CAN_BUS_ID);
+OPEN1722_INLINE uint8_t Avtp_CanBrief_GetCanBusId(const Avtp_CanBrief_t *const pdu)
+{
+    return (uint8_t)GET_CAN_BRIEF_FIELD(AVTP_CAN_BRIEF_FIELD_CAN_BUS_ID);
 }
 
 /**
@@ -219,19 +233,9 @@ OPEN1722_INLINE uint8_t Avtp_CanBrief_GetCanBusId(const Avtp_CanBrief_t* const p
  * @param pdu Pointer to the first bit of an 1722 ACF CAN Brief PDU.
  * @returns Value of the ACF CAN Brief PDU CAN Identifier field.
  */
-OPEN1722_INLINE uint32_t Avtp_CanBrief_GetCanIdentifier(const Avtp_CanBrief_t* const pdu) {
-    return (uint32_t) GET_CAN_BRIEF_FIELD(AVTP_CAN_BRIEF_FIELD_CAN_IDENTIFIER);
-}
-
-/**
- * Sets the value of an an ACF Abbreviated CAN PDU field as specified in the IEEE 1722 Specification.
- *
- * @param pdu Pointer to the first bit of an 1722 ACF Abbreviated CAN PDU.
- * @param field Specifies the position of the data field to be read
- * @param value Pointer to location to store the value.
- */
-OPEN1722_INLINE void Avtp_CanBrief_SetField(Avtp_CanBrief_t* pdu, Avtp_CanBriefFields_t field, uint64_t value) {
-    SET_CAN_BRIEF_FIELD(field, value);
+OPEN1722_INLINE uint32_t Avtp_CanBrief_GetCanIdentifier(const Avtp_CanBrief_t *const pdu)
+{
+    return (uint32_t)GET_CAN_BRIEF_FIELD(AVTP_CAN_BRIEF_FIELD_CAN_IDENTIFIER);
 }
 
 /**
@@ -240,155 +244,121 @@ OPEN1722_INLINE void Avtp_CanBrief_SetField(Avtp_CanBrief_t* pdu, Avtp_CanBriefF
  * @param pdu Pointer to the first bit of an 1722 ACF CAN Brief PDU.
  * @param value Value to set the ACF message type field to.
  */
-OPEN1722_INLINE void Avtp_CanBrief_SetAcfMsgType(Avtp_CanBrief_t* pdu, uint8_t value) {
+OPEN1722_INLINE void Avtp_CanBrief_SetAcfMsgType(Avtp_CanBrief_t *pdu, uint8_t value)
+{
     SET_CAN_BRIEF_FIELD(AVTP_CAN_BRIEF_FIELD_ACF_MSG_TYPE, value);
 }
 
 /**
  * Set the value of an an ACF message length field as specified in the IEEE 1722 Specification.
+ * Note: the size is in Quadlets as specified in the IEEE 1722 Specification.
+ * You can use Avtp_CanBrief_SetPayloadLength to set length in bytes and automatically set the
+ * correct padding.
  *
  * @param pdu Pointer to the first bit of an 1722 ACF CAN Brief PDU.
  * @param value Value to set the ACF message length field to.
  */
-OPEN1722_INLINE void Avtp_CanBrief_SetAcfMsgLength(Avtp_CanBrief_t* pdu, uint16_t value) {
+OPEN1722_INLINE void Avtp_CanBrief_SetAcfMsgLength(Avtp_CanBrief_t *pdu, uint16_t value)
+{
     SET_CAN_BRIEF_FIELD(AVTP_CAN_BRIEF_FIELD_ACF_MSG_LENGTH, value);
 }
 
 /**
  * Set the value of an an ACF padding field as specified in the IEEE 1722 Specification.
- * 
+ *
  * @param pdu Pointer to the first bit of an 1722 ACF CAN Brief PDU.
  * @param value Value to set the ACF padding field to.
  */
-OPEN1722_INLINE void Avtp_CanBrief_SetPad(Avtp_CanBrief_t* pdu, uint8_t value) {
+OPEN1722_INLINE void Avtp_CanBrief_SetPad(Avtp_CanBrief_t *pdu, uint8_t value)
+{
     SET_CAN_BRIEF_FIELD(AVTP_CAN_BRIEF_FIELD_PAD, value);
 }
 
 /**
- * Enable the MTV bit in an ACF CAN Brief frame as specified in the IEEE 1722 Specification.
+ * Set the MTV bit in an ACF CAN Brief frame as specified in the IEEE 1722 Specification.
  *
  * @param pdu Pointer to the first bit of an 1722 ACF CAN Brief PDU.
+ * @param mtv Value to set the MTV bit to.
  */
-OPEN1722_INLINE void Avtp_CanBrief_EnableMtv(Avtp_CanBrief_t* pdu) {
-    SET_CAN_BRIEF_FIELD(AVTP_CAN_BRIEF_FIELD_MTV, 1);
+OPEN1722_INLINE void Avtp_CanBrief_SetMtv(Avtp_CanBrief_t *pdu, bool mtv)
+{
+    SET_CAN_BRIEF_FIELD(AVTP_CAN_BRIEF_FIELD_MTV, mtv);
 }
 
 /**
- * Disable the MTV bit in an ACF CAN Brief frame as specified in the IEEE 1722 Specification.
+ * Set the RTR bit in an ACF CAN Brief frame as specified in the IEEE 1722 Specification.
  *
  * @param pdu Pointer to the first bit of an 1722 ACF CAN Brief PDU.
+ * @param rtr Value to set the RTR bit to.
  */
-OPEN1722_INLINE void Avtp_CanBrief_DisableMtv(Avtp_CanBrief_t* pdu) {
-    SET_CAN_BRIEF_FIELD(AVTP_CAN_BRIEF_FIELD_MTV, 0);
+OPEN1722_INLINE void Avtp_CanBrief_SetRtr(Avtp_CanBrief_t *pdu, bool rtr)
+{
+    SET_CAN_BRIEF_FIELD(AVTP_CAN_BRIEF_FIELD_RTR, rtr);
 }
 
 /**
- * Enable the RTR bit in an ACF CAN Brief frame as specified in the IEEE 1722 Specification.
+ * Set the EFF bit in an ACF CAN Brief frame as specified in the IEEE 1722 Specification.
  *
  * @param pdu Pointer to the first bit of an 1722 ACF CAN Brief PDU.
+ * @param eff Value to set the EFF bit to.
  */
-OPEN1722_INLINE void Avtp_CanBrief_EnableRtr(Avtp_CanBrief_t* pdu) {
-    SET_CAN_BRIEF_FIELD(AVTP_CAN_BRIEF_FIELD_RTR, 1);
+OPEN1722_INLINE void Avtp_CanBrief_SetEff(Avtp_CanBrief_t *pdu, bool eff)
+{
+    SET_CAN_BRIEF_FIELD(AVTP_CAN_BRIEF_FIELD_EFF, eff);
 }
 
 /**
- * Disable the RTR bit in an ACF CAN Brief frame as specified in the IEEE 1722 Specification.
+ * Set the BRS bit in an ACF CAN Brief frame as specified in the IEEE 1722 Specification.
  *
  * @param pdu Pointer to the first bit of an 1722 ACF CAN Brief PDU.
+ * @param brs Value to set the BRS bit to.
  */
-OPEN1722_INLINE void Avtp_CanBrief_DisableRtr(Avtp_CanBrief_t* pdu) {
-    SET_CAN_BRIEF_FIELD(AVTP_CAN_BRIEF_FIELD_RTR, 0);
+OPEN1722_INLINE void Avtp_CanBrief_SetBrs(Avtp_CanBrief_t *pdu, bool brs)
+{
+    SET_CAN_BRIEF_FIELD(AVTP_CAN_BRIEF_FIELD_BRS, brs);
 }
 
 /**
- * Enable the EFF bit in an ACF CAN Brief frame as specified in the IEEE 1722 Specification.
+ * Set the FDF bit in an ACF CAN Brief frame as specified in the IEEE 1722 Specification.
  *
  * @param pdu Pointer to the first bit of an 1722 ACF CAN Brief PDU.
+ * @param fdf Value to set the FDF bit to.
  */
-OPEN1722_INLINE void Avtp_CanBrief_EnableEff(Avtp_CanBrief_t* pdu) {
-    SET_CAN_BRIEF_FIELD(AVTP_CAN_BRIEF_FIELD_EFF, 1);
+OPEN1722_INLINE void Avtp_CanBrief_SetFdf(Avtp_CanBrief_t *pdu, bool fdf)
+{
+    SET_CAN_BRIEF_FIELD(AVTP_CAN_BRIEF_FIELD_FDF, fdf);
 }
 
 /**
- * Disable the EFF bit in an ACF CAN Brief frame as specified in the IEEE 1722 Specification.
+ * Set the ESI bit in an ACF CAN Brief frame as specified in the IEEE 1722 Specification.
  *
  * @param pdu Pointer to the first bit of an 1722 ACF CAN Brief PDU.
+ * @param esi Value to set the ESI bit to.
  */
-OPEN1722_INLINE void Avtp_CanBrief_DisableEff(Avtp_CanBrief_t* pdu) {
-    SET_CAN_BRIEF_FIELD(AVTP_CAN_BRIEF_FIELD_EFF, 0);
-}
-
-/**
- * Enable the BRS bit in an ACF CAN Brief frame as specified in the IEEE 1722 Specification.
- *
- * @param pdu Pointer to the first bit of an 1722 ACF CAN Brief PDU.
- */
-OPEN1722_INLINE void Avtp_CanBrief_EnableBrs(Avtp_CanBrief_t* pdu) {
-    SET_CAN_BRIEF_FIELD(AVTP_CAN_BRIEF_FIELD_BRS, 1);
-}
-
-/**
- * Disable the BRS bit in an ACF CAN Brief frame as specified in the IEEE 1722 Specification.
- *
- * @param pdu Pointer to the first bit of an 1722 ACF CAN Brief PDU.
- */
-OPEN1722_INLINE void Avtp_CanBrief_DisableBrs(Avtp_CanBrief_t* pdu) {
-    SET_CAN_BRIEF_FIELD(AVTP_CAN_BRIEF_FIELD_BRS, 0);
-}
-
-/**
- * Enable the FDF bit in an ACF CAN Brief frame as specified in the IEEE 1722 Specification.
- * 
- * @param pdu Pointer to the first bit of an 1722 ACF CAN Brief PDU.
- */
-OPEN1722_INLINE void Avtp_CanBrief_EnableFdf(Avtp_CanBrief_t* pdu) {
-    SET_CAN_BRIEF_FIELD(AVTP_CAN_BRIEF_FIELD_FDF, 1);
-}
-
-/**
- * Disable the FDF bit in an ACF CAN Brief frame as specified in the IEEE 1722 Specification.
- * 
- * @param pdu Pointer to the first bit of an 1722 ACF CAN Brief PDU.
- */
-OPEN1722_INLINE void Avtp_CanBrief_DisableFdf(Avtp_CanBrief_t* pdu) {
-    SET_CAN_BRIEF_FIELD(AVTP_CAN_BRIEF_FIELD_FDF, 0);
-}
-
-/**
- * Enable the ESI bit in an ACF CAN Brief frame as specified in the IEEE 1722 Specification.
- * 
- * @param pdu Pointer to the first bit of an 1722 ACF CAN Brief PDU.
- */
-OPEN1722_INLINE void Avtp_CanBrief_EnableEsi(Avtp_CanBrief_t* pdu) {
-    SET_CAN_BRIEF_FIELD(AVTP_CAN_BRIEF_FIELD_ESI, 1);
-}
-
-/**
- * Disable the ESI bit in an ACF CAN Brief frame as specified in the IEEE 1722 Specification.
- * 
- * @param pdu Pointer to the first bit of an 1722 ACF CAN Brief PDU.
- */
-OPEN1722_INLINE void Avtp_CanBrief_DisableEsi(Avtp_CanBrief_t* pdu) {
-    SET_CAN_BRIEF_FIELD(AVTP_CAN_BRIEF_FIELD_ESI, 0);
+OPEN1722_INLINE void Avtp_CanBrief_SetEsi(Avtp_CanBrief_t *pdu, bool esi)
+{
+    SET_CAN_BRIEF_FIELD(AVTP_CAN_BRIEF_FIELD_ESI, esi);
 }
 
 /**
  * Set the value of an an ACF CAN Brief PDU CAN Bus ID field as specified in the IEEE 1722 Specification.
- * 
+ *
  * @param pdu Pointer to the first bit of an 1722 ACF CAN Brief PDU.
  * @param value Value to set the ACF CAN Brief PDU CAN Bus ID field to.
  */
-OPEN1722_INLINE void Avtp_CanBrief_SetCanBusId(Avtp_CanBrief_t* pdu, uint8_t value) {
+OPEN1722_INLINE void Avtp_CanBrief_SetCanBusId(Avtp_CanBrief_t *pdu, uint8_t value)
+{
     SET_CAN_BRIEF_FIELD(AVTP_CAN_BRIEF_FIELD_CAN_BUS_ID, value);
 }
 
 /**
  * Set the value of an an ACF CAN Brief PDU CAN Identifier field as specified in the IEEE 1722 Specification.
- * 
+ *
  * @param pdu Pointer to the first bit of an 1722 ACF CAN Brief PDU.
  * @param value Value to set the ACF CAN Brief PDU CAN Identifier field to.
  */
-OPEN1722_INLINE void Avtp_CanBrief_SetCanIdentifier(Avtp_CanBrief_t* pdu, uint32_t value) {
+OPEN1722_INLINE void Avtp_CanBrief_SetCanIdentifier(Avtp_CanBrief_t *pdu, uint32_t value)
+{
     SET_CAN_BRIEF_FIELD(AVTP_CAN_BRIEF_FIELD_CAN_IDENTIFIER, value);
 }
 
@@ -402,69 +372,92 @@ OPEN1722_INLINE void Avtp_CanBrief_SetCanIdentifier(Avtp_CanBrief_t* pdu, uint32
  * @param payload_length Length of the payload.
  * @param can_variant Classic CAN or CAN-FD
  */
-void Avtp_CanBrief_CreateAcfMessage(Avtp_CanBrief_t* can_pdu, uint32_t frame_id, uint8_t* payload,
-    uint16_t payload_length, Avtp_CanVariant_t can_variant);
+void Avtp_CanBrief_CreateAcfMessage(Avtp_CanBrief_t *can_pdu, uint32_t frame_id, uint8_t *payload,
+                                    uint16_t payload_length, Avtp_CanVariant_t can_variant);
 
 /**
-* Returns pointer to payload of an ACF CAN Brief frame.
-*
-* @param can_pdu Pointer to the first bit of an 1722 ACF CAN Brief PDU.
-* @return Pointer to ACF CAN Brief frame payload
-*/
-const uint8_t* Avtp_CanBrief_GetPayload(const Avtp_CanBrief_t* const can_pdu);
+ * Returns pointer to payload of an ACF CAN Brief frame.
+ *
+ * @param can_pdu Pointer to the first bit of an 1722 ACF CAN Brief PDU.
+ * @return Pointer to ACF CAN Brief frame payload
+ */
+OPEN1722_INLINE const uint8_t *Avtp_CanBrief_GetPayload(const Avtp_CanBrief_t *const can_pdu)
+{
+    return can_pdu->payload;
+}
 
 /**
-* Sets the CAN payload in an ACF CAN Brief frame.
-*
-* @param can_pdu Pointer to the first bit of an 1722 ACF CAN Brief PDU.
-* @param payload Pointer to the payload byte array
-* @param payload_length Length of the payload
-*/
-void Avtp_CanBrief_SetPayload(Avtp_CanBrief_t* can_pdu, uint8_t* payload,
-            uint16_t payload_length);
+ * Sets the CAN payload in an ACF CAN Brief frame.
+ *
+ * @param can_pdu Pointer to the first bit of an 1722 ACF CAN Brief PDU.
+ * @param payload Pointer to the payload byte array
+ * @param payload_length Length of the payload
+ */
+OPEN1722_INLINE void Avtp_CanBrief_SetPayload(Avtp_CanBrief_t *can_pdu, uint8_t *payload,
+                                              uint16_t payload_length)
+{
+    memcpy(can_pdu->payload, payload, payload_length);
+}
 
 /**
-* Finalizes the ACF CAN Brief frame. This function will set the
-* length and pad fields while inserting the padded bytes.
-*
-* @param can_pdu Pointer to the first bit of an 1722 ACF CAN Brief PDU.
-* @param payload Pointer to the payload byte array
-* @param payload_length Length of the CAN frame payload.
-*/
-void Avtp_CanBrief_Finalize(Avtp_CanBrief_t* can_pdu, uint16_t payload_length);
+ * Finalizes the ACF CAN Brief frame. This function will set the
+ * length and pad fields while inserting the padded bytes. This will also
+ * set padding bytes to zero if the payload length is not a multiple of 4.
+ * to avoid leaking information
+ *
+ * @param can_pdu Pointer to the first bit of an 1722 ACF CAN Brief PDU.
+ * @param payload_length Length of the CAN frame payload.
+ */
+OPEN1722_INLINE void Avtp_CanBrief_SetPayloadLength(Avtp_CanBrief_t *can_pdu, uint16_t payload_length)
+{
+    uint16_t msgLenBytes = AVTP_CAN_BRIEF_HEADER_LEN + payload_length;
+    uint8_t pad = (uint8_t)(4 - (msgLenBytes % 4)) % 4;
+    if (pad > 0) {
+        memset(can_pdu->payload + payload_length, 0, pad);
+    }
+    uint16_t msgLenQuadlets = (uint16_t)((msgLenBytes + pad) / 4);
+    Avtp_CanBrief_SetPad(can_pdu, pad);
+    Avtp_CanBrief_SetAcfMsgLength(can_pdu, msgLenQuadlets);
+}
 
 /**
-* Returns the length of the CAN payload without the padding bytes and the
-* header length of the encapsulating ACF Frame.
-*
-* Precondition: the caller must have validated the PDU with
-* Avtp_CanBrief_IsValid(). IsValid checks both buffer-size containment and
-* the CAN payload-length invariant (<= 8 bytes for classic CAN, <= 64
-* bytes for CAN-FD). This function performs no further bounds checking
-* and assumes those invariants already hold.
-*
-* @param pdu Pointer to the first bit of an 1722 ACF CAN Brief PDU.
-* @return  Length of CAN payload in bytes
-*/
-uint8_t Avtp_CanBrief_GetCanPayloadLength(const Avtp_CanBrief_t* const pdu);
+ * Returns the length of the CAN payload without the padding bytes and the
+ * header length of the encapsulating ACF Frame.
+ *
+ * Precondition: the caller must have validated the PDU with
+ * Avtp_CanBrief_IsValid(). IsValid checks both buffer-size containment and the
+ * CAN payload-length invariant (<= 8 bytes for classic CAN, <= 64 bytes
+ * for CAN-FD). This function performs no further bounds checking and
+ * assumes those invariants already hold.
+ *
+ * @param pdu Pointer to the first bit of an 1722 ACF CAN Brief PDU.
+ * @return  Length of CAN payload in bytes
+ */
+OPEN1722_INLINE uint8_t Avtp_CanBrief_GetPayloadLength(const Avtp_CanBrief_t *const pdu)
+{
+    uint8_t pad_length = Avtp_CanBrief_GetPad(pdu);
+    uint16_t acf_length_bytes = Avtp_CanBrief_GetAcfMsgLengthInBytes(pdu);
+    return (uint8_t)(acf_length_bytes - AVTP_CAN_BRIEF_HEADER_LEN - pad_length);
+}
 
 /**
  * Checks if the ACF CAN Brief frame is valid by checking:
- *     1) if the length field of AVTP/ACF messages contains a value larger than the actual size of the buffer that contains the AVTP message.
- *     2) if other format specific invariants are not upheld
+ *     1) if the length field of AVTP/ACF messages contains a value larger than the actual size of
+ * the buffer that contains the AVTP message. 2) if other format specific invariants are not upheld
  * @param pdu Pointer to the first bit of an 1722 ACF CAN Brief PDU.
  * @param bufferSize Size of the buffer containing the ACF CAN Brief frame.
  * @return true if the ACF CAN Brief frame is valid, false otherwise.
  */
-uint8_t Avtp_CanBrief_IsValid(const Avtp_CanBrief_t* const pdu, size_t bufferSize);
+bool Avtp_CanBrief_IsValid(const Avtp_CanBrief_t *const pdu, size_t bufferSize);
 
 /**
  * Initializes an ACF Abbreviated CAN PDU header as specified in the IEEE 1722 Specification.
  *
  * @param pdu Pointer to the first bit of a 1722 ACF Abbreviated CAN PDU.
  */
-OPEN1722_INLINE void Avtp_CanBrief_Init(Avtp_CanBrief_t* pdu) {
-    if(pdu != NULL) {
+OPEN1722_INLINE void Avtp_CanBrief_Init(Avtp_CanBrief_t *pdu)
+{
+    if (pdu != NULL) {
         memset(pdu, 0, sizeof(Avtp_CanBrief_t));
         Avtp_CanBrief_SetAcfMsgType(pdu, AVTP_ACF_TYPE_CAN_BRIEF);
     }

--- a/src/avtp/acf/CanBrief.c
+++ b/src/avtp/acf/CanBrief.c
@@ -27,100 +27,61 @@
  * SPDX-License-Identifier: BSD-3-Clause
  */
 
-#include <errno.h>
-
 #include "avtp/acf/CanBrief.h"
 
-void Avtp_CanBrief_CreateAcfMessage(Avtp_CanBrief_t* can_pdu, uint32_t frame_id, uint8_t* payload,
-    uint16_t payload_length, Avtp_CanVariant_t can_variant)
+void Avtp_CanBrief_CreateAcfMessage(Avtp_CanBrief_t *pdu, uint32_t frame_id, uint8_t *payload,
+                                    uint16_t payload_length, Avtp_CanVariant_t can_variant)
 {
     // Copy the payload into the CAN PDU
-    Avtp_CanBrief_SetPayload(can_pdu, payload, payload_length);
+    Avtp_CanBrief_SetPayload(pdu, payload, payload_length);
 
     // Set the Frame ID and CAN variant
     if (frame_id > 0x7ff) {
-        Avtp_CanBrief_EnableEff(can_pdu);
+        Avtp_CanBrief_SetEff(pdu, true);
     }
 
-    Avtp_CanBrief_SetCanIdentifier(can_pdu, frame_id);
+    Avtp_CanBrief_SetCanIdentifier(pdu, frame_id);
     if (can_variant == AVTP_CAN_FD) {
-        Avtp_CanBrief_EnableFdf(can_pdu);
+        Avtp_CanBrief_SetFdf(pdu, true);
     }
 
     // Finalize the AVTP CAN Frame
-    Avtp_CanBrief_Finalize(can_pdu, payload_length);
+    Avtp_CanBrief_SetPayloadLength(pdu, payload_length);
 }
 
-void Avtp_CanBrief_SetPayload(Avtp_CanBrief_t* can_pdu, uint8_t* payload,
-    uint16_t payload_length)
-{
-    memcpy(can_pdu->payload, payload, payload_length);
-}
-
-void Avtp_CanBrief_Finalize(Avtp_CanBrief_t* can_pdu, uint16_t payload_length)
-{
-    uint8_t padSize;
-    uint32_t avtpCanLength = AVTP_CAN_BRIEF_HEADER_LEN + payload_length;
-
-    // Check if padding is required
-    padSize = AVTP_QUADLET_SIZE - (payload_length % AVTP_QUADLET_SIZE);
-    if (payload_length % AVTP_QUADLET_SIZE) {
-        memset(can_pdu->payload + payload_length, 0, padSize);
-        avtpCanLength += padSize;
-    }
-
-    // Set the length and padding fields
-    Avtp_CanBrief_SetAcfMsgLength(can_pdu, (uint16_t) avtpCanLength/AVTP_QUADLET_SIZE);
-    Avtp_CanBrief_SetPad(can_pdu, padSize);
-}
-
-const uint8_t* Avtp_CanBrief_GetPayload(const Avtp_CanBrief_t* const can_pdu) {
-    return can_pdu->payload;
-}
-
-uint8_t Avtp_CanBrief_GetCanPayloadLength(const Avtp_CanBrief_t* const pdu) {
-    /* Precondition: caller has validated the PDU via Avtp_CanBrief_IsValid().
-     * See Avtp_Can_GetCanPayloadLength in Can.c for the same shape. */
-    uint16_t msg_length_bytes = (uint16_t)Avtp_CanBrief_GetAcfMsgLength(pdu) * 4;
-    uint8_t  pad_length       = Avtp_CanBrief_GetPad(pdu);
-    return (uint8_t)(msg_length_bytes - AVTP_CAN_BRIEF_HEADER_LEN - pad_length);
-}
-
-uint8_t Avtp_CanBrief_IsValid(const Avtp_CanBrief_t* const pdu, size_t bufferSize)
+bool Avtp_CanBrief_IsValid(const Avtp_CanBrief_t *const pdu, size_t bufferSize)
 {
     if (pdu == NULL) {
-        return FALSE;
+        return false;
     }
 
     if (bufferSize < AVTP_CAN_BRIEF_HEADER_LEN) {
-        return FALSE;
+        return false;
     }
 
     if (Avtp_CanBrief_GetAcfMsgType(pdu) != AVTP_ACF_TYPE_CAN_BRIEF) {
-        return FALSE;
+        return false;
     }
 
     // Avtp_CanBrief_GetAcfMsgLength returns quadlets. Convert the length field to octets.
     uint16_t msg_length_bytes = (uint16_t)Avtp_CanBrief_GetAcfMsgLength(pdu) * 4;
     if (msg_length_bytes > bufferSize) {
-        return FALSE;
+        return false;
     }
 
     /* CAN payload-length invariant: classic CAN ≤ 8 bytes, CAN-FD ≤ 64
      * bytes (selected by the FDF bit). The encoded message length must
      * also accommodate header + declared padding so the payload
-     * computation in Avtp_CanBrief_GetCanPayloadLength() doesn't
-     * underflow. */
-    uint8_t  pad_length     = Avtp_CanBrief_GetPad(pdu);
+     * computation in Avtp_CanBrief_GetPayloadLength() doesn't underflow. */
+    uint8_t pad_length = Avtp_CanBrief_GetPad(pdu);
     uint16_t header_and_pad = (uint16_t)AVTP_CAN_BRIEF_HEADER_LEN + pad_length;
     if (msg_length_bytes < header_and_pad) {
-        return FALSE;
+        return false;
     }
     uint16_t payload_length = msg_length_bytes - header_and_pad;
-    uint16_t max_payload    = Avtp_CanBrief_GetFdf(pdu) ? 64u : 8u;
+    uint16_t max_payload = Avtp_CanBrief_IsFdf(pdu) ? 64u : 8u;
     if (payload_length > max_payload) {
-        return FALSE;
+        return false;
     }
-
-    return TRUE;
+    return true;
 }

--- a/unit/test-can.c
+++ b/unit/test-can.c
@@ -46,10 +46,11 @@ extern "C" {
 #include "avtp/acf/Can.h"
 #include "avtp/acf/CanBrief.h"
 
-#define MAX_PDU_SIZE        1500
-#define CAN_PAYLOAD_SIZE    8
+#define MAX_PDU_SIZE 1500
+#define CAN_PAYLOAD_SIZE 8
 
-static void can_init(void **state) {
+static void can_init(void **state)
+{
 
     uint8_t pdu[MAX_PDU_SIZE];
     uint8_t init_pdu[AVTP_CAN_HEADER_LEN];
@@ -58,13 +59,14 @@ static void can_init(void **state) {
     Avtp_Can_Init(NULL);
 
     // Check if the function is initializing properly
-    Avtp_Can_Init((Avtp_Can_t*)pdu);
+    Avtp_Can_Init((Avtp_Can_t *)pdu);
     memset(init_pdu, 0, AVTP_CAN_HEADER_LEN);
     init_pdu[0] = AVTP_ACF_TYPE_CAN << 1; // Setting ACF type as ACF_CAN
     assert_memory_equal(init_pdu, pdu, AVTP_CAN_HEADER_LEN);
 }
 
-static void can_brief_init(void **state) {
+static void can_brief_init(void **state)
+{
 
     uint8_t pdu[MAX_PDU_SIZE];
     uint8_t init_pdu[AVTP_CAN_BRIEF_HEADER_LEN];
@@ -73,56 +75,58 @@ static void can_brief_init(void **state) {
     Avtp_CanBrief_Init(NULL);
 
     // Check if the function is initializing properly
-    Avtp_CanBrief_Init((Avtp_CanBrief_t*)pdu);
+    Avtp_CanBrief_Init((Avtp_CanBrief_t *)pdu);
     memset(init_pdu, 0, AVTP_CAN_BRIEF_HEADER_LEN);
     init_pdu[0] = 0x04; // Setting ACF type as ACF_CAN
     assert_memory_equal(init_pdu, pdu, AVTP_CAN_BRIEF_HEADER_LEN);
 }
 
-static void can_set_payload(void **state) {
+static void can_set_payload(void **state)
+{
 
     uint8_t pdu[MAX_PDU_SIZE];
     uint32_t set_frame_id = 0x7ff;
-    uint8_t set_payload[CAN_PAYLOAD_SIZE] = {0,1,2,3,4,5,6,7};
+    uint8_t set_payload[CAN_PAYLOAD_SIZE] = {0, 1, 2, 3, 4, 5, 6, 7};
 
     // Initialize PDU
-    Avtp_Can_Init((Avtp_Can_t*)pdu);
+    Avtp_Can_Init((Avtp_Can_t *)pdu);
 
     // Set payload and check for EFF
-    Avtp_Can_CreateAcfMessage((Avtp_Can_t*)pdu, set_frame_id, set_payload,
-                        CAN_PAYLOAD_SIZE, AVTP_CAN_CLASSIC);
-    assert_int_equal(htonl(set_frame_id), (uint32_t) *((int*)pdu+3));
-    assert_memory_equal(set_payload, pdu+16, CAN_PAYLOAD_SIZE);
-    assert_int_equal(0x0, *(pdu+2)&0x08);    // Check EFF
+    Avtp_Can_CreateAcfMessage((Avtp_Can_t *)pdu, set_frame_id, set_payload, CAN_PAYLOAD_SIZE,
+                              AVTP_CAN_CLASSIC);
+    assert_int_equal(htonl(set_frame_id), (uint32_t) * ((int *)pdu + 3));
+    assert_memory_equal(set_payload, pdu + 16, CAN_PAYLOAD_SIZE);
+    assert_int_equal(0x0, *(pdu + 2) & 0x08); // Check EFF
 
     // Check EFF for extended Frame IDs
     set_frame_id = 0x800;
-    Avtp_Can_CreateAcfMessage((Avtp_Can_t*)pdu, set_frame_id, set_payload,
-                        CAN_PAYLOAD_SIZE, AVTP_CAN_CLASSIC);
-    assert_int_equal(htonl(set_frame_id), (uint32_t) *((int*)pdu+3));
-    assert_int_equal(0x8, *(pdu+2)&0x08);    // Check EFF
+    Avtp_Can_CreateAcfMessage((Avtp_Can_t *)pdu, set_frame_id, set_payload, CAN_PAYLOAD_SIZE,
+                              AVTP_CAN_CLASSIC);
+    assert_int_equal(htonl(set_frame_id), (uint32_t) * ((int *)pdu + 3));
+    assert_int_equal(0x8, *(pdu + 2) & 0x08); // Check EFF
 
     // Check padding bytes and length field
     uint8_t zero_array[CAN_PAYLOAD_SIZE] = {0, 0, 0, 0, 0, 0, 0, 0};
-    for (int i=0; i<CAN_PAYLOAD_SIZE; i++) {
+    for (int i = 0; i < CAN_PAYLOAD_SIZE; i++) {
         memset(pdu, 0, MAX_PDU_SIZE);
-        Avtp_Can_Init((Avtp_Can_t*)pdu);
-        Avtp_Can_CreateAcfMessage((Avtp_Can_t*)pdu, set_frame_id, set_payload,
-                        i, AVTP_CAN_CLASSIC);
-        assert_memory_equal(set_payload, pdu+16, i);
-        assert_memory_equal(zero_array, pdu+16+i, CAN_PAYLOAD_SIZE-i);
+        Avtp_Can_Init((Avtp_Can_t *)pdu);
+        Avtp_Can_CreateAcfMessage((Avtp_Can_t *)pdu, set_frame_id, set_payload, i,
+                                  AVTP_CAN_CLASSIC);
+        assert_memory_equal(set_payload, pdu + 16, i);
+        assert_memory_equal(zero_array, pdu + 16 + i, CAN_PAYLOAD_SIZE - i);
 
         // Padding tests
-        uint8_t pad = *(pdu+2) & 0xc0;
-        assert_int_equal(pad>>6, (4 - i%4)&0x3);
+        uint8_t pad = *(pdu + 2) & 0xc0;
+        assert_int_equal(pad >> 6, (4 - i % 4) & 0x3);
 
         // Length tests
-        uint8_t length = *(pdu+1);
-        assert_int_equal(length, (4+ceil(i/4.0)));
+        uint8_t length = *(pdu + 1);
+        assert_int_equal(length, (4 + ceil(i / 4.0)));
     }
 }
 
-static void can_is_valid(void **state) {
+static void can_is_valid(void **state)
+{
 
     uint8_t pdu[MAX_PDU_SIZE];
     uint32_t frame_id = 0x123;
@@ -130,33 +134,33 @@ static void can_is_valid(void **state) {
     // An Init-only PDU has AcfMsgLength == 0 — i.e. it declares a frame
     // shorter than its own header. Per IEEE 1722 ACF wire format that is
     // not a valid frame, so IsValid must reject it.
-    Avtp_Can_Init((Avtp_Can_t*)pdu);
-    assert_int_equal(Avtp_Can_IsValid((Avtp_Can_t*)pdu, MAX_PDU_SIZE), 0);
+    Avtp_Can_Init((Avtp_Can_t *)pdu);
+    assert_int_equal(Avtp_Can_IsValid((Avtp_Can_t *)pdu, MAX_PDU_SIZE), 0);
 
     // A properly-formed classic CAN frame with an 8-byte payload (the
     // classic-CAN max) is valid.
     {
-        uint8_t payload[8] = {0,1,2,3,4,5,6,7};
-        Avtp_Can_Init((Avtp_Can_t*)pdu);
-        Avtp_Can_CreateAcfMessage((Avtp_Can_t*)pdu, frame_id, payload,
-                                  sizeof(payload), AVTP_CAN_CLASSIC);
-        assert_int_equal(Avtp_Can_IsValid((Avtp_Can_t*)pdu, MAX_PDU_SIZE), 1);
+        uint8_t payload[8] = {0, 1, 2, 3, 4, 5, 6, 7};
+        Avtp_Can_Init((Avtp_Can_t *)pdu);
+        Avtp_Can_CreateAcfMessage((Avtp_Can_t *)pdu, frame_id, payload, sizeof(payload),
+                                  AVTP_CAN_CLASSIC);
+        assert_int_equal(Avtp_Can_IsValid((Avtp_Can_t *)pdu, MAX_PDU_SIZE), 1);
     }
 
     // Not an IEEE 1722 ACF-CAN message (zero buffer, AcfMsgType != CAN).
     memset(pdu, 0, MAX_PDU_SIZE);
-    assert_int_equal(Avtp_Can_IsValid((Avtp_Can_t*)pdu, MAX_PDU_SIZE), 0);
+    assert_int_equal(Avtp_Can_IsValid((Avtp_Can_t *)pdu, MAX_PDU_SIZE), 0);
 
     // Valid IEEE 1722 CAN Frame (Length 24, Buffer 25). AcfMsgLength=6
     // quadlets = 24 bytes; payload = 24 - 16 header = 8 bytes (classic max).
-    Avtp_Can_Init((Avtp_Can_t*)pdu);
-    Avtp_Can_SetAcfMsgLength((Avtp_Can_t*)pdu, 6);
-    assert_int_equal(Avtp_Can_IsValid((Avtp_Can_t*)pdu, 25), 1);
+    Avtp_Can_Init((Avtp_Can_t *)pdu);
+    Avtp_Can_SetAcfMsgLength((Avtp_Can_t *)pdu, 6);
+    assert_int_equal(Avtp_Can_IsValid((Avtp_Can_t *)pdu, 25), 1);
 
     // Invalid IEEE 1722 CAN Frame (Length 24 but buffer only 9!).
-    Avtp_Can_Init((Avtp_Can_t*)pdu);
-    Avtp_Can_SetAcfMsgLength((Avtp_Can_t*)pdu, 6);
-    assert_int_equal(Avtp_Can_IsValid((Avtp_Can_t*)pdu, 9), 0);
+    Avtp_Can_Init((Avtp_Can_t *)pdu);
+    Avtp_Can_SetAcfMsgLength((Avtp_Can_t *)pdu, 6);
+    assert_int_equal(Avtp_Can_IsValid((Avtp_Can_t *)pdu, 9), 0);
 
     // Classic CAN payload bound: a frame declaring a 12-byte payload as
     // classic CAN is invalid (classic tops out at 8). Constructed by
@@ -164,74 +168,74 @@ static void can_is_valid(void **state) {
     // frame as classic — the wire encoding succeeds but IsValid rejects.
     {
         uint8_t too_big[12] = {0};
-        Avtp_Can_Init((Avtp_Can_t*)pdu);
-        Avtp_Can_CreateAcfMessage((Avtp_Can_t*)pdu, frame_id, too_big,
-                                  sizeof(too_big), AVTP_CAN_CLASSIC);
-        assert_int_equal(Avtp_Can_IsValid((Avtp_Can_t*)pdu, MAX_PDU_SIZE), 0);
+        Avtp_Can_Init((Avtp_Can_t *)pdu);
+        Avtp_Can_CreateAcfMessage((Avtp_Can_t *)pdu, frame_id, too_big, sizeof(too_big),
+                                  AVTP_CAN_CLASSIC);
+        assert_int_equal(Avtp_Can_IsValid((Avtp_Can_t *)pdu, MAX_PDU_SIZE), 0);
     }
 
     // CAN-FD payload bound: 64 bytes is at the FD limit (valid); 68 bytes
     // exceeds it (invalid).
     {
         uint8_t fd_max[64] = {0};
-        Avtp_Can_Init((Avtp_Can_t*)pdu);
-        Avtp_Can_CreateAcfMessage((Avtp_Can_t*)pdu, frame_id, fd_max,
-                                  sizeof(fd_max), AVTP_CAN_FD);
-        assert_int_equal(Avtp_Can_IsValid((Avtp_Can_t*)pdu, MAX_PDU_SIZE), 1);
+        Avtp_Can_Init((Avtp_Can_t *)pdu);
+        Avtp_Can_CreateAcfMessage((Avtp_Can_t *)pdu, frame_id, fd_max, sizeof(fd_max), AVTP_CAN_FD);
+        assert_int_equal(Avtp_Can_IsValid((Avtp_Can_t *)pdu, MAX_PDU_SIZE), 1);
     }
     {
         uint8_t fd_too_big[68] = {0};
-        Avtp_Can_Init((Avtp_Can_t*)pdu);
-        Avtp_Can_CreateAcfMessage((Avtp_Can_t*)pdu, frame_id, fd_too_big,
-                                  sizeof(fd_too_big), AVTP_CAN_FD);
-        assert_int_equal(Avtp_Can_IsValid((Avtp_Can_t*)pdu, MAX_PDU_SIZE), 0);
+        Avtp_Can_Init((Avtp_Can_t *)pdu);
+        Avtp_Can_CreateAcfMessage((Avtp_Can_t *)pdu, frame_id, fd_too_big, sizeof(fd_too_big),
+                                  AVTP_CAN_FD);
+        assert_int_equal(Avtp_Can_IsValid((Avtp_Can_t *)pdu, MAX_PDU_SIZE), 0);
     }
 }
 
-static void can_brief_set_payload(void **state) {
+static void can_brief_set_payload(void **state)
+{
 
     uint8_t pdu[MAX_PDU_SIZE];
     uint32_t set_frame_id = 0x7ff;
-    uint8_t set_payload[CAN_PAYLOAD_SIZE] = {0,1,2,3,4,5,6,7};
+    uint8_t set_payload[CAN_PAYLOAD_SIZE] = {0, 1, 2, 3, 4, 5, 6, 7};
 
     // Initialize PDU
-    Avtp_CanBrief_Init((Avtp_CanBrief_t*)pdu);
+    Avtp_CanBrief_Init((Avtp_CanBrief_t *)pdu);
 
     // Set payload and check for EFF
-    Avtp_CanBrief_CreateAcfMessage((Avtp_CanBrief_t*)pdu, set_frame_id, set_payload,
+    Avtp_CanBrief_CreateAcfMessage((Avtp_CanBrief_t *)pdu, set_frame_id, set_payload,
                                    CAN_PAYLOAD_SIZE, AVTP_CAN_CLASSIC);
-    assert_int_equal(Avtp_CanBrief_GetCanIdentifier((Avtp_CanBrief_t*)pdu), set_frame_id);
-    assert_int_equal(Avtp_CanBrief_IsEff((Avtp_CanBrief_t*)pdu), 0);
+    assert_int_equal(Avtp_CanBrief_GetCanIdentifier((Avtp_CanBrief_t *)pdu), set_frame_id);
+    assert_int_equal(Avtp_CanBrief_IsEff((Avtp_CanBrief_t *)pdu), 0);
     assert_memory_equal(set_payload, pdu + AVTP_CAN_BRIEF_HEADER_LEN, CAN_PAYLOAD_SIZE);
-    assert_int_equal(Avtp_CanBrief_GetPayloadLength((Avtp_CanBrief_t*)pdu), CAN_PAYLOAD_SIZE);
+    assert_int_equal(Avtp_CanBrief_GetPayloadLength((Avtp_CanBrief_t *)pdu), CAN_PAYLOAD_SIZE);
 
     // Check EFF for extended Frame IDs
     set_frame_id = 0x800;
-    Avtp_CanBrief_CreateAcfMessage((Avtp_CanBrief_t*)pdu, set_frame_id, set_payload,
+    Avtp_CanBrief_CreateAcfMessage((Avtp_CanBrief_t *)pdu, set_frame_id, set_payload,
                                    CAN_PAYLOAD_SIZE, AVTP_CAN_CLASSIC);
-    assert_int_equal(Avtp_CanBrief_GetCanIdentifier((Avtp_CanBrief_t*)pdu), set_frame_id);
-    assert_int_equal(Avtp_CanBrief_IsEff((Avtp_CanBrief_t*)pdu), 1);
+    assert_int_equal(Avtp_CanBrief_GetCanIdentifier((Avtp_CanBrief_t *)pdu), set_frame_id);
+    assert_int_equal(Avtp_CanBrief_IsEff((Avtp_CanBrief_t *)pdu), 1);
 
     // Check padding bytes and length field
     uint8_t zero_array[CAN_PAYLOAD_SIZE] = {0, 0, 0, 0, 0, 0, 0, 0};
-    for (int i=0; i<CAN_PAYLOAD_SIZE; i++) {
+    for (int i = 0; i < CAN_PAYLOAD_SIZE; i++) {
         memset(pdu, 0, MAX_PDU_SIZE);
-        Avtp_CanBrief_Init((Avtp_CanBrief_t*)pdu);
-        Avtp_CanBrief_CreateAcfMessage((Avtp_CanBrief_t*)pdu, set_frame_id, set_payload,
-                                       i, AVTP_CAN_CLASSIC);
+        Avtp_CanBrief_Init((Avtp_CanBrief_t *)pdu);
+        Avtp_CanBrief_CreateAcfMessage((Avtp_CanBrief_t *)pdu, set_frame_id, set_payload, i,
+                                       AVTP_CAN_CLASSIC);
         assert_memory_equal(set_payload, pdu + AVTP_CAN_BRIEF_HEADER_LEN, i);
-        assert_memory_equal(zero_array, pdu + AVTP_CAN_BRIEF_HEADER_LEN + i,
-                            CAN_PAYLOAD_SIZE - i);
+        assert_memory_equal(zero_array, pdu + AVTP_CAN_BRIEF_HEADER_LEN + i, CAN_PAYLOAD_SIZE - i);
 
         uint16_t msgLenBytes = AVTP_CAN_BRIEF_HEADER_LEN + i;
         uint8_t pad = (uint8_t)(4 - (msgLenBytes % 4)) % 4;
-        assert_int_equal(Avtp_CanBrief_GetPad((Avtp_CanBrief_t*)pdu), pad);
-        assert_int_equal(Avtp_CanBrief_GetAcfMsgLength((Avtp_CanBrief_t*)pdu),
+        assert_int_equal(Avtp_CanBrief_GetPad((Avtp_CanBrief_t *)pdu), pad);
+        assert_int_equal(Avtp_CanBrief_GetAcfMsgLength((Avtp_CanBrief_t *)pdu),
                          (msgLenBytes + pad) / 4);
     }
 }
 
-static void can_brief_is_valid(void **state) {
+static void can_brief_is_valid(void **state)
+{
 
     uint8_t pdu[MAX_PDU_SIZE];
     uint32_t frame_id = 0x123;
@@ -239,72 +243,70 @@ static void can_brief_is_valid(void **state) {
     // An Init-only PDU has AcfMsgLength == 0 — i.e. it declares a frame
     // shorter than its own header. Per IEEE 1722 ACF wire format that is
     // not a valid frame, so IsValid must reject it.
-    Avtp_CanBrief_Init((Avtp_CanBrief_t*)pdu);
-    assert_int_equal(Avtp_CanBrief_IsValid((Avtp_CanBrief_t*)pdu, MAX_PDU_SIZE), 0);
+    Avtp_CanBrief_Init((Avtp_CanBrief_t *)pdu);
+    assert_int_equal(Avtp_CanBrief_IsValid((Avtp_CanBrief_t *)pdu, MAX_PDU_SIZE), 0);
 
     // A properly-formed classic CAN frame with an 8-byte payload (the
     // classic-CAN max) is valid.
     {
-        uint8_t payload[8] = {0,1,2,3,4,5,6,7};
-        Avtp_CanBrief_Init((Avtp_CanBrief_t*)pdu);
-        Avtp_CanBrief_CreateAcfMessage((Avtp_CanBrief_t*)pdu, frame_id, payload,
-                                       sizeof(payload), AVTP_CAN_CLASSIC);
-        assert_int_equal(Avtp_CanBrief_IsValid((Avtp_CanBrief_t*)pdu, MAX_PDU_SIZE), 1);
+        uint8_t payload[8] = {0, 1, 2, 3, 4, 5, 6, 7};
+        Avtp_CanBrief_Init((Avtp_CanBrief_t *)pdu);
+        Avtp_CanBrief_CreateAcfMessage((Avtp_CanBrief_t *)pdu, frame_id, payload, sizeof(payload),
+                                       AVTP_CAN_CLASSIC);
+        assert_int_equal(Avtp_CanBrief_IsValid((Avtp_CanBrief_t *)pdu, MAX_PDU_SIZE), 1);
     }
 
     // Not an IEEE 1722 ACF-CAN Brief message (zero buffer, AcfMsgType != CAN_BRIEF).
     memset(pdu, 0, MAX_PDU_SIZE);
-    assert_int_equal(Avtp_CanBrief_IsValid((Avtp_CanBrief_t*)pdu, MAX_PDU_SIZE), 0);
+    assert_int_equal(Avtp_CanBrief_IsValid((Avtp_CanBrief_t *)pdu, MAX_PDU_SIZE), 0);
 
     // Valid IEEE 1722 CAN Brief Frame (Length 16, Buffer 17). AcfMsgLength=4
     // quadlets = 16 bytes; payload = 16 - 8 header = 8 bytes (classic max).
-    Avtp_CanBrief_Init((Avtp_CanBrief_t*)pdu);
-    Avtp_CanBrief_SetAcfMsgLength((Avtp_CanBrief_t*)pdu, 4);
-    assert_int_equal(Avtp_CanBrief_IsValid((Avtp_CanBrief_t*)pdu, 17), 1);
+    Avtp_CanBrief_Init((Avtp_CanBrief_t *)pdu);
+    Avtp_CanBrief_SetAcfMsgLength((Avtp_CanBrief_t *)pdu, 4);
+    assert_int_equal(Avtp_CanBrief_IsValid((Avtp_CanBrief_t *)pdu, 17), 1);
 
     // Invalid IEEE 1722 CAN Brief Frame (Length 16 but buffer only 9!).
-    Avtp_CanBrief_Init((Avtp_CanBrief_t*)pdu);
-    Avtp_CanBrief_SetAcfMsgLength((Avtp_CanBrief_t*)pdu, 4);
-    assert_int_equal(Avtp_CanBrief_IsValid((Avtp_CanBrief_t*)pdu, 9), 0);
+    Avtp_CanBrief_Init((Avtp_CanBrief_t *)pdu);
+    Avtp_CanBrief_SetAcfMsgLength((Avtp_CanBrief_t *)pdu, 4);
+    assert_int_equal(Avtp_CanBrief_IsValid((Avtp_CanBrief_t *)pdu, 9), 0);
 
     // Classic CAN payload bound: a frame declaring a 12-byte payload as
     // classic CAN is invalid (classic tops out at 8).
     {
         uint8_t too_big[12] = {0};
-        Avtp_CanBrief_Init((Avtp_CanBrief_t*)pdu);
-        Avtp_CanBrief_CreateAcfMessage((Avtp_CanBrief_t*)pdu, frame_id, too_big,
-                                       sizeof(too_big), AVTP_CAN_CLASSIC);
-        assert_int_equal(Avtp_CanBrief_IsValid((Avtp_CanBrief_t*)pdu, MAX_PDU_SIZE), 0);
+        Avtp_CanBrief_Init((Avtp_CanBrief_t *)pdu);
+        Avtp_CanBrief_CreateAcfMessage((Avtp_CanBrief_t *)pdu, frame_id, too_big, sizeof(too_big),
+                                       AVTP_CAN_CLASSIC);
+        assert_int_equal(Avtp_CanBrief_IsValid((Avtp_CanBrief_t *)pdu, MAX_PDU_SIZE), 0);
     }
 
     // CAN-FD payload bound: 64 bytes is at the FD limit (valid); 68 bytes
     // exceeds it (invalid).
     {
         uint8_t fd_max[64] = {0};
-        Avtp_CanBrief_Init((Avtp_CanBrief_t*)pdu);
-        Avtp_CanBrief_CreateAcfMessage((Avtp_CanBrief_t*)pdu, frame_id, fd_max,
-                                       sizeof(fd_max), AVTP_CAN_FD);
-        assert_int_equal(Avtp_CanBrief_IsValid((Avtp_CanBrief_t*)pdu, MAX_PDU_SIZE), 1);
+        Avtp_CanBrief_Init((Avtp_CanBrief_t *)pdu);
+        Avtp_CanBrief_CreateAcfMessage((Avtp_CanBrief_t *)pdu, frame_id, fd_max, sizeof(fd_max),
+                                       AVTP_CAN_FD);
+        assert_int_equal(Avtp_CanBrief_IsValid((Avtp_CanBrief_t *)pdu, MAX_PDU_SIZE), 1);
     }
     {
         uint8_t fd_too_big[68] = {0};
-        Avtp_CanBrief_Init((Avtp_CanBrief_t*)pdu);
-        Avtp_CanBrief_CreateAcfMessage((Avtp_CanBrief_t*)pdu, frame_id, fd_too_big,
+        Avtp_CanBrief_Init((Avtp_CanBrief_t *)pdu);
+        Avtp_CanBrief_CreateAcfMessage((Avtp_CanBrief_t *)pdu, frame_id, fd_too_big,
                                        sizeof(fd_too_big), AVTP_CAN_FD);
-        assert_int_equal(Avtp_CanBrief_IsValid((Avtp_CanBrief_t*)pdu, MAX_PDU_SIZE), 0);
+        assert_int_equal(Avtp_CanBrief_IsValid((Avtp_CanBrief_t *)pdu, MAX_PDU_SIZE), 0);
     }
 }
 
 int main(void)
 {
-    const struct CMUnitTest tests[] = {
-        cmocka_unit_test(can_init),
-        cmocka_unit_test(can_brief_init),
-        cmocka_unit_test(can_set_payload),
-        cmocka_unit_test(can_is_valid),
-        cmocka_unit_test(can_brief_set_payload),
-        cmocka_unit_test(can_brief_is_valid)
-    };
+    const struct CMUnitTest tests[] = {cmocka_unit_test(can_init),
+                                       cmocka_unit_test(can_brief_init),
+                                       cmocka_unit_test(can_set_payload),
+                                       cmocka_unit_test(can_is_valid),
+                                       cmocka_unit_test(can_brief_set_payload),
+                                       cmocka_unit_test(can_brief_is_valid)};
 
     return cmocka_run_group_tests(tests, NULL, NULL);
 }

--- a/unit/test-can.c
+++ b/unit/test-can.c
@@ -188,13 +188,122 @@ static void can_is_valid(void **state) {
     }
 }
 
+static void can_brief_set_payload(void **state) {
+
+    uint8_t pdu[MAX_PDU_SIZE];
+    uint32_t set_frame_id = 0x7ff;
+    uint8_t set_payload[CAN_PAYLOAD_SIZE] = {0,1,2,3,4,5,6,7};
+
+    // Initialize PDU
+    Avtp_CanBrief_Init((Avtp_CanBrief_t*)pdu);
+
+    // Set payload and check for EFF
+    Avtp_CanBrief_CreateAcfMessage((Avtp_CanBrief_t*)pdu, set_frame_id, set_payload,
+                                   CAN_PAYLOAD_SIZE, AVTP_CAN_CLASSIC);
+    assert_int_equal(Avtp_CanBrief_GetCanIdentifier((Avtp_CanBrief_t*)pdu), set_frame_id);
+    assert_int_equal(Avtp_CanBrief_IsEff((Avtp_CanBrief_t*)pdu), 0);
+    assert_memory_equal(set_payload, pdu + AVTP_CAN_BRIEF_HEADER_LEN, CAN_PAYLOAD_SIZE);
+    assert_int_equal(Avtp_CanBrief_GetPayloadLength((Avtp_CanBrief_t*)pdu), CAN_PAYLOAD_SIZE);
+
+    // Check EFF for extended Frame IDs
+    set_frame_id = 0x800;
+    Avtp_CanBrief_CreateAcfMessage((Avtp_CanBrief_t*)pdu, set_frame_id, set_payload,
+                                   CAN_PAYLOAD_SIZE, AVTP_CAN_CLASSIC);
+    assert_int_equal(Avtp_CanBrief_GetCanIdentifier((Avtp_CanBrief_t*)pdu), set_frame_id);
+    assert_int_equal(Avtp_CanBrief_IsEff((Avtp_CanBrief_t*)pdu), 1);
+
+    // Check padding bytes and length field
+    uint8_t zero_array[CAN_PAYLOAD_SIZE] = {0, 0, 0, 0, 0, 0, 0, 0};
+    for (int i=0; i<CAN_PAYLOAD_SIZE; i++) {
+        memset(pdu, 0, MAX_PDU_SIZE);
+        Avtp_CanBrief_Init((Avtp_CanBrief_t*)pdu);
+        Avtp_CanBrief_CreateAcfMessage((Avtp_CanBrief_t*)pdu, set_frame_id, set_payload,
+                                       i, AVTP_CAN_CLASSIC);
+        assert_memory_equal(set_payload, pdu + AVTP_CAN_BRIEF_HEADER_LEN, i);
+        assert_memory_equal(zero_array, pdu + AVTP_CAN_BRIEF_HEADER_LEN + i,
+                            CAN_PAYLOAD_SIZE - i);
+
+        uint16_t msgLenBytes = AVTP_CAN_BRIEF_HEADER_LEN + i;
+        uint8_t pad = (uint8_t)(4 - (msgLenBytes % 4)) % 4;
+        assert_int_equal(Avtp_CanBrief_GetPad((Avtp_CanBrief_t*)pdu), pad);
+        assert_int_equal(Avtp_CanBrief_GetAcfMsgLength((Avtp_CanBrief_t*)pdu),
+                         (msgLenBytes + pad) / 4);
+    }
+}
+
+static void can_brief_is_valid(void **state) {
+
+    uint8_t pdu[MAX_PDU_SIZE];
+    uint32_t frame_id = 0x123;
+
+    // An Init-only PDU has AcfMsgLength == 0 — i.e. it declares a frame
+    // shorter than its own header. Per IEEE 1722 ACF wire format that is
+    // not a valid frame, so IsValid must reject it.
+    Avtp_CanBrief_Init((Avtp_CanBrief_t*)pdu);
+    assert_int_equal(Avtp_CanBrief_IsValid((Avtp_CanBrief_t*)pdu, MAX_PDU_SIZE), 0);
+
+    // A properly-formed classic CAN frame with an 8-byte payload (the
+    // classic-CAN max) is valid.
+    {
+        uint8_t payload[8] = {0,1,2,3,4,5,6,7};
+        Avtp_CanBrief_Init((Avtp_CanBrief_t*)pdu);
+        Avtp_CanBrief_CreateAcfMessage((Avtp_CanBrief_t*)pdu, frame_id, payload,
+                                       sizeof(payload), AVTP_CAN_CLASSIC);
+        assert_int_equal(Avtp_CanBrief_IsValid((Avtp_CanBrief_t*)pdu, MAX_PDU_SIZE), 1);
+    }
+
+    // Not an IEEE 1722 ACF-CAN Brief message (zero buffer, AcfMsgType != CAN_BRIEF).
+    memset(pdu, 0, MAX_PDU_SIZE);
+    assert_int_equal(Avtp_CanBrief_IsValid((Avtp_CanBrief_t*)pdu, MAX_PDU_SIZE), 0);
+
+    // Valid IEEE 1722 CAN Brief Frame (Length 16, Buffer 17). AcfMsgLength=4
+    // quadlets = 16 bytes; payload = 16 - 8 header = 8 bytes (classic max).
+    Avtp_CanBrief_Init((Avtp_CanBrief_t*)pdu);
+    Avtp_CanBrief_SetAcfMsgLength((Avtp_CanBrief_t*)pdu, 4);
+    assert_int_equal(Avtp_CanBrief_IsValid((Avtp_CanBrief_t*)pdu, 17), 1);
+
+    // Invalid IEEE 1722 CAN Brief Frame (Length 16 but buffer only 9!).
+    Avtp_CanBrief_Init((Avtp_CanBrief_t*)pdu);
+    Avtp_CanBrief_SetAcfMsgLength((Avtp_CanBrief_t*)pdu, 4);
+    assert_int_equal(Avtp_CanBrief_IsValid((Avtp_CanBrief_t*)pdu, 9), 0);
+
+    // Classic CAN payload bound: a frame declaring a 12-byte payload as
+    // classic CAN is invalid (classic tops out at 8).
+    {
+        uint8_t too_big[12] = {0};
+        Avtp_CanBrief_Init((Avtp_CanBrief_t*)pdu);
+        Avtp_CanBrief_CreateAcfMessage((Avtp_CanBrief_t*)pdu, frame_id, too_big,
+                                       sizeof(too_big), AVTP_CAN_CLASSIC);
+        assert_int_equal(Avtp_CanBrief_IsValid((Avtp_CanBrief_t*)pdu, MAX_PDU_SIZE), 0);
+    }
+
+    // CAN-FD payload bound: 64 bytes is at the FD limit (valid); 68 bytes
+    // exceeds it (invalid).
+    {
+        uint8_t fd_max[64] = {0};
+        Avtp_CanBrief_Init((Avtp_CanBrief_t*)pdu);
+        Avtp_CanBrief_CreateAcfMessage((Avtp_CanBrief_t*)pdu, frame_id, fd_max,
+                                       sizeof(fd_max), AVTP_CAN_FD);
+        assert_int_equal(Avtp_CanBrief_IsValid((Avtp_CanBrief_t*)pdu, MAX_PDU_SIZE), 1);
+    }
+    {
+        uint8_t fd_too_big[68] = {0};
+        Avtp_CanBrief_Init((Avtp_CanBrief_t*)pdu);
+        Avtp_CanBrief_CreateAcfMessage((Avtp_CanBrief_t*)pdu, frame_id, fd_too_big,
+                                       sizeof(fd_too_big), AVTP_CAN_FD);
+        assert_int_equal(Avtp_CanBrief_IsValid((Avtp_CanBrief_t*)pdu, MAX_PDU_SIZE), 0);
+    }
+}
+
 int main(void)
 {
     const struct CMUnitTest tests[] = {
         cmocka_unit_test(can_init),
         cmocka_unit_test(can_brief_init),
         cmocka_unit_test(can_set_payload),
-        cmocka_unit_test(can_is_valid)
+        cmocka_unit_test(can_is_valid),
+        cmocka_unit_test(can_brief_set_payload),
+        cmocka_unit_test(can_brief_is_valid)
     };
 
     return cmocka_run_group_tests(tests, NULL, NULL);


### PR DESCRIPTION
Changes to CanBrief

- include/avtp/acf/CanBrief.h: packed struct, stdbool.h, removed GetField/SetField, flags converted to Is<Flag>/Set<Flag>(bool) (IsMtv, IsRtr, IsEff, IsBrs, IsFdf, IsEsi), IsValid returns bool, and convenience helpers inlined/renamed (GetAcfMsgLengthInBytes, GetPayload, SetPayload, SetPayloadLength, GetPayloadLength).
- src/avtp/acf/CanBrief.c: trimmed to CreateAcfMessage + IsValid (now bool), with the stale Finalize/GetCanPayloadLength/Enable* calls replaced.
- unit/test-can.c: added can_brief_set_payload and can_brief_is_valid mirroring the CAN coverage.
- finalize had a bug, padding aligned data, fixed in SetPayloadLength