### PR TITLE
CanBriefV2 apply API guidelines

### DIFF
--- a/include/avtp/acf/CanBriefV2.h
+++ b/include/avtp/acf/CanBriefV2.h
@@ -50,7 +50,7 @@ extern "C" {
 #define GET_CAN_BRIEF_V2_FIELD(field)                                                              \
     (Avtp_GetField(Avtp_CanBriefV2FieldDesc, AVTP_CAN_BRIEF_V2_FIELD_MAX, (uint8_t *)pdu, field))
 #define SET_CAN_BRIEF_V2_FIELD(field, value)                                                       \
-    (Avtp_SetField(Avtp_CanBriefV2FieldDesc, AVTP_CAN_BRIEF_V2_FIELD_MAX, (uint8_t *)pdu, field,  \
+    (Avtp_SetField(Avtp_CanBriefV2FieldDesc, AVTP_CAN_BRIEF_V2_FIELD_MAX, (uint8_t *)pdu, field,   \
                    value))
 
 /**
@@ -91,21 +91,20 @@ typedef enum {
 /**
  * This table describes all the offsets of the ACF_CAN_BRIEF_V2 header fields.
  */
-static const Avtp_FieldDescriptor_t Avtp_CanBriefV2FieldDesc[AVTP_CAN_BRIEF_V2_FIELD_MAX] =
-{
+static const Avtp_FieldDescriptor_t Avtp_CanBriefV2FieldDesc[AVTP_CAN_BRIEF_V2_FIELD_MAX] = {
     /* ACF common header fields */
-    [AVTP_CAN_BRIEF_V2_FIELD_ACF_MSG_TYPE]       = { .quadlet = 0, .offset =  0, .bits =  7 },
-    [AVTP_CAN_BRIEF_V2_FIELD_ACF_MSG_LENGTH]     = { .quadlet = 0, .offset =  7, .bits =  9 },
+    [AVTP_CAN_BRIEF_V2_FIELD_ACF_MSG_TYPE] = {.quadlet = 0, .offset = 0, .bits = 7},
+    [AVTP_CAN_BRIEF_V2_FIELD_ACF_MSG_LENGTH] = {.quadlet = 0, .offset = 7, .bits = 9},
     /* ACF CAN_BRIEF_V2 header fields */
-    [AVTP_CAN_BRIEF_V2_FIELD_PAD]                = { .quadlet = 0, .offset = 16, .bits =  2 },
-    [AVTP_CAN_BRIEF_V2_FIELD_MTV]                = { .quadlet = 0, .offset = 18, .bits =  1 },
-    [AVTP_CAN_BRIEF_V2_FIELD_RTR]                = { .quadlet = 0, .offset = 19, .bits =  1 },
-    [AVTP_CAN_BRIEF_V2_FIELD_EFF]                = { .quadlet = 0, .offset = 20, .bits =  1 },
-    [AVTP_CAN_BRIEF_V2_FIELD_CAN_BUS_ID]         = { .quadlet = 0, .offset = 21, .bits = 11 },
-    [AVTP_CAN_BRIEF_V2_FIELD_BRS]                = { .quadlet = 1, .offset =  0, .bits =  1 },
-    [AVTP_CAN_BRIEF_V2_FIELD_FDF]                = { .quadlet = 1, .offset =  1, .bits =  1 },
-    [AVTP_CAN_BRIEF_V2_FIELD_ESI]                = { .quadlet = 1, .offset =  2, .bits =  1 },
-    [AVTP_CAN_BRIEF_V2_FIELD_CAN_IDENTIFIER]     = { .quadlet = 1, .offset =  3, .bits = 29 },
+    [AVTP_CAN_BRIEF_V2_FIELD_PAD] = {.quadlet = 0, .offset = 16, .bits = 2},
+    [AVTP_CAN_BRIEF_V2_FIELD_MTV] = {.quadlet = 0, .offset = 18, .bits = 1},
+    [AVTP_CAN_BRIEF_V2_FIELD_RTR] = {.quadlet = 0, .offset = 19, .bits = 1},
+    [AVTP_CAN_BRIEF_V2_FIELD_EFF] = {.quadlet = 0, .offset = 20, .bits = 1},
+    [AVTP_CAN_BRIEF_V2_FIELD_CAN_BUS_ID] = {.quadlet = 0, .offset = 21, .bits = 11},
+    [AVTP_CAN_BRIEF_V2_FIELD_BRS] = {.quadlet = 1, .offset = 0, .bits = 1},
+    [AVTP_CAN_BRIEF_V2_FIELD_FDF] = {.quadlet = 1, .offset = 1, .bits = 1},
+    [AVTP_CAN_BRIEF_V2_FIELD_ESI] = {.quadlet = 1, .offset = 2, .bits = 1},
+    [AVTP_CAN_BRIEF_V2_FIELD_CAN_IDENTIFIER] = {.quadlet = 1, .offset = 3, .bits = 29},
 };
 
 /**
@@ -114,8 +113,9 @@ static const Avtp_FieldDescriptor_t Avtp_CanBriefV2FieldDesc[AVTP_CAN_BRIEF_V2_F
  * @param pdu Pointer to the first bit of a 1722 ACF CAN Brief V2 PDU.
  * @returns Value of the ACF message type field.
  */
-OPEN1722_INLINE uint8_t Avtp_CanBriefV2_GetAcfMsgType(const Avtp_CanBriefV2_t* const pdu) {
-    return (uint8_t) GET_CAN_BRIEF_V2_FIELD(AVTP_CAN_BRIEF_V2_FIELD_ACF_MSG_TYPE);
+OPEN1722_INLINE uint8_t Avtp_CanBriefV2_GetAcfMsgType(const Avtp_CanBriefV2_t *const pdu)
+{
+    return (uint8_t)GET_CAN_BRIEF_V2_FIELD(AVTP_CAN_BRIEF_V2_FIELD_ACF_MSG_TYPE);
 }
 
 /**
@@ -127,8 +127,9 @@ OPEN1722_INLINE uint8_t Avtp_CanBriefV2_GetAcfMsgType(const Avtp_CanBriefV2_t* c
  * @param pdu Pointer to the first bit of a 1722 ACF CAN Brief V2 PDU.
  * @returns Value of the ACF message length field.
  */
-OPEN1722_INLINE uint16_t Avtp_CanBriefV2_GetAcfMsgLength(const Avtp_CanBriefV2_t* const pdu) {
-    return (uint16_t) GET_CAN_BRIEF_V2_FIELD(AVTP_CAN_BRIEF_V2_FIELD_ACF_MSG_LENGTH);
+OPEN1722_INLINE uint16_t Avtp_CanBriefV2_GetAcfMsgLength(const Avtp_CanBriefV2_t *const pdu)
+{
+    return (uint16_t)GET_CAN_BRIEF_V2_FIELD(AVTP_CAN_BRIEF_V2_FIELD_ACF_MSG_LENGTH);
 }
 
 /**
@@ -137,8 +138,9 @@ OPEN1722_INLINE uint16_t Avtp_CanBriefV2_GetAcfMsgLength(const Avtp_CanBriefV2_t
  * @param pdu Pointer to the first bit of a 1722 ACF CAN Brief V2 PDU.
  * @returns Length of the ACF message in bytes.
  */
-OPEN1722_INLINE uint16_t Avtp_CanBriefV2_GetAcfMsgLengthInBytes(const Avtp_CanBriefV2_t* const pdu) {
-    return (uint16_t) GET_CAN_BRIEF_V2_FIELD(AVTP_CAN_BRIEF_V2_FIELD_ACF_MSG_LENGTH) * 4;
+OPEN1722_INLINE uint16_t Avtp_CanBriefV2_GetAcfMsgLengthInBytes(const Avtp_CanBriefV2_t *const pdu)
+{
+    return (uint16_t)GET_CAN_BRIEF_V2_FIELD(AVTP_CAN_BRIEF_V2_FIELD_ACF_MSG_LENGTH) * 4;
 }
 
 /**
@@ -147,7 +149,8 @@ OPEN1722_INLINE uint16_t Avtp_CanBriefV2_GetAcfMsgLengthInBytes(const Avtp_CanBr
  * @param pdu Pointer to the first bit of a 1722 ACF CAN Brief V2 PDU.
  * @param value Value to set the ACF message type field to.
  */
-OPEN1722_INLINE void Avtp_CanBriefV2_SetAcfMsgType(Avtp_CanBriefV2_t* pdu, uint8_t value) {
+OPEN1722_INLINE void Avtp_CanBriefV2_SetAcfMsgType(Avtp_CanBriefV2_t *pdu, uint8_t value)
+{
     SET_CAN_BRIEF_V2_FIELD(AVTP_CAN_BRIEF_V2_FIELD_ACF_MSG_TYPE, value);
 }
 
@@ -160,7 +163,8 @@ OPEN1722_INLINE void Avtp_CanBriefV2_SetAcfMsgType(Avtp_CanBriefV2_t* pdu, uint8
  * @param pdu Pointer to the first bit of a 1722 ACF CAN Brief V2 PDU.
  * @param value Value to set the ACF message length field to.
  */
-OPEN1722_INLINE void Avtp_CanBriefV2_SetAcfMsgLength(Avtp_CanBriefV2_t* pdu, uint16_t value) {
+OPEN1722_INLINE void Avtp_CanBriefV2_SetAcfMsgLength(Avtp_CanBriefV2_t *pdu, uint16_t value)
+{
     SET_CAN_BRIEF_V2_FIELD(AVTP_CAN_BRIEF_V2_FIELD_ACF_MSG_LENGTH, value);
 }
 
@@ -170,8 +174,9 @@ OPEN1722_INLINE void Avtp_CanBriefV2_SetAcfMsgLength(Avtp_CanBriefV2_t* pdu, uin
  * @param pdu Pointer to an ACF_CAN_BRIEF_V2 message.
  * @returns The value of the pad field.
  */
-OPEN1722_INLINE uint8_t Avtp_CanBriefV2_GetPad(const Avtp_CanBriefV2_t* const pdu) {
-    return (uint8_t) GET_CAN_BRIEF_V2_FIELD(AVTP_CAN_BRIEF_V2_FIELD_PAD);
+OPEN1722_INLINE uint8_t Avtp_CanBriefV2_GetPad(const Avtp_CanBriefV2_t *const pdu)
+{
+    return (uint8_t)GET_CAN_BRIEF_V2_FIELD(AVTP_CAN_BRIEF_V2_FIELD_PAD);
 }
 
 /**
@@ -180,7 +185,8 @@ OPEN1722_INLINE uint8_t Avtp_CanBriefV2_GetPad(const Avtp_CanBriefV2_t* const pd
  * @param pdu Pointer to an ACF_CAN_BRIEF_V2 message.
  * @param pad The value to set.
  */
-OPEN1722_INLINE void Avtp_CanBriefV2_SetPad(Avtp_CanBriefV2_t* pdu, uint8_t pad) {
+OPEN1722_INLINE void Avtp_CanBriefV2_SetPad(Avtp_CanBriefV2_t *pdu, uint8_t pad)
+{
     SET_CAN_BRIEF_V2_FIELD(AVTP_CAN_BRIEF_V2_FIELD_PAD, pad);
 }
 
@@ -190,8 +196,9 @@ OPEN1722_INLINE void Avtp_CanBriefV2_SetPad(Avtp_CanBriefV2_t* pdu, uint8_t pad)
  * @param pdu Pointer to an ACF_CAN_BRIEF_V2 message.
  * @returns The value of the mtv flag.
  */
-OPEN1722_INLINE bool Avtp_CanBriefV2_IsMtv(const Avtp_CanBriefV2_t* const pdu) {
-    return (bool) GET_CAN_BRIEF_V2_FIELD(AVTP_CAN_BRIEF_V2_FIELD_MTV);
+OPEN1722_INLINE bool Avtp_CanBriefV2_IsMtv(const Avtp_CanBriefV2_t *const pdu)
+{
+    return (bool)GET_CAN_BRIEF_V2_FIELD(AVTP_CAN_BRIEF_V2_FIELD_MTV);
 }
 
 /**
@@ -200,8 +207,9 @@ OPEN1722_INLINE bool Avtp_CanBriefV2_IsMtv(const Avtp_CanBriefV2_t* const pdu) {
  * @param pdu Pointer to an ACF_CAN_BRIEF_V2 message.
  * @returns The value of the rtr flag.
  */
-OPEN1722_INLINE bool Avtp_CanBriefV2_IsRtr(const Avtp_CanBriefV2_t* const pdu) {
-    return (bool) GET_CAN_BRIEF_V2_FIELD(AVTP_CAN_BRIEF_V2_FIELD_RTR);
+OPEN1722_INLINE bool Avtp_CanBriefV2_IsRtr(const Avtp_CanBriefV2_t *const pdu)
+{
+    return (bool)GET_CAN_BRIEF_V2_FIELD(AVTP_CAN_BRIEF_V2_FIELD_RTR);
 }
 
 /**
@@ -210,8 +218,9 @@ OPEN1722_INLINE bool Avtp_CanBriefV2_IsRtr(const Avtp_CanBriefV2_t* const pdu) {
  * @param pdu Pointer to an ACF_CAN_BRIEF_V2 message.
  * @returns The value of the eff flag.
  */
-OPEN1722_INLINE bool Avtp_CanBriefV2_IsEff(const Avtp_CanBriefV2_t* const pdu) {
-    return (bool) GET_CAN_BRIEF_V2_FIELD(AVTP_CAN_BRIEF_V2_FIELD_EFF);
+OPEN1722_INLINE bool Avtp_CanBriefV2_IsEff(const Avtp_CanBriefV2_t *const pdu)
+{
+    return (bool)GET_CAN_BRIEF_V2_FIELD(AVTP_CAN_BRIEF_V2_FIELD_EFF);
 }
 
 /**
@@ -220,8 +229,9 @@ OPEN1722_INLINE bool Avtp_CanBriefV2_IsEff(const Avtp_CanBriefV2_t* const pdu) {
  * @param pdu Pointer to an ACF_CAN_BRIEF_V2 message.
  * @returns The value of the can_bus_id field.
  */
-OPEN1722_INLINE uint16_t Avtp_CanBriefV2_GetCanBusId(const Avtp_CanBriefV2_t* const pdu) {
-    return (uint16_t) GET_CAN_BRIEF_V2_FIELD(AVTP_CAN_BRIEF_V2_FIELD_CAN_BUS_ID);
+OPEN1722_INLINE uint16_t Avtp_CanBriefV2_GetCanBusId(const Avtp_CanBriefV2_t *const pdu)
+{
+    return (uint16_t)GET_CAN_BRIEF_V2_FIELD(AVTP_CAN_BRIEF_V2_FIELD_CAN_BUS_ID);
 }
 
 /**
@@ -230,8 +240,9 @@ OPEN1722_INLINE uint16_t Avtp_CanBriefV2_GetCanBusId(const Avtp_CanBriefV2_t* co
  * @param pdu Pointer to an ACF_CAN_BRIEF_V2 message.
  * @returns The value of the brs flag.
  */
-OPEN1722_INLINE bool Avtp_CanBriefV2_IsBrs(const Avtp_CanBriefV2_t* const pdu) {
-    return (bool) GET_CAN_BRIEF_V2_FIELD(AVTP_CAN_BRIEF_V2_FIELD_BRS);
+OPEN1722_INLINE bool Avtp_CanBriefV2_IsBrs(const Avtp_CanBriefV2_t *const pdu)
+{
+    return (bool)GET_CAN_BRIEF_V2_FIELD(AVTP_CAN_BRIEF_V2_FIELD_BRS);
 }
 
 /**
@@ -240,8 +251,9 @@ OPEN1722_INLINE bool Avtp_CanBriefV2_IsBrs(const Avtp_CanBriefV2_t* const pdu) {
  * @param pdu Pointer to an ACF_CAN_BRIEF_V2 message.
  * @returns The value of the fdf flag.
  */
-OPEN1722_INLINE bool Avtp_CanBriefV2_IsFdf(const Avtp_CanBriefV2_t* const pdu) {
-    return (bool) GET_CAN_BRIEF_V2_FIELD(AVTP_CAN_BRIEF_V2_FIELD_FDF);
+OPEN1722_INLINE bool Avtp_CanBriefV2_IsFdf(const Avtp_CanBriefV2_t *const pdu)
+{
+    return (bool)GET_CAN_BRIEF_V2_FIELD(AVTP_CAN_BRIEF_V2_FIELD_FDF);
 }
 
 /**
@@ -250,8 +262,9 @@ OPEN1722_INLINE bool Avtp_CanBriefV2_IsFdf(const Avtp_CanBriefV2_t* const pdu) {
  * @param pdu Pointer to an ACF_CAN_BRIEF_V2 message.
  * @returns The value of the esi flag.
  */
-OPEN1722_INLINE bool Avtp_CanBriefV2_IsEsi(const Avtp_CanBriefV2_t* const pdu) {
-    return (bool) GET_CAN_BRIEF_V2_FIELD(AVTP_CAN_BRIEF_V2_FIELD_ESI);
+OPEN1722_INLINE bool Avtp_CanBriefV2_IsEsi(const Avtp_CanBriefV2_t *const pdu)
+{
+    return (bool)GET_CAN_BRIEF_V2_FIELD(AVTP_CAN_BRIEF_V2_FIELD_ESI);
 }
 
 /**
@@ -260,8 +273,9 @@ OPEN1722_INLINE bool Avtp_CanBriefV2_IsEsi(const Avtp_CanBriefV2_t* const pdu) {
  * @param pdu Pointer to an ACF_CAN_BRIEF_V2 message.
  * @returns The value of the can_identifier field.
  */
-OPEN1722_INLINE uint32_t Avtp_CanBriefV2_GetCanIdentifier(const Avtp_CanBriefV2_t* const pdu) {
-    return (uint32_t) GET_CAN_BRIEF_V2_FIELD(AVTP_CAN_BRIEF_V2_FIELD_CAN_IDENTIFIER);
+OPEN1722_INLINE uint32_t Avtp_CanBriefV2_GetCanIdentifier(const Avtp_CanBriefV2_t *const pdu)
+{
+    return (uint32_t)GET_CAN_BRIEF_V2_FIELD(AVTP_CAN_BRIEF_V2_FIELD_CAN_IDENTIFIER);
 }
 
 /**
@@ -270,7 +284,8 @@ OPEN1722_INLINE uint32_t Avtp_CanBriefV2_GetCanIdentifier(const Avtp_CanBriefV2_
  * @param pdu Pointer to an ACF_CAN_BRIEF_V2 message.
  * @param mtv The value to set.
  */
-OPEN1722_INLINE void Avtp_CanBriefV2_SetMtv(Avtp_CanBriefV2_t* pdu, bool mtv) {
+OPEN1722_INLINE void Avtp_CanBriefV2_SetMtv(Avtp_CanBriefV2_t *pdu, bool mtv)
+{
     SET_CAN_BRIEF_V2_FIELD(AVTP_CAN_BRIEF_V2_FIELD_MTV, mtv);
 }
 
@@ -280,7 +295,8 @@ OPEN1722_INLINE void Avtp_CanBriefV2_SetMtv(Avtp_CanBriefV2_t* pdu, bool mtv) {
  * @param pdu Pointer to an ACF_CAN_BRIEF_V2 message.
  * @param rtr The value to set.
  */
-OPEN1722_INLINE void Avtp_CanBriefV2_SetRtr(Avtp_CanBriefV2_t* pdu, bool rtr) {
+OPEN1722_INLINE void Avtp_CanBriefV2_SetRtr(Avtp_CanBriefV2_t *pdu, bool rtr)
+{
     SET_CAN_BRIEF_V2_FIELD(AVTP_CAN_BRIEF_V2_FIELD_RTR, rtr);
 }
 
@@ -290,7 +306,8 @@ OPEN1722_INLINE void Avtp_CanBriefV2_SetRtr(Avtp_CanBriefV2_t* pdu, bool rtr) {
  * @param pdu Pointer to an ACF_CAN_BRIEF_V2 message.
  * @param eff The value to set.
  */
-OPEN1722_INLINE void Avtp_CanBriefV2_SetEff(Avtp_CanBriefV2_t* pdu, bool eff) {
+OPEN1722_INLINE void Avtp_CanBriefV2_SetEff(Avtp_CanBriefV2_t *pdu, bool eff)
+{
     SET_CAN_BRIEF_V2_FIELD(AVTP_CAN_BRIEF_V2_FIELD_EFF, eff);
 }
 
@@ -300,7 +317,8 @@ OPEN1722_INLINE void Avtp_CanBriefV2_SetEff(Avtp_CanBriefV2_t* pdu, bool eff) {
  * @param pdu Pointer to an ACF_CAN_BRIEF_V2 message.
  * @param canBusId The value to set.
  */
-OPEN1722_INLINE void Avtp_CanBriefV2_SetCanBusId(Avtp_CanBriefV2_t* pdu, uint16_t canBusId) {
+OPEN1722_INLINE void Avtp_CanBriefV2_SetCanBusId(Avtp_CanBriefV2_t *pdu, uint16_t canBusId)
+{
     SET_CAN_BRIEF_V2_FIELD(AVTP_CAN_BRIEF_V2_FIELD_CAN_BUS_ID, canBusId);
 }
 
@@ -310,7 +328,8 @@ OPEN1722_INLINE void Avtp_CanBriefV2_SetCanBusId(Avtp_CanBriefV2_t* pdu, uint16_
  * @param pdu Pointer to an ACF_CAN_BRIEF_V2 message.
  * @param brs The value to set.
  */
-OPEN1722_INLINE void Avtp_CanBriefV2_SetBrs(Avtp_CanBriefV2_t* pdu, bool brs) {
+OPEN1722_INLINE void Avtp_CanBriefV2_SetBrs(Avtp_CanBriefV2_t *pdu, bool brs)
+{
     SET_CAN_BRIEF_V2_FIELD(AVTP_CAN_BRIEF_V2_FIELD_BRS, brs);
 }
 
@@ -320,7 +339,8 @@ OPEN1722_INLINE void Avtp_CanBriefV2_SetBrs(Avtp_CanBriefV2_t* pdu, bool brs) {
  * @param pdu Pointer to an ACF_CAN_BRIEF_V2 message.
  * @param fdf The value to set.
  */
-OPEN1722_INLINE void Avtp_CanBriefV2_SetFdf(Avtp_CanBriefV2_t* pdu, bool fdf) {
+OPEN1722_INLINE void Avtp_CanBriefV2_SetFdf(Avtp_CanBriefV2_t *pdu, bool fdf)
+{
     SET_CAN_BRIEF_V2_FIELD(AVTP_CAN_BRIEF_V2_FIELD_FDF, fdf);
 }
 
@@ -330,7 +350,8 @@ OPEN1722_INLINE void Avtp_CanBriefV2_SetFdf(Avtp_CanBriefV2_t* pdu, bool fdf) {
  * @param pdu Pointer to an ACF_CAN_BRIEF_V2 message.
  * @param esi The value to set.
  */
-OPEN1722_INLINE void Avtp_CanBriefV2_SetEsi(Avtp_CanBriefV2_t* pdu, bool esi) {
+OPEN1722_INLINE void Avtp_CanBriefV2_SetEsi(Avtp_CanBriefV2_t *pdu, bool esi)
+{
     SET_CAN_BRIEF_V2_FIELD(AVTP_CAN_BRIEF_V2_FIELD_ESI, esi);
 }
 
@@ -340,7 +361,9 @@ OPEN1722_INLINE void Avtp_CanBriefV2_SetEsi(Avtp_CanBriefV2_t* pdu, bool esi) {
  * @param pdu Pointer to an ACF_CAN_BRIEF_V2 message.
  * @param canIdentifier The value to set.
  */
-OPEN1722_INLINE void Avtp_CanBriefV2_SetCanIdentifier(Avtp_CanBriefV2_t* pdu, uint32_t canIdentifier) {
+OPEN1722_INLINE void Avtp_CanBriefV2_SetCanIdentifier(Avtp_CanBriefV2_t *pdu,
+                                                      uint32_t canIdentifier)
+{
     SET_CAN_BRIEF_V2_FIELD(AVTP_CAN_BRIEF_V2_FIELD_CAN_IDENTIFIER, canIdentifier);
 }
 
@@ -350,7 +373,7 @@ OPEN1722_INLINE void Avtp_CanBriefV2_SetCanIdentifier(Avtp_CanBriefV2_t* pdu, ui
  * @param pdu Pointer to the first bit of a 1722 ACF CAN Brief V2 PDU.
  * @return Pointer to ACF CAN Brief V2 frame payload
  */
-OPEN1722_INLINE const uint8_t *Avtp_CanBriefV2_GetPayload(const Avtp_CanBriefV2_t* const pdu)
+OPEN1722_INLINE const uint8_t *Avtp_CanBriefV2_GetPayload(const Avtp_CanBriefV2_t *const pdu)
 {
     return pdu->payload;
 }
@@ -377,7 +400,8 @@ OPEN1722_INLINE void Avtp_CanBriefV2_SetPayload(Avtp_CanBriefV2_t *pdu, uint8_t 
  * @param pdu Pointer to the first bit of a 1722 ACF CAN Brief V2 PDU.
  * @param payload_length Length of the CAN frame payload.
  */
-OPEN1722_INLINE void Avtp_CanBriefV2_SetPayloadLength(Avtp_CanBriefV2_t *pdu, uint16_t payload_length)
+OPEN1722_INLINE void Avtp_CanBriefV2_SetPayloadLength(Avtp_CanBriefV2_t *pdu,
+                                                      uint16_t payload_length)
 {
     uint16_t msgLenBytes = AVTP_CAN_BRIEF_V2_HEADER_LEN + payload_length;
     uint8_t pad = (uint8_t)(4 - (msgLenBytes % 4)) % 4;
@@ -402,7 +426,7 @@ OPEN1722_INLINE void Avtp_CanBriefV2_SetPayloadLength(Avtp_CanBriefV2_t *pdu, ui
  * @param pdu Pointer to the first bit of a 1722 ACF CAN Brief V2 PDU.
  * @return  Length of CAN payload in bytes
  */
-OPEN1722_INLINE uint8_t Avtp_CanBriefV2_GetPayloadLength(const Avtp_CanBriefV2_t* const pdu)
+OPEN1722_INLINE uint8_t Avtp_CanBriefV2_GetPayloadLength(const Avtp_CanBriefV2_t *const pdu)
 {
     uint8_t pad_length = Avtp_CanBriefV2_GetPad(pdu);
     uint16_t acf_length_bytes = Avtp_CanBriefV2_GetAcfMsgLengthInBytes(pdu);
@@ -451,7 +475,7 @@ OPEN1722_INLINE void Avtp_CanBriefV2_CreateAcfMessage(Avtp_CanBriefV2_t *pdu, ui
  * @param bufferSize Size of the buffer containing the ACF CAN Brief V2 frame.
  * @return true if the ACF CAN Brief V2 frame is valid, false otherwise.
  */
-OPEN1722_INLINE bool Avtp_CanBriefV2_IsValid(const Avtp_CanBriefV2_t* const pdu, size_t bufferSize)
+OPEN1722_INLINE bool Avtp_CanBriefV2_IsValid(const Avtp_CanBriefV2_t *const pdu, size_t bufferSize)
 {
     if (pdu == NULL) {
         return false;
@@ -493,7 +517,8 @@ OPEN1722_INLINE bool Avtp_CanBriefV2_IsValid(const Avtp_CanBriefV2_t* const pdu,
  *
  * @param pdu Pointer to the first bit of a 1722 ACF CAN Brief V2 PDU.
  */
-OPEN1722_INLINE void Avtp_CanBriefV2_Init(Avtp_CanBriefV2_t* pdu) {
+OPEN1722_INLINE void Avtp_CanBriefV2_Init(Avtp_CanBriefV2_t *pdu)
+{
     if (pdu != NULL) {
         memset(pdu, 0, sizeof(Avtp_CanBriefV2_t));
         Avtp_CanBriefV2_SetAcfMsgType(pdu, AVTP_ACF_TYPE_CAN_BRIEF_V2);

--- a/include/avtp/acf/CanBriefV2.h
+++ b/include/avtp/acf/CanBriefV2.h
@@ -43,9 +43,15 @@ extern "C" {
 #include <stdbool.h>
 #include <string.h>
 
+#include "avtp/Utils.h"
 #include "avtp/Defines.h"
 #include "avtp/acf/AcfCommon.h"
-#include "avtp/Utils.h"
+
+#define GET_CAN_BRIEF_V2_FIELD(field)                                                              \
+    (Avtp_GetField(Avtp_CanBriefV2FieldDesc, AVTP_CAN_BRIEF_V2_FIELD_MAX, (uint8_t *)pdu, field))
+#define SET_CAN_BRIEF_V2_FIELD(field, value)                                                       \
+    (Avtp_SetField(Avtp_CanBriefV2FieldDesc, AVTP_CAN_BRIEF_V2_FIELD_MAX, (uint8_t *)pdu, field,  \
+                   value))
 
 /**
  * Length of ACF_CAN_BRIEF_V2 message header in bytes.
@@ -59,7 +65,7 @@ extern "C" {
 typedef struct {
     uint8_t header[AVTP_CAN_BRIEF_V2_HEADER_LEN];
     uint8_t payload[0];
-} Avtp_CanBriefV2_t;
+} __attribute__((packed)) Avtp_CanBriefV2_t;
 
 /**
  * Fields encoded in the ACF_CAN_BRIEF_V2 header.
@@ -80,12 +86,12 @@ typedef enum {
     AVTP_CAN_BRIEF_V2_FIELD_CAN_IDENTIFIER,
     /* Count number of fields for bound checks */
     AVTP_CAN_BRIEF_V2_FIELD_MAX
-} Avtp_CanBriefV2Field_t;
+} Avtp_CanBriefV2Fields_t;
 
 /**
  * This table describes all the offsets of the ACF_CAN_BRIEF_V2 header fields.
  */
-static const Avtp_FieldDescriptor_t __AVTP_CAN_BRIEF_V2_FIELDS[AVTP_CAN_BRIEF_V2_FIELD_MAX] =
+static const Avtp_FieldDescriptor_t Avtp_CanBriefV2FieldDesc[AVTP_CAN_BRIEF_V2_FIELD_MAX] =
 {
     /* ACF common header fields */
     [AVTP_CAN_BRIEF_V2_FIELD_ACF_MSG_TYPE]       = { .quadlet = 0, .offset =  0, .bits =  7 },
@@ -103,248 +109,395 @@ static const Avtp_FieldDescriptor_t __AVTP_CAN_BRIEF_V2_FIELDS[AVTP_CAN_BRIEF_V2
 };
 
 /**
- * Macro to get the value of a field from an ACF_CAN_BRIEF_V2 message header.
+ * Return the value of the ACF message type field as specified in the IEEE 1722 Specification.
  *
- * @note This macro should not be used directly, instead use the field specific
- * getter functions defined below.
+ * @param pdu Pointer to the first bit of a 1722 ACF CAN Brief V2 PDU.
+ * @returns Value of the ACF message type field.
  */
-#define __Avtp_CanBriefV2_GetField(field) \
-        (Avtp_GetField(__AVTP_CAN_BRIEF_V2_FIELDS, AVTP_CAN_BRIEF_V2_FIELD_MAX, (uint8_t*)msg, field))
+OPEN1722_INLINE uint8_t Avtp_CanBriefV2_GetAcfMsgType(const Avtp_CanBriefV2_t* const pdu) {
+    return (uint8_t) GET_CAN_BRIEF_V2_FIELD(AVTP_CAN_BRIEF_V2_FIELD_ACF_MSG_TYPE);
+}
 
 /**
- * Macro to set the value of a field in an ACF_CAN_BRIEF_V2 message header.
+ * Return the value of the ACF message length field as specified in the IEEE 1722 Specification.
+ * This returns the length in Quadlets as specified in the IEEE 1722 Specification.
  *
- * @note This macro should not be used directly, instead use the field specific
- * setter functions defined below.
+ * You can use Avtp_CanBriefV2_GetPayloadLength to get the length in bytes without padding.
+ *
+ * @param pdu Pointer to the first bit of a 1722 ACF CAN Brief V2 PDU.
+ * @returns Value of the ACF message length field.
  */
-#define __Avtp_CanBriefV2_SetField(field, value) \
-        (Avtp_SetField(__AVTP_CAN_BRIEF_V2_FIELDS, AVTP_CAN_BRIEF_V2_FIELD_MAX, (uint8_t*)msg, field, value))
+OPEN1722_INLINE uint16_t Avtp_CanBriefV2_GetAcfMsgLength(const Avtp_CanBriefV2_t* const pdu) {
+    return (uint16_t) GET_CAN_BRIEF_V2_FIELD(AVTP_CAN_BRIEF_V2_FIELD_ACF_MSG_LENGTH);
+}
 
 /**
- * Initializes an ACF_CAN_BRIEF_V2 message with default values for the header fields
- * including acf_msg_type and acf_msg_length.
+ * Return the ACF message length in bytes.
  *
- * @param msg Pointer to the ACF_CAN_BRIEF_V2 message to initialize.
+ * @param pdu Pointer to the first bit of a 1722 ACF CAN Brief V2 PDU.
+ * @returns Length of the ACF message in bytes.
  */
-OPEN1722_INLINE void Avtp_CanBriefV2_Init(Avtp_CanBriefV2_t* msg) {
-    memset(msg, 0, sizeof(Avtp_CanBriefV2_t));
-    __Avtp_CanBriefV2_SetField(AVTP_CAN_BRIEF_V2_FIELD_ACF_MSG_TYPE, AVTP_ACF_TYPE_CAN_BRIEF_V2);
-    __Avtp_CanBriefV2_SetField(AVTP_CAN_BRIEF_V2_FIELD_ACF_MSG_LENGTH, AVTP_CAN_BRIEF_V2_HEADER_LEN / AVTP_QUADLET_SIZE);
+OPEN1722_INLINE uint16_t Avtp_CanBriefV2_GetAcfMsgLengthInBytes(const Avtp_CanBriefV2_t* const pdu) {
+    return (uint16_t) GET_CAN_BRIEF_V2_FIELD(AVTP_CAN_BRIEF_V2_FIELD_ACF_MSG_LENGTH) * 4;
+}
+
+/**
+ * Set the value of the ACF message type field as specified in the IEEE 1722 Specification.
+ *
+ * @param pdu Pointer to the first bit of a 1722 ACF CAN Brief V2 PDU.
+ * @param value Value to set the ACF message type field to.
+ */
+OPEN1722_INLINE void Avtp_CanBriefV2_SetAcfMsgType(Avtp_CanBriefV2_t* pdu, uint8_t value) {
+    SET_CAN_BRIEF_V2_FIELD(AVTP_CAN_BRIEF_V2_FIELD_ACF_MSG_TYPE, value);
+}
+
+/**
+ * Set the value of the ACF message length field as specified in the IEEE 1722 Specification.
+ * Note: the size is in Quadlets as specified in the IEEE 1722 Specification.
+ * You can use Avtp_CanBriefV2_SetPayloadLength to set length in bytes and automatically set the
+ * correct padding.
+ *
+ * @param pdu Pointer to the first bit of a 1722 ACF CAN Brief V2 PDU.
+ * @param value Value to set the ACF message length field to.
+ */
+OPEN1722_INLINE void Avtp_CanBriefV2_SetAcfMsgLength(Avtp_CanBriefV2_t* pdu, uint16_t value) {
+    SET_CAN_BRIEF_V2_FIELD(AVTP_CAN_BRIEF_V2_FIELD_ACF_MSG_LENGTH, value);
 }
 
 /**
  * Returns the pad field from an ACF_CAN_BRIEF_V2 message header.
  *
- * @param msg Pointer to an ACF_CAN_BRIEF_V2 message.
+ * @param pdu Pointer to an ACF_CAN_BRIEF_V2 message.
  * @returns The value of the pad field.
  */
-OPEN1722_INLINE uint8_t Avtp_CanBriefV2_GetPad(const Avtp_CanBriefV2_t* msg) {
-    return (uint8_t) __Avtp_CanBriefV2_GetField(AVTP_CAN_BRIEF_V2_FIELD_PAD);
+OPEN1722_INLINE uint8_t Avtp_CanBriefV2_GetPad(const Avtp_CanBriefV2_t* const pdu) {
+    return (uint8_t) GET_CAN_BRIEF_V2_FIELD(AVTP_CAN_BRIEF_V2_FIELD_PAD);
 }
 
 /**
- * Returns the message timestamp valid flag (mtv) from an ACF_CAN_BRIEF_V2 message
- * header.
+ * Sets the pad field in an ACF_CAN_BRIEF_V2 message header.
  *
- * @param msg Pointer to an ACF_CAN_BRIEF_V2 message.
+ * @param pdu Pointer to an ACF_CAN_BRIEF_V2 message.
+ * @param pad The value to set.
+ */
+OPEN1722_INLINE void Avtp_CanBriefV2_SetPad(Avtp_CanBriefV2_t* pdu, uint8_t pad) {
+    SET_CAN_BRIEF_V2_FIELD(AVTP_CAN_BRIEF_V2_FIELD_PAD, pad);
+}
+
+/**
+ * Returns the message timestamp valid flag (mtv) from an ACF_CAN_BRIEF_V2 message header.
+ *
+ * @param pdu Pointer to an ACF_CAN_BRIEF_V2 message.
  * @returns The value of the mtv flag.
  */
-OPEN1722_INLINE bool Avtp_CanBriefV2_IsMtv(const Avtp_CanBriefV2_t* msg) {
-    return (bool) __Avtp_CanBriefV2_GetField(AVTP_CAN_BRIEF_V2_FIELD_MTV);
+OPEN1722_INLINE bool Avtp_CanBriefV2_IsMtv(const Avtp_CanBriefV2_t* const pdu) {
+    return (bool) GET_CAN_BRIEF_V2_FIELD(AVTP_CAN_BRIEF_V2_FIELD_MTV);
 }
 
 /**
- * Returns the Remote Transmission Request flag (rtr) from an ACF_CAN_BRIEF_V2 message
- * header.
+ * Returns the Remote Transmission Request flag (rtr) from an ACF_CAN_BRIEF_V2 message header.
  *
- * @param msg Pointer to an ACF_CAN_BRIEF_V2 message.
+ * @param pdu Pointer to an ACF_CAN_BRIEF_V2 message.
  * @returns The value of the rtr flag.
  */
-OPEN1722_INLINE bool Avtp_CanBriefV2_IsRtr(const Avtp_CanBriefV2_t* msg) {
-    return (bool) __Avtp_CanBriefV2_GetField(AVTP_CAN_BRIEF_V2_FIELD_RTR);
+OPEN1722_INLINE bool Avtp_CanBriefV2_IsRtr(const Avtp_CanBriefV2_t* const pdu) {
+    return (bool) GET_CAN_BRIEF_V2_FIELD(AVTP_CAN_BRIEF_V2_FIELD_RTR);
 }
 
 /**
- * Returns the Extended Frame Format flag (eff) from an ACF_CAN_BRIEF_V2 message
- * header.
+ * Returns the Extended Frame Format flag (eff) from an ACF_CAN_BRIEF_V2 message header.
  *
- * @param msg Pointer to an ACF_CAN_BRIEF_V2 message.
+ * @param pdu Pointer to an ACF_CAN_BRIEF_V2 message.
  * @returns The value of the eff flag.
  */
-OPEN1722_INLINE bool Avtp_CanBriefV2_IsEff(const Avtp_CanBriefV2_t* msg) {
-    return (bool) __Avtp_CanBriefV2_GetField(AVTP_CAN_BRIEF_V2_FIELD_EFF);
+OPEN1722_INLINE bool Avtp_CanBriefV2_IsEff(const Avtp_CanBriefV2_t* const pdu) {
+    return (bool) GET_CAN_BRIEF_V2_FIELD(AVTP_CAN_BRIEF_V2_FIELD_EFF);
 }
 
 /**
  * Returns the value of the can_bus_id field from an ACF_CAN_BRIEF_V2 message header.
  *
- * @param msg Pointer to an ACF_CAN_BRIEF_V2 message.
+ * @param pdu Pointer to an ACF_CAN_BRIEF_V2 message.
  * @returns The value of the can_bus_id field.
  */
-OPEN1722_INLINE uint16_t Avtp_CanBriefV2_GetCanBusId(const Avtp_CanBriefV2_t* msg) {
-    return (uint16_t) __Avtp_CanBriefV2_GetField(AVTP_CAN_BRIEF_V2_FIELD_CAN_BUS_ID);
+OPEN1722_INLINE uint16_t Avtp_CanBriefV2_GetCanBusId(const Avtp_CanBriefV2_t* const pdu) {
+    return (uint16_t) GET_CAN_BRIEF_V2_FIELD(AVTP_CAN_BRIEF_V2_FIELD_CAN_BUS_ID);
 }
 
 /**
  * Returns the Bit Rate Switch flag (brs) from an ACF_CAN_BRIEF_V2 message header.
  *
- * @param msg Pointer to an ACF_CAN_BRIEF_V2 message.
+ * @param pdu Pointer to an ACF_CAN_BRIEF_V2 message.
  * @returns The value of the brs flag.
  */
-OPEN1722_INLINE bool Avtp_CanBriefV2_IsBrs(const Avtp_CanBriefV2_t* msg) {
-    return (bool) __Avtp_CanBriefV2_GetField(AVTP_CAN_BRIEF_V2_FIELD_BRS);
+OPEN1722_INLINE bool Avtp_CanBriefV2_IsBrs(const Avtp_CanBriefV2_t* const pdu) {
+    return (bool) GET_CAN_BRIEF_V2_FIELD(AVTP_CAN_BRIEF_V2_FIELD_BRS);
 }
 
 /**
  * Returns the FD Format flag (fdf) from an ACF_CAN_BRIEF_V2 message header.
  *
- * @param msg Pointer to an ACF_CAN_BRIEF_V2 message.
+ * @param pdu Pointer to an ACF_CAN_BRIEF_V2 message.
  * @returns The value of the fdf flag.
  */
-OPEN1722_INLINE bool Avtp_CanBriefV2_IsFdf(const Avtp_CanBriefV2_t* msg) {
-    return (bool) __Avtp_CanBriefV2_GetField(AVTP_CAN_BRIEF_V2_FIELD_FDF);
+OPEN1722_INLINE bool Avtp_CanBriefV2_IsFdf(const Avtp_CanBriefV2_t* const pdu) {
+    return (bool) GET_CAN_BRIEF_V2_FIELD(AVTP_CAN_BRIEF_V2_FIELD_FDF);
 }
 
 /**
- * Returns the Error State Indicator flag (esi) from an ACF_CAN_BRIEF_V2 message
- * header.
+ * Returns the Error State Indicator flag (esi) from an ACF_CAN_BRIEF_V2 message header.
  *
- * @param msg Pointer to an ACF_CAN_BRIEF_V2 message.
+ * @param pdu Pointer to an ACF_CAN_BRIEF_V2 message.
  * @returns The value of the esi flag.
  */
-OPEN1722_INLINE bool Avtp_CanBriefV2_IsEsi(const Avtp_CanBriefV2_t* msg) {
-    return (bool) __Avtp_CanBriefV2_GetField(AVTP_CAN_BRIEF_V2_FIELD_ESI);
+OPEN1722_INLINE bool Avtp_CanBriefV2_IsEsi(const Avtp_CanBriefV2_t* const pdu) {
+    return (bool) GET_CAN_BRIEF_V2_FIELD(AVTP_CAN_BRIEF_V2_FIELD_ESI);
 }
 
 /**
  * Returns the value of the can_identifier field from an ACF_CAN_BRIEF_V2 message header.
  *
- * @param msg Pointer to an ACF_CAN_BRIEF_V2 message.
+ * @param pdu Pointer to an ACF_CAN_BRIEF_V2 message.
  * @returns The value of the can_identifier field.
  */
-OPEN1722_INLINE uint32_t Avtp_CanBriefV2_GetCanIdentifier(const Avtp_CanBriefV2_t* msg) {
-    return (uint32_t) __Avtp_CanBriefV2_GetField(AVTP_CAN_BRIEF_V2_FIELD_CAN_IDENTIFIER);
-}
-
-/**
- * Returns the payload length from an ACF_CAN_BRIEF_V2 message (in bytes). This is
- * calculated based on the value of the acf_msg_length field in the header
- * as well as the value of the pad field.
- *
- * @param msg Pointer to an ACF_CAN_BRIEF_V2 message.
- * @returns The payload length in bytes.
- */
-OPEN1722_INLINE uint16_t Avtp_CanBriefV2_GetPayloadLen(const Avtp_CanBriefV2_t* msg) {
-    return (uint16_t) (__Avtp_CanBriefV2_GetField(AVTP_CAN_BRIEF_V2_FIELD_ACF_MSG_LENGTH) * AVTP_QUADLET_SIZE
-           - AVTP_CAN_BRIEF_V2_HEADER_LEN
-           - __Avtp_CanBriefV2_GetField(AVTP_CAN_BRIEF_V2_FIELD_PAD));
-}
-
-/**
- * Returns the total message length from an ACF_CAN_BRIEF_V2 message (in bytes)
- * including header and payload section.
- *
- * @param msg Pointer to an ACF_CAN_BRIEF_V2 message.
- * @returns The total message length in bytes.
- */
-OPEN1722_INLINE uint16_t Avtp_CanBriefV2_GetLen(const Avtp_CanBriefV2_t* msg) {
-    return (uint16_t) (__Avtp_CanBriefV2_GetField(AVTP_CAN_BRIEF_V2_FIELD_ACF_MSG_LENGTH) * AVTP_QUADLET_SIZE);
+OPEN1722_INLINE uint32_t Avtp_CanBriefV2_GetCanIdentifier(const Avtp_CanBriefV2_t* const pdu) {
+    return (uint32_t) GET_CAN_BRIEF_V2_FIELD(AVTP_CAN_BRIEF_V2_FIELD_CAN_IDENTIFIER);
 }
 
 /**
  * Sets the value of the mtv flag in an ACF_CAN_BRIEF_V2 message header.
  *
- * @param msg Pointer to an ACF_CAN_BRIEF_V2 message.
+ * @param pdu Pointer to an ACF_CAN_BRIEF_V2 message.
  * @param mtv The value to set.
  */
-OPEN1722_INLINE void Avtp_CanBriefV2_SetMtv(Avtp_CanBriefV2_t* msg, bool mtv) {
-    __Avtp_CanBriefV2_SetField(AVTP_CAN_BRIEF_V2_FIELD_MTV, mtv);
+OPEN1722_INLINE void Avtp_CanBriefV2_SetMtv(Avtp_CanBriefV2_t* pdu, bool mtv) {
+    SET_CAN_BRIEF_V2_FIELD(AVTP_CAN_BRIEF_V2_FIELD_MTV, mtv);
 }
 
 /**
  * Sets the value of the rtr flag in an ACF_CAN_BRIEF_V2 message header.
  *
- * @param msg Pointer to an ACF_CAN_BRIEF_V2 message.
+ * @param pdu Pointer to an ACF_CAN_BRIEF_V2 message.
  * @param rtr The value to set.
  */
-OPEN1722_INLINE void Avtp_CanBriefV2_SetRtr(Avtp_CanBriefV2_t* msg, bool rtr) {
-    __Avtp_CanBriefV2_SetField(AVTP_CAN_BRIEF_V2_FIELD_RTR, rtr);
+OPEN1722_INLINE void Avtp_CanBriefV2_SetRtr(Avtp_CanBriefV2_t* pdu, bool rtr) {
+    SET_CAN_BRIEF_V2_FIELD(AVTP_CAN_BRIEF_V2_FIELD_RTR, rtr);
 }
 
 /**
  * Sets the value of the eff flag in an ACF_CAN_BRIEF_V2 message header.
  *
- * @param msg Pointer to an ACF_CAN_BRIEF_V2 message.
+ * @param pdu Pointer to an ACF_CAN_BRIEF_V2 message.
  * @param eff The value to set.
  */
-OPEN1722_INLINE void Avtp_CanBriefV2_SetEff(Avtp_CanBriefV2_t* msg, bool eff) {
-    __Avtp_CanBriefV2_SetField(AVTP_CAN_BRIEF_V2_FIELD_EFF, eff);
+OPEN1722_INLINE void Avtp_CanBriefV2_SetEff(Avtp_CanBriefV2_t* pdu, bool eff) {
+    SET_CAN_BRIEF_V2_FIELD(AVTP_CAN_BRIEF_V2_FIELD_EFF, eff);
 }
 
 /**
  * Sets the value of the can_bus_id field in an ACF_CAN_BRIEF_V2 message header.
  *
- * @param msg Pointer to an ACF_CAN_BRIEF_V2 message.
+ * @param pdu Pointer to an ACF_CAN_BRIEF_V2 message.
  * @param canBusId The value to set.
  */
-OPEN1722_INLINE void Avtp_CanBriefV2_SetCanBusId(Avtp_CanBriefV2_t* msg, uint16_t canBusId) {
-    __Avtp_CanBriefV2_SetField(AVTP_CAN_BRIEF_V2_FIELD_CAN_BUS_ID, canBusId);
+OPEN1722_INLINE void Avtp_CanBriefV2_SetCanBusId(Avtp_CanBriefV2_t* pdu, uint16_t canBusId) {
+    SET_CAN_BRIEF_V2_FIELD(AVTP_CAN_BRIEF_V2_FIELD_CAN_BUS_ID, canBusId);
 }
 
 /**
  * Sets the value of the brs flag in an ACF_CAN_BRIEF_V2 message header.
  *
- * @param msg Pointer to an ACF_CAN_BRIEF_V2 message.
+ * @param pdu Pointer to an ACF_CAN_BRIEF_V2 message.
  * @param brs The value to set.
  */
-OPEN1722_INLINE void Avtp_CanBriefV2_SetBrs(Avtp_CanBriefV2_t* msg, bool brs) {
-    __Avtp_CanBriefV2_SetField(AVTP_CAN_BRIEF_V2_FIELD_BRS, brs);
+OPEN1722_INLINE void Avtp_CanBriefV2_SetBrs(Avtp_CanBriefV2_t* pdu, bool brs) {
+    SET_CAN_BRIEF_V2_FIELD(AVTP_CAN_BRIEF_V2_FIELD_BRS, brs);
 }
 
 /**
  * Sets the value of the fdf flag in an ACF_CAN_BRIEF_V2 message header.
  *
- * @param msg Pointer to an ACF_CAN_BRIEF_V2 message.
+ * @param pdu Pointer to an ACF_CAN_BRIEF_V2 message.
  * @param fdf The value to set.
  */
-OPEN1722_INLINE void Avtp_CanBriefV2_SetFdf(Avtp_CanBriefV2_t* msg, bool fdf) {
-    __Avtp_CanBriefV2_SetField(AVTP_CAN_BRIEF_V2_FIELD_FDF, fdf);
+OPEN1722_INLINE void Avtp_CanBriefV2_SetFdf(Avtp_CanBriefV2_t* pdu, bool fdf) {
+    SET_CAN_BRIEF_V2_FIELD(AVTP_CAN_BRIEF_V2_FIELD_FDF, fdf);
 }
 
 /**
  * Sets the value of the esi flag in an ACF_CAN_BRIEF_V2 message header.
  *
- * @param msg Pointer to an ACF_CAN_BRIEF_V2 message.
+ * @param pdu Pointer to an ACF_CAN_BRIEF_V2 message.
  * @param esi The value to set.
  */
-OPEN1722_INLINE void Avtp_CanBriefV2_SetEsi(Avtp_CanBriefV2_t* msg, bool esi) {
-    __Avtp_CanBriefV2_SetField(AVTP_CAN_BRIEF_V2_FIELD_ESI, esi);
+OPEN1722_INLINE void Avtp_CanBriefV2_SetEsi(Avtp_CanBriefV2_t* pdu, bool esi) {
+    SET_CAN_BRIEF_V2_FIELD(AVTP_CAN_BRIEF_V2_FIELD_ESI, esi);
 }
 
 /**
  * Sets the value of the can_identifier field in an ACF_CAN_BRIEF_V2 message header.
  *
- * @param msg Pointer to an ACF_CAN_BRIEF_V2 message.
+ * @param pdu Pointer to an ACF_CAN_BRIEF_V2 message.
  * @param canIdentifier The value to set.
  */
-OPEN1722_INLINE void Avtp_CanBriefV2_SetCanIdentifier(Avtp_CanBriefV2_t* msg, uint32_t canIdentifier) {
-    __Avtp_CanBriefV2_SetField(AVTP_CAN_BRIEF_V2_FIELD_CAN_IDENTIFIER, canIdentifier);
+OPEN1722_INLINE void Avtp_CanBriefV2_SetCanIdentifier(Avtp_CanBriefV2_t* pdu, uint32_t canIdentifier) {
+    SET_CAN_BRIEF_V2_FIELD(AVTP_CAN_BRIEF_V2_FIELD_CAN_IDENTIFIER, canIdentifier);
 }
 
 /**
- * Sets the value of the acf_msg_length field in an ACF_CAN_BRIEF_V2 message header
- * based on the given payload length. This function also calculates the
- * required padding and sets the value of the pad field accordingly.
+ * Returns pointer to payload of an ACF CAN Brief V2 frame.
  *
- * @param msg Pointer to an ACF_CAN_BRIEF_V2 message.
- * @param payloadLen The length of the payload in bytes.
+ * @param pdu Pointer to the first bit of a 1722 ACF CAN Brief V2 PDU.
+ * @return Pointer to ACF CAN Brief V2 frame payload
  */
-OPEN1722_INLINE void Avtp_CanBriefV2_SetPayloadLen(Avtp_CanBriefV2_t* msg, uint16_t payloadLen) {
-    uint16_t msgLenBytes = AVTP_CAN_BRIEF_V2_HEADER_LEN + payloadLen;
+OPEN1722_INLINE const uint8_t *Avtp_CanBriefV2_GetPayload(const Avtp_CanBriefV2_t* const pdu)
+{
+    return pdu->payload;
+}
+
+/**
+ * Sets the CAN payload in an ACF CAN Brief V2 frame.
+ *
+ * @param pdu Pointer to the first bit of a 1722 ACF CAN Brief V2 PDU.
+ * @param payload Pointer to the payload byte array
+ * @param payload_length Length of the payload
+ */
+OPEN1722_INLINE void Avtp_CanBriefV2_SetPayload(Avtp_CanBriefV2_t *pdu, uint8_t *payload,
+                                                uint16_t payload_length)
+{
+    memcpy(pdu->payload, payload, payload_length);
+}
+
+/**
+ * Finalizes the ACF CAN Brief V2 frame. This function will set the
+ * length and pad fields while inserting the padded bytes. This will also
+ * set padding bytes to zero if the payload length is not a multiple of 4.
+ * to avoid leaking information
+ *
+ * @param pdu Pointer to the first bit of a 1722 ACF CAN Brief V2 PDU.
+ * @param payload_length Length of the CAN frame payload.
+ */
+OPEN1722_INLINE void Avtp_CanBriefV2_SetPayloadLength(Avtp_CanBriefV2_t *pdu, uint16_t payload_length)
+{
+    uint16_t msgLenBytes = AVTP_CAN_BRIEF_V2_HEADER_LEN + payload_length;
     uint8_t pad = (uint8_t)(4 - (msgLenBytes % 4)) % 4;
-    uint16_t msgLenQuadlets = (uint16_t) ((msgLenBytes + pad) / 4);
-    __Avtp_CanBriefV2_SetField(AVTP_CAN_BRIEF_V2_FIELD_ACF_MSG_LENGTH, msgLenQuadlets);
-    __Avtp_CanBriefV2_SetField(AVTP_CAN_BRIEF_V2_FIELD_PAD, pad);
+    if (pad > 0) {
+        memset(pdu->payload + payload_length, 0, pad);
+    }
+    uint16_t msgLenQuadlets = (uint16_t)((msgLenBytes + pad) / 4);
+    Avtp_CanBriefV2_SetPad(pdu, pad);
+    Avtp_CanBriefV2_SetAcfMsgLength(pdu, msgLenQuadlets);
+}
+
+/**
+ * Returns the length of the CAN payload without the padding bytes and the
+ * header length of the encapsulating ACF Frame.
+ *
+ * Precondition: the caller must have validated the PDU with
+ * Avtp_CanBriefV2_IsValid(). IsValid checks both buffer-size containment and the
+ * CAN payload-length invariant (<= 8 bytes for classic CAN, <= 64 bytes
+ * for CAN-FD). This function performs no further bounds checking and
+ * assumes those invariants already hold.
+ *
+ * @param pdu Pointer to the first bit of a 1722 ACF CAN Brief V2 PDU.
+ * @return  Length of CAN payload in bytes
+ */
+OPEN1722_INLINE uint8_t Avtp_CanBriefV2_GetPayloadLength(const Avtp_CanBriefV2_t* const pdu)
+{
+    uint8_t pad_length = Avtp_CanBriefV2_GetPad(pdu);
+    uint16_t acf_length_bytes = Avtp_CanBriefV2_GetAcfMsgLengthInBytes(pdu);
+    return (uint8_t)(acf_length_bytes - AVTP_CAN_BRIEF_V2_HEADER_LEN - pad_length);
+}
+
+/**
+ * Copies the payload data, CAN frame ID and CAN bus ID into the ACF CAN Brief V2 frame. This
+ * function will also set the length and pad fields while inserting the padded bytes.
+ *
+ * @param pdu Pointer to the first bit of a 1722 ACF CAN Brief V2 PDU.
+ * @param frame_id ID of the CAN frame
+ * @param can_bus_id CAN bus ID
+ * @param payload Pointer to the payload byte array
+ * @param payload_length Length of the payload.
+ * @param can_variant Classic CAN or CAN-FD
+ */
+OPEN1722_INLINE void Avtp_CanBriefV2_CreateAcfMessage(Avtp_CanBriefV2_t *pdu, uint32_t frame_id,
+                                                      uint16_t can_bus_id, uint8_t *payload,
+                                                      uint16_t payload_length,
+                                                      Avtp_CanVariant_t can_variant)
+{
+    // Copy the payload into the CAN PDU
+    Avtp_CanBriefV2_SetPayload(pdu, payload, payload_length);
+
+    // Set the Frame ID, bus ID and CAN variant
+    if (frame_id > 0x7ff) {
+        Avtp_CanBriefV2_SetEff(pdu, true);
+    }
+
+    Avtp_CanBriefV2_SetCanIdentifier(pdu, frame_id);
+    Avtp_CanBriefV2_SetCanBusId(pdu, can_bus_id);
+    if (can_variant == AVTP_CAN_FD) {
+        Avtp_CanBriefV2_SetFdf(pdu, true);
+    }
+
+    // Finalize the AVTP CAN Frame
+    Avtp_CanBriefV2_SetPayloadLength(pdu, payload_length);
+}
+
+/**
+ * Checks if the ACF CAN Brief V2 frame is valid by checking:
+ *     1) if the length field of AVTP/ACF messages contains a value larger than the actual size of
+ * the buffer that contains the AVTP message. 2) if other format specific invariants are not upheld
+ * @param pdu Pointer to the first bit of a 1722 ACF CAN Brief V2 PDU.
+ * @param bufferSize Size of the buffer containing the ACF CAN Brief V2 frame.
+ * @return true if the ACF CAN Brief V2 frame is valid, false otherwise.
+ */
+OPEN1722_INLINE bool Avtp_CanBriefV2_IsValid(const Avtp_CanBriefV2_t* const pdu, size_t bufferSize)
+{
+    if (pdu == NULL) {
+        return false;
+    }
+
+    if (bufferSize < AVTP_CAN_BRIEF_V2_HEADER_LEN) {
+        return false;
+    }
+
+    if (Avtp_CanBriefV2_GetAcfMsgType(pdu) != AVTP_ACF_TYPE_CAN_BRIEF_V2) {
+        return false;
+    }
+
+    // Avtp_CanBriefV2_GetAcfMsgLength returns quadlets. Convert the length field to octets.
+    uint16_t msg_length_bytes = (uint16_t)Avtp_CanBriefV2_GetAcfMsgLength(pdu) * 4;
+    if (msg_length_bytes > bufferSize) {
+        return false;
+    }
+
+    /* CAN payload-length invariant: classic CAN ≤ 8 bytes, CAN-FD ≤ 64
+     * bytes (selected by the FDF bit). The encoded message length must
+     * also accommodate header + declared padding so the payload
+     * computation in Avtp_CanBriefV2_GetPayloadLength() doesn't underflow. */
+    uint8_t pad_length = Avtp_CanBriefV2_GetPad(pdu);
+    uint16_t header_and_pad = (uint16_t)AVTP_CAN_BRIEF_V2_HEADER_LEN + pad_length;
+    if (msg_length_bytes < header_and_pad) {
+        return false;
+    }
+    uint16_t payload_length = msg_length_bytes - header_and_pad;
+    uint16_t max_payload = Avtp_CanBriefV2_IsFdf(pdu) ? 64u : 8u;
+    if (payload_length > max_payload) {
+        return false;
+    }
+    return true;
+}
+
+/**
+ * Initializes an ACF_CAN_BRIEF_V2 message header as specified in the IEEE 1722 Specification.
+ *
+ * @param pdu Pointer to the first bit of a 1722 ACF CAN Brief V2 PDU.
+ */
+OPEN1722_INLINE void Avtp_CanBriefV2_Init(Avtp_CanBriefV2_t* pdu) {
+    if (pdu != NULL) {
+        memset(pdu, 0, sizeof(Avtp_CanBriefV2_t));
+        Avtp_CanBriefV2_SetAcfMsgType(pdu, AVTP_ACF_TYPE_CAN_BRIEF_V2);
+    }
 }
 
 #ifdef __cplusplus

--- a/unit/test-can-brief-v2.c
+++ b/unit/test-can-brief-v2.c
@@ -39,381 +39,283 @@ extern "C" {
 #include <cmocka.h>
 #include <stdio.h>
 
-static void Test_CanBriefV2_Init(void** state)
+static void Test_CanBriefV2_Init(void **state)
 {
     const size_t msg_len = AVTP_CAN_BRIEF_V2_HEADER_LEN + 4;
     uint8_t msg[msg_len] = {0};
-    Avtp_CanBriefV2_t* canV2 = (Avtp_CanBriefV2_t*)msg;
+    Avtp_CanBriefV2_t *canV2 = (Avtp_CanBriefV2_t *)msg;
 
     // Check init function while passing in a null pointer
     Avtp_CanBriefV2_Init(NULL);
 
     Avtp_CanBriefV2_Init(canV2);
 
-    uint8_t expected_msg[msg_len] = {
-        0x44, 0x00, 0x0,  0x0,
-        0x0,  0x0,  0x0,  0x0,
-        0x0,  0x0,  0x0,  0x0
-    };
+    uint8_t expected_msg[msg_len] = {0x44, 0x00, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0};
 
     assert_memory_equal(msg, expected_msg, msg_len);
 }
 
-static void Test_CanBriefV2_GetAcfMsgType(void** state)
+static void Test_CanBriefV2_GetAcfMsgType(void **state)
 {
     const size_t msg_len = AVTP_CAN_BRIEF_V2_HEADER_LEN + 4;
-    uint8_t msg[msg_len] = {
-        0x44, 0x02, 0x0,  0x0,
-        0x0,  0x0,  0x0,  0x0,
-        0x0,  0x0,  0x0,  0x0
-    };
-    Avtp_CanBriefV2_t* canV2 = (Avtp_CanBriefV2_t*)msg;
+    uint8_t msg[msg_len] = {0x44, 0x02, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0};
+    Avtp_CanBriefV2_t *canV2 = (Avtp_CanBriefV2_t *)msg;
     assert_int_equal(Avtp_CanBriefV2_GetAcfMsgType(canV2), AVTP_ACF_TYPE_CAN_BRIEF_V2);
 }
 
-static void Test_CanBriefV2_GetAcfMsgLength(void** state)
+static void Test_CanBriefV2_GetAcfMsgLength(void **state)
 {
     const size_t msg_len = AVTP_CAN_BRIEF_V2_HEADER_LEN + 4;
-    uint8_t msg[msg_len] = {
-        0x44, 0x02, 0x0,  0x0,
-        0x0,  0x0,  0x0,  0x0,
-        0x0,  0x0,  0x0,  0x0
-    };
-    Avtp_CanBriefV2_t* canV2 = (Avtp_CanBriefV2_t*)msg;
+    uint8_t msg[msg_len] = {0x44, 0x02, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0};
+    Avtp_CanBriefV2_t *canV2 = (Avtp_CanBriefV2_t *)msg;
     assert_int_equal(Avtp_CanBriefV2_GetAcfMsgLength(canV2), 2);
 }
 
-static void Test_CanBriefV2_GetPad(void** state)
+static void Test_CanBriefV2_GetPad(void **state)
 {
     const size_t msg_len = AVTP_CAN_BRIEF_V2_HEADER_LEN + 4;
-    uint8_t msg[msg_len] = {
-        0x44, 0x02, 0xC0, 0x0,
-        0x0,  0x0,  0x0,  0x0,
-        0x0,  0x0,  0x0,  0x0
-    };
-    Avtp_CanBriefV2_t* canV2 = (Avtp_CanBriefV2_t*)msg;
+    uint8_t msg[msg_len] = {0x44, 0x02, 0xC0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0};
+    Avtp_CanBriefV2_t *canV2 = (Avtp_CanBriefV2_t *)msg;
     assert_int_equal(Avtp_CanBriefV2_GetPad(canV2), 3);
 }
 
-static void Test_CanBriefV2_IsMtv(void** state)
+static void Test_CanBriefV2_IsMtv(void **state)
 {
     const size_t msg_len = AVTP_CAN_BRIEF_V2_HEADER_LEN + 4;
-    uint8_t msg[msg_len] = {
-        0x44, 0x02, 0x20, 0x0,
-        0x0,  0x0,  0x0,  0x0,
-        0x0,  0x0,  0x0,  0x0
-    };
-    Avtp_CanBriefV2_t* canV2 = (Avtp_CanBriefV2_t*)msg;
+    uint8_t msg[msg_len] = {0x44, 0x02, 0x20, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0};
+    Avtp_CanBriefV2_t *canV2 = (Avtp_CanBriefV2_t *)msg;
     assert_int_equal(Avtp_CanBriefV2_IsMtv(canV2), true);
 }
 
-static void Test_CanBriefV2_IsRtr(void** state)
+static void Test_CanBriefV2_IsRtr(void **state)
 {
     const size_t msg_len = AVTP_CAN_BRIEF_V2_HEADER_LEN + 4;
-    uint8_t msg[msg_len] = {
-        0x44, 0x02, 0x10, 0x0,
-        0x0,  0x0,  0x0,  0x0,
-        0x0,  0x0,  0x0,  0x0
-    };
-    Avtp_CanBriefV2_t* canV2 = (Avtp_CanBriefV2_t*)msg;
+    uint8_t msg[msg_len] = {0x44, 0x02, 0x10, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0};
+    Avtp_CanBriefV2_t *canV2 = (Avtp_CanBriefV2_t *)msg;
     assert_int_equal(Avtp_CanBriefV2_IsRtr(canV2), true);
 }
 
-static void Test_CanBriefV2_IsEff(void** state)
+static void Test_CanBriefV2_IsEff(void **state)
 {
     const size_t msg_len = AVTP_CAN_BRIEF_V2_HEADER_LEN + 4;
-    uint8_t msg[msg_len] = {
-        0x44, 0x02, 0x08, 0x0,
-        0x0,  0x0,  0x0,  0x0,
-        0x0,  0x0,  0x0,  0x0
-    };
-    Avtp_CanBriefV2_t* canV2 = (Avtp_CanBriefV2_t*)msg;
+    uint8_t msg[msg_len] = {0x44, 0x02, 0x08, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0};
+    Avtp_CanBriefV2_t *canV2 = (Avtp_CanBriefV2_t *)msg;
     assert_int_equal(Avtp_CanBriefV2_IsEff(canV2), true);
 }
 
-static void Test_CanBriefV2_GetCanBusId(void** state)
+static void Test_CanBriefV2_GetCanBusId(void **state)
 {
     const size_t msg_len = AVTP_CAN_BRIEF_V2_HEADER_LEN + 4;
-    uint8_t msg[msg_len] = {
-        0x44, 0x02, 0x05, 0xFF,
-        0x0,  0x0,  0x0,  0x0,
-        0x0,  0x0,  0x0,  0x0
-    };
-    Avtp_CanBriefV2_t* canV2 = (Avtp_CanBriefV2_t*)msg;
+    uint8_t msg[msg_len] = {0x44, 0x02, 0x05, 0xFF, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0};
+    Avtp_CanBriefV2_t *canV2 = (Avtp_CanBriefV2_t *)msg;
     assert_int_equal(Avtp_CanBriefV2_GetCanBusId(canV2), 0x5FF);
 }
 
-static void Test_CanBriefV2_IsBrs(void** state)
+static void Test_CanBriefV2_IsBrs(void **state)
 {
     const size_t msg_len = AVTP_CAN_BRIEF_V2_HEADER_LEN + 4;
-    uint8_t msg[msg_len] = {
-        0x44, 0x02, 0x0,  0x0,
-        0x80, 0x0,  0x0,  0x0,
-        0x0,  0x0,  0x0,  0x0
-    };
-    Avtp_CanBriefV2_t* canV2 = (Avtp_CanBriefV2_t*)msg;
+    uint8_t msg[msg_len] = {0x44, 0x02, 0x0, 0x0, 0x80, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0};
+    Avtp_CanBriefV2_t *canV2 = (Avtp_CanBriefV2_t *)msg;
     assert_int_equal(Avtp_CanBriefV2_IsBrs(canV2), true);
 }
 
-static void Test_CanBriefV2_IsFdf(void** state)
+static void Test_CanBriefV2_IsFdf(void **state)
 {
     const size_t msg_len = AVTP_CAN_BRIEF_V2_HEADER_LEN + 4;
-    uint8_t msg[msg_len] = {
-        0x44, 0x02, 0x0,  0x0,
-        0x40, 0x0,  0x0,  0x0,
-        0x0,  0x0,  0x0,  0x0
-    };
-    Avtp_CanBriefV2_t* canV2 = (Avtp_CanBriefV2_t*)msg;
+    uint8_t msg[msg_len] = {0x44, 0x02, 0x0, 0x0, 0x40, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0};
+    Avtp_CanBriefV2_t *canV2 = (Avtp_CanBriefV2_t *)msg;
     assert_int_equal(Avtp_CanBriefV2_IsFdf(canV2), true);
 }
 
-static void Test_CanBriefV2_IsEsi(void** state)
+static void Test_CanBriefV2_IsEsi(void **state)
 {
     const size_t msg_len = AVTP_CAN_BRIEF_V2_HEADER_LEN + 4;
-    uint8_t msg[msg_len] = {
-        0x44, 0x02, 0x0,  0x0,
-        0x20, 0x0,  0x0,  0x0,
-        0x0,  0x0,  0x0,  0x0
-    };
-    Avtp_CanBriefV2_t* canV2 = (Avtp_CanBriefV2_t*)msg;
+    uint8_t msg[msg_len] = {0x44, 0x02, 0x0, 0x0, 0x20, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0};
+    Avtp_CanBriefV2_t *canV2 = (Avtp_CanBriefV2_t *)msg;
     assert_int_equal(Avtp_CanBriefV2_IsEsi(canV2), true);
 }
 
-static void Test_CanBriefV2_GetCanIdentifier(void** state)
+static void Test_CanBriefV2_GetCanIdentifier(void **state)
 {
     const size_t msg_len = AVTP_CAN_BRIEF_V2_HEADER_LEN + 4;
-    uint8_t msg[msg_len] = {
-        0x44, 0x02, 0x0,  0x0,
-        0x17, 0xFF, 0xFF, 0xFF,
-        0x0,  0x0,  0x0,  0x0
-    };
-    Avtp_CanBriefV2_t* canV2 = (Avtp_CanBriefV2_t*)msg;
+    uint8_t msg[msg_len] = {0x44, 0x02, 0x0, 0x0, 0x17, 0xFF, 0xFF, 0xFF, 0x0, 0x0, 0x0, 0x0};
+    Avtp_CanBriefV2_t *canV2 = (Avtp_CanBriefV2_t *)msg;
     assert_int_equal(Avtp_CanBriefV2_GetCanIdentifier(canV2), 0x17FFFFFFul);
 }
 
-static void Test_CanBriefV2_GetPayloadLength(void** state)
+static void Test_CanBriefV2_GetPayloadLength(void **state)
 {
     const size_t msg_len = AVTP_CAN_BRIEF_V2_HEADER_LEN + 4;
-    uint8_t msg[msg_len] = {
-        0x44, 0x03, 0xC0, 0x0,
-        0x0,  0x0,  0x0,  0x0,
-        0x0,  0x0,  0x0,  0x0
-    };
-    Avtp_CanBriefV2_t* canV2 = (Avtp_CanBriefV2_t*)msg;
+    uint8_t msg[msg_len] = {0x44, 0x03, 0xC0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0};
+    Avtp_CanBriefV2_t *canV2 = (Avtp_CanBriefV2_t *)msg;
     assert_int_equal(Avtp_CanBriefV2_GetPayloadLength(canV2), 1);
 }
 
-static void Test_CanBriefV2_GetPayloadLength_NoPadding(void** state)
+static void Test_CanBriefV2_GetPayloadLength_NoPadding(void **state)
 {
     const size_t msg_len = AVTP_CAN_BRIEF_V2_HEADER_LEN + 4;
-    uint8_t msg[msg_len] = {
-        0x44, 0x03, 0x0,  0x0,
-        0x0,  0x0,  0x0,  0x0,
-        0x0,  0x0,  0x0,  0x0
-    };
-    Avtp_CanBriefV2_t* canV2 = (Avtp_CanBriefV2_t*)msg;
+    uint8_t msg[msg_len] = {0x44, 0x03, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0};
+    Avtp_CanBriefV2_t *canV2 = (Avtp_CanBriefV2_t *)msg;
     assert_int_equal(Avtp_CanBriefV2_GetPayloadLength(canV2), 4);
 }
 
-static void Test_CanBriefV2_GetAcfMsgLengthInBytes(void** state)
+static void Test_CanBriefV2_GetAcfMsgLengthInBytes(void **state)
 {
     const size_t msg_len = AVTP_CAN_BRIEF_V2_HEADER_LEN + 4;
-    uint8_t msg[msg_len] = {
-        0x44, 0x03, 0x0,  0x0,
-        0x0,  0x0,  0x0,  0x0,
-        0x0,  0x0,  0x0,  0x0
-    };
-    Avtp_CanBriefV2_t* canV2 = (Avtp_CanBriefV2_t*)msg;
+    uint8_t msg[msg_len] = {0x44, 0x03, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0};
+    Avtp_CanBriefV2_t *canV2 = (Avtp_CanBriefV2_t *)msg;
     assert_int_equal(Avtp_CanBriefV2_GetAcfMsgLengthInBytes(canV2), 3 * 4);
 }
 
-static void Test_CanBriefV2_SetAcfMsgType(void** state)
+static void Test_CanBriefV2_SetAcfMsgType(void **state)
 {
     const size_t msg_len = AVTP_CAN_BRIEF_V2_HEADER_LEN + 4;
     uint8_t msg[msg_len] = {0};
-    Avtp_CanBriefV2_t* canV2 = (Avtp_CanBriefV2_t*)msg;
+    Avtp_CanBriefV2_t *canV2 = (Avtp_CanBriefV2_t *)msg;
     Avtp_CanBriefV2_Init(canV2);
     Avtp_CanBriefV2_SetAcfMsgType(canV2, AVTP_ACF_TYPE_CAN_BRIEF_V2);
     assert_int_equal(Avtp_CanBriefV2_GetAcfMsgType(canV2), AVTP_ACF_TYPE_CAN_BRIEF_V2);
 }
 
-static void Test_CanBriefV2_SetAcfMsgLength(void** state)
+static void Test_CanBriefV2_SetAcfMsgLength(void **state)
 {
     const size_t msg_len = AVTP_CAN_BRIEF_V2_HEADER_LEN + 4;
     uint8_t msg[msg_len] = {0};
-    Avtp_CanBriefV2_t* canV2 = (Avtp_CanBriefV2_t*)msg;
+    Avtp_CanBriefV2_t *canV2 = (Avtp_CanBriefV2_t *)msg;
     Avtp_CanBriefV2_Init(canV2);
     Avtp_CanBriefV2_SetAcfMsgLength(canV2, 5);
     assert_int_equal(Avtp_CanBriefV2_GetAcfMsgLength(canV2), 5);
     assert_int_equal(Avtp_CanBriefV2_GetAcfMsgLengthInBytes(canV2), 20);
 }
 
-static void Test_CanBriefV2_SetMtv(void** state)
+static void Test_CanBriefV2_SetMtv(void **state)
 {
     const size_t msg_len = AVTP_CAN_BRIEF_V2_HEADER_LEN + 4;
     uint8_t msg[msg_len] = {0};
-    Avtp_CanBriefV2_t* canV2 = (Avtp_CanBriefV2_t*)msg;
+    Avtp_CanBriefV2_t *canV2 = (Avtp_CanBriefV2_t *)msg;
     Avtp_CanBriefV2_Init(canV2);
     Avtp_CanBriefV2_SetMtv(canV2, true);
 
-    uint8_t expected_msg[msg_len] = {
-        0x44, 0x00, 0x20, 0x0,
-        0x0,  0x0,  0x0,  0x0,
-        0x0,  0x0,  0x0,  0x0
-    };
+    uint8_t expected_msg[msg_len] = {0x44, 0x00, 0x20, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0};
     assert_memory_equal(msg, expected_msg, msg_len);
 }
 
-static void Test_CanBriefV2_SetRtr(void** state)
+static void Test_CanBriefV2_SetRtr(void **state)
 {
     const size_t msg_len = AVTP_CAN_BRIEF_V2_HEADER_LEN + 4;
     uint8_t msg[msg_len] = {0};
-    Avtp_CanBriefV2_t* canV2 = (Avtp_CanBriefV2_t*)msg;
+    Avtp_CanBriefV2_t *canV2 = (Avtp_CanBriefV2_t *)msg;
     Avtp_CanBriefV2_Init(canV2);
     Avtp_CanBriefV2_SetRtr(canV2, true);
 
-    uint8_t expected_msg[msg_len] = {
-        0x44, 0x00, 0x10, 0x0,
-        0x0,  0x0,  0x0,  0x0,
-        0x0,  0x0,  0x0,  0x0
-    };
+    uint8_t expected_msg[msg_len] = {0x44, 0x00, 0x10, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0};
     assert_memory_equal(msg, expected_msg, msg_len);
 }
 
-static void Test_CanBriefV2_SetEff(void** state)
+static void Test_CanBriefV2_SetEff(void **state)
 {
     const size_t msg_len = AVTP_CAN_BRIEF_V2_HEADER_LEN + 4;
     uint8_t msg[msg_len] = {0};
-    Avtp_CanBriefV2_t* canV2 = (Avtp_CanBriefV2_t*)msg;
+    Avtp_CanBriefV2_t *canV2 = (Avtp_CanBriefV2_t *)msg;
     Avtp_CanBriefV2_Init(canV2);
     Avtp_CanBriefV2_SetEff(canV2, true);
 
-    uint8_t expected_msg[msg_len] = {
-        0x44, 0x00, 0x08, 0x0,
-        0x0,  0x0,  0x0,  0x0,
-        0x0,  0x0,  0x0,  0x0
-    };
+    uint8_t expected_msg[msg_len] = {0x44, 0x00, 0x08, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0};
     assert_memory_equal(msg, expected_msg, msg_len);
 }
 
-static void Test_CanBriefV2_SetCanBusId(void** state)
+static void Test_CanBriefV2_SetCanBusId(void **state)
 {
     const size_t msg_len = AVTP_CAN_BRIEF_V2_HEADER_LEN + 4;
     uint8_t msg[msg_len] = {0};
-    Avtp_CanBriefV2_t* canV2 = (Avtp_CanBriefV2_t*)msg;
+    Avtp_CanBriefV2_t *canV2 = (Avtp_CanBriefV2_t *)msg;
     Avtp_CanBriefV2_Init(canV2);
     Avtp_CanBriefV2_SetCanBusId(canV2, 0x5FF);
 
-    uint8_t expected_msg[msg_len] = {
-        0x44, 0x00, 0x05, 0xFF,
-        0x0,  0x0,  0x0,  0x0,
-        0x0,  0x0,  0x0,  0x0
-    };
+    uint8_t expected_msg[msg_len] = {0x44, 0x00, 0x05, 0xFF, 0x0, 0x0,
+                                     0x0,  0x0,  0x0,  0x0,  0x0, 0x0};
     assert_memory_equal(msg, expected_msg, msg_len);
 }
 
-static void Test_CanBriefV2_SetBrs(void** state)
+static void Test_CanBriefV2_SetBrs(void **state)
 {
     const size_t msg_len = AVTP_CAN_BRIEF_V2_HEADER_LEN + 4;
     uint8_t msg[msg_len] = {0};
-    Avtp_CanBriefV2_t* canV2 = (Avtp_CanBriefV2_t*)msg;
+    Avtp_CanBriefV2_t *canV2 = (Avtp_CanBriefV2_t *)msg;
     Avtp_CanBriefV2_Init(canV2);
     Avtp_CanBriefV2_SetBrs(canV2, true);
 
-    uint8_t expected_msg[msg_len] = {
-        0x44, 0x00, 0x0,  0x0,
-        0x80, 0x0,  0x0,  0x0,
-        0x0,  0x0,  0x0,  0x0
-    };
+    uint8_t expected_msg[msg_len] = {0x44, 0x00, 0x0, 0x0, 0x80, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0};
     assert_memory_equal(msg, expected_msg, msg_len);
 }
 
-static void Test_CanBriefV2_SetFdf(void** state)
+static void Test_CanBriefV2_SetFdf(void **state)
 {
     const size_t msg_len = AVTP_CAN_BRIEF_V2_HEADER_LEN + 4;
     uint8_t msg[msg_len] = {0};
-    Avtp_CanBriefV2_t* canV2 = (Avtp_CanBriefV2_t*)msg;
+    Avtp_CanBriefV2_t *canV2 = (Avtp_CanBriefV2_t *)msg;
     Avtp_CanBriefV2_Init(canV2);
     Avtp_CanBriefV2_SetFdf(canV2, true);
 
-    uint8_t expected_msg[msg_len] = {
-        0x44, 0x00, 0x0,  0x0,
-        0x40, 0x0,  0x0,  0x0,
-        0x0,  0x0,  0x0,  0x0
-    };
+    uint8_t expected_msg[msg_len] = {0x44, 0x00, 0x0, 0x0, 0x40, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0};
     assert_memory_equal(msg, expected_msg, msg_len);
 }
 
-static void Test_CanBriefV2_SetEsi(void** state)
+static void Test_CanBriefV2_SetEsi(void **state)
 {
     const size_t msg_len = AVTP_CAN_BRIEF_V2_HEADER_LEN + 4;
     uint8_t msg[msg_len] = {0};
-    Avtp_CanBriefV2_t* canV2 = (Avtp_CanBriefV2_t*)msg;
+    Avtp_CanBriefV2_t *canV2 = (Avtp_CanBriefV2_t *)msg;
     Avtp_CanBriefV2_Init(canV2);
     Avtp_CanBriefV2_SetEsi(canV2, true);
 
-    uint8_t expected_msg[msg_len] = {
-        0x44, 0x00, 0x0,  0x0,
-        0x20, 0x0,  0x0,  0x0,
-        0x0,  0x0,  0x0,  0x0
-    };
+    uint8_t expected_msg[msg_len] = {0x44, 0x00, 0x0, 0x0, 0x20, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0};
     assert_memory_equal(msg, expected_msg, msg_len);
 }
 
-static void Test_CanBriefV2_SetCanIdentifier(void** state)
+static void Test_CanBriefV2_SetCanIdentifier(void **state)
 {
     const size_t msg_len = AVTP_CAN_BRIEF_V2_HEADER_LEN + 4;
     uint8_t msg[msg_len] = {0};
-    Avtp_CanBriefV2_t* canV2 = (Avtp_CanBriefV2_t*)msg;
+    Avtp_CanBriefV2_t *canV2 = (Avtp_CanBriefV2_t *)msg;
     Avtp_CanBriefV2_Init(canV2);
     Avtp_CanBriefV2_SetCanIdentifier(canV2, 0x17FFFFFFul);
 
-    uint8_t expected_msg[msg_len] = {
-        0x44, 0x00, 0x0,  0x0,
-        0x17, 0xFF, 0xFF, 0xFF,
-        0x0,  0x0,  0x0,  0x0
-    };
+    uint8_t expected_msg[msg_len] = {0x44, 0x00, 0x0, 0x0, 0x17, 0xFF,
+                                     0xFF, 0xFF, 0x0, 0x0, 0x0,  0x0};
     assert_memory_equal(msg, expected_msg, msg_len);
 }
 
-static void Test_CanBriefV2_SetPayloadLength(void** state)
+static void Test_CanBriefV2_SetPayloadLength(void **state)
 {
     const size_t msg_len = AVTP_CAN_BRIEF_V2_HEADER_LEN + 4;
     uint8_t msg[msg_len] = {0};
-    Avtp_CanBriefV2_t* canV2 = (Avtp_CanBriefV2_t*)msg;
+    Avtp_CanBriefV2_t *canV2 = (Avtp_CanBriefV2_t *)msg;
     Avtp_CanBriefV2_Init(canV2);
     Avtp_CanBriefV2_SetPayloadLength(canV2, 3);
 
-    uint8_t expected_msg[msg_len] = {
-        0x44, 0x03, 0x40, 0x0,
-        0x0,  0x0,  0x0,  0x0,
-        0x0,  0x0,  0x0,  0x0
-    };
+    uint8_t expected_msg[msg_len] = {0x44, 0x03, 0x40, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0};
     assert_memory_equal(msg, expected_msg, msg_len);
 }
 
-static void Test_CanBriefV2_SetPayloadLength_NoPadding(void** state)
+static void Test_CanBriefV2_SetPayloadLength_NoPadding(void **state)
 {
     const size_t msg_len = AVTP_CAN_BRIEF_V2_HEADER_LEN + 4;
     uint8_t msg[msg_len] = {0};
-    Avtp_CanBriefV2_t* canV2 = (Avtp_CanBriefV2_t*)msg;
+    Avtp_CanBriefV2_t *canV2 = (Avtp_CanBriefV2_t *)msg;
     Avtp_CanBriefV2_Init(canV2);
     Avtp_CanBriefV2_SetPayloadLength(canV2, 4);
 
-    uint8_t expected_msg[msg_len] = {
-        0x44, 0x03, 0x0,  0x0,
-        0x0,  0x0,  0x0,  0x0,
-        0x0,  0x0,  0x0,  0x0
-    };
+    uint8_t expected_msg[msg_len] = {0x44, 0x03, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0};
     assert_memory_equal(msg, expected_msg, msg_len);
 }
 
-static void Test_CanBriefV2_Payload(void** state)
+static void Test_CanBriefV2_Payload(void **state)
 {
     const size_t msg_len = AVTP_CAN_BRIEF_V2_HEADER_LEN + 8;
     uint8_t msg[msg_len] = {0};
-    Avtp_CanBriefV2_t* canV2 = (Avtp_CanBriefV2_t*)msg;
-    uint8_t payload[8] = {0,1,2,3,4,5,6,7};
+    Avtp_CanBriefV2_t *canV2 = (Avtp_CanBriefV2_t *)msg;
+    uint8_t payload[8] = {0, 1, 2, 3, 4, 5, 6, 7};
 
     Avtp_CanBriefV2_Init(canV2);
     Avtp_CanBriefV2_SetPayload(canV2, payload, sizeof(payload));
@@ -422,15 +324,16 @@ static void Test_CanBriefV2_Payload(void** state)
     assert_memory_equal(payload, Avtp_CanBriefV2_GetPayload(canV2), sizeof(payload));
 }
 
-static void Test_CanBriefV2_CreateAcfMessage(void** state)
+static void Test_CanBriefV2_CreateAcfMessage(void **state)
 {
     const size_t msg_len = AVTP_CAN_BRIEF_V2_HEADER_LEN + 8;
     uint8_t msg[msg_len] = {0};
-    Avtp_CanBriefV2_t* canV2 = (Avtp_CanBriefV2_t*)msg;
-    uint8_t payload[8] = {0,1,2,3,4,5,6,7};
+    Avtp_CanBriefV2_t *canV2 = (Avtp_CanBriefV2_t *)msg;
+    uint8_t payload[8] = {0, 1, 2, 3, 4, 5, 6, 7};
 
     Avtp_CanBriefV2_Init(canV2);
-    Avtp_CanBriefV2_CreateAcfMessage(canV2, 0x7ff, 0x5FF, payload, sizeof(payload), AVTP_CAN_CLASSIC);
+    Avtp_CanBriefV2_CreateAcfMessage(canV2, 0x7ff, 0x5FF, payload, sizeof(payload),
+                                     AVTP_CAN_CLASSIC);
 
     assert_int_equal(Avtp_CanBriefV2_GetCanIdentifier(canV2), 0x7ff);
     assert_int_equal(Avtp_CanBriefV2_GetCanBusId(canV2), 0x5FF);
@@ -439,16 +342,17 @@ static void Test_CanBriefV2_CreateAcfMessage(void** state)
     assert_int_equal(Avtp_CanBriefV2_GetPayloadLength(canV2), 8);
 
     // Extended Frame IDs set the EFF flag
-    Avtp_CanBriefV2_CreateAcfMessage(canV2, 0x800, 0x5FF, payload, sizeof(payload), AVTP_CAN_CLASSIC);
+    Avtp_CanBriefV2_CreateAcfMessage(canV2, 0x800, 0x5FF, payload, sizeof(payload),
+                                     AVTP_CAN_CLASSIC);
     assert_int_equal(Avtp_CanBriefV2_GetCanIdentifier(canV2), 0x800);
     assert_int_equal(Avtp_CanBriefV2_IsEff(canV2), true);
 }
 
-static void Test_CanBriefV2_IsValid(void** state)
+static void Test_CanBriefV2_IsValid(void **state)
 {
     const size_t msg_len = AVTP_CAN_BRIEF_V2_HEADER_LEN + 68;
     uint8_t msg[msg_len] = {0};
-    Avtp_CanBriefV2_t* canV2 = (Avtp_CanBriefV2_t*)msg;
+    Avtp_CanBriefV2_t *canV2 = (Avtp_CanBriefV2_t *)msg;
     uint32_t frame_id = 0x123;
 
     // An Init-only PDU has AcfMsgLength == 0, so IsValid must reject it.
@@ -457,9 +361,10 @@ static void Test_CanBriefV2_IsValid(void** state)
 
     // A properly-formed classic CAN frame with an 8-byte payload is valid.
     {
-        uint8_t payload[8] = {0,1,2,3,4,5,6,7};
+        uint8_t payload[8] = {0, 1, 2, 3, 4, 5, 6, 7};
         Avtp_CanBriefV2_Init(canV2);
-        Avtp_CanBriefV2_CreateAcfMessage(canV2, frame_id, 0x0, payload, sizeof(payload), AVTP_CAN_CLASSIC);
+        Avtp_CanBriefV2_CreateAcfMessage(canV2, frame_id, 0x0, payload, sizeof(payload),
+                                         AVTP_CAN_CLASSIC);
         assert_int_equal(Avtp_CanBriefV2_IsValid(canV2, msg_len), 1);
     }
 
@@ -471,7 +376,8 @@ static void Test_CanBriefV2_IsValid(void** state)
     {
         uint8_t too_big[12] = {0};
         Avtp_CanBriefV2_Init(canV2);
-        Avtp_CanBriefV2_CreateAcfMessage(canV2, frame_id, 0x0, too_big, sizeof(too_big), AVTP_CAN_CLASSIC);
+        Avtp_CanBriefV2_CreateAcfMessage(canV2, frame_id, 0x0, too_big, sizeof(too_big),
+                                         AVTP_CAN_CLASSIC);
         assert_int_equal(Avtp_CanBriefV2_IsValid(canV2, msg_len), 0);
     }
 
@@ -485,45 +391,44 @@ static void Test_CanBriefV2_IsValid(void** state)
     {
         uint8_t fd_too_big[68] = {0};
         Avtp_CanBriefV2_Init(canV2);
-        Avtp_CanBriefV2_CreateAcfMessage(canV2, frame_id, 0x0, fd_too_big, sizeof(fd_too_big), AVTP_CAN_FD);
+        Avtp_CanBriefV2_CreateAcfMessage(canV2, frame_id, 0x0, fd_too_big, sizeof(fd_too_big),
+                                         AVTP_CAN_FD);
         assert_int_equal(Avtp_CanBriefV2_IsValid(canV2, msg_len), 0);
     }
 }
 
 int main(void)
 {
-    const struct CMUnitTest tests[] = {
-        cmocka_unit_test(Test_CanBriefV2_Init),
-        cmocka_unit_test(Test_CanBriefV2_GetAcfMsgType),
-        cmocka_unit_test(Test_CanBriefV2_GetAcfMsgLength),
-        cmocka_unit_test(Test_CanBriefV2_GetPad),
-        cmocka_unit_test(Test_CanBriefV2_IsMtv),
-        cmocka_unit_test(Test_CanBriefV2_IsRtr),
-        cmocka_unit_test(Test_CanBriefV2_IsEff),
-        cmocka_unit_test(Test_CanBriefV2_GetCanBusId),
-        cmocka_unit_test(Test_CanBriefV2_IsBrs),
-        cmocka_unit_test(Test_CanBriefV2_IsFdf),
-        cmocka_unit_test(Test_CanBriefV2_IsEsi),
-        cmocka_unit_test(Test_CanBriefV2_GetCanIdentifier),
-        cmocka_unit_test(Test_CanBriefV2_GetPayloadLength),
-        cmocka_unit_test(Test_CanBriefV2_GetPayloadLength_NoPadding),
-        cmocka_unit_test(Test_CanBriefV2_GetAcfMsgLengthInBytes),
-        cmocka_unit_test(Test_CanBriefV2_SetAcfMsgType),
-        cmocka_unit_test(Test_CanBriefV2_SetAcfMsgLength),
-        cmocka_unit_test(Test_CanBriefV2_SetMtv),
-        cmocka_unit_test(Test_CanBriefV2_SetRtr),
-        cmocka_unit_test(Test_CanBriefV2_SetEff),
-        cmocka_unit_test(Test_CanBriefV2_SetCanBusId),
-        cmocka_unit_test(Test_CanBriefV2_SetBrs),
-        cmocka_unit_test(Test_CanBriefV2_SetFdf),
-        cmocka_unit_test(Test_CanBriefV2_SetEsi),
-        cmocka_unit_test(Test_CanBriefV2_SetCanIdentifier),
-        cmocka_unit_test(Test_CanBriefV2_SetPayloadLength),
-        cmocka_unit_test(Test_CanBriefV2_SetPayloadLength_NoPadding),
-        cmocka_unit_test(Test_CanBriefV2_Payload),
-        cmocka_unit_test(Test_CanBriefV2_CreateAcfMessage),
-        cmocka_unit_test(Test_CanBriefV2_IsValid)
-    };
+    const struct CMUnitTest tests[] = {cmocka_unit_test(Test_CanBriefV2_Init),
+                                       cmocka_unit_test(Test_CanBriefV2_GetAcfMsgType),
+                                       cmocka_unit_test(Test_CanBriefV2_GetAcfMsgLength),
+                                       cmocka_unit_test(Test_CanBriefV2_GetPad),
+                                       cmocka_unit_test(Test_CanBriefV2_IsMtv),
+                                       cmocka_unit_test(Test_CanBriefV2_IsRtr),
+                                       cmocka_unit_test(Test_CanBriefV2_IsEff),
+                                       cmocka_unit_test(Test_CanBriefV2_GetCanBusId),
+                                       cmocka_unit_test(Test_CanBriefV2_IsBrs),
+                                       cmocka_unit_test(Test_CanBriefV2_IsFdf),
+                                       cmocka_unit_test(Test_CanBriefV2_IsEsi),
+                                       cmocka_unit_test(Test_CanBriefV2_GetCanIdentifier),
+                                       cmocka_unit_test(Test_CanBriefV2_GetPayloadLength),
+                                       cmocka_unit_test(Test_CanBriefV2_GetPayloadLength_NoPadding),
+                                       cmocka_unit_test(Test_CanBriefV2_GetAcfMsgLengthInBytes),
+                                       cmocka_unit_test(Test_CanBriefV2_SetAcfMsgType),
+                                       cmocka_unit_test(Test_CanBriefV2_SetAcfMsgLength),
+                                       cmocka_unit_test(Test_CanBriefV2_SetMtv),
+                                       cmocka_unit_test(Test_CanBriefV2_SetRtr),
+                                       cmocka_unit_test(Test_CanBriefV2_SetEff),
+                                       cmocka_unit_test(Test_CanBriefV2_SetCanBusId),
+                                       cmocka_unit_test(Test_CanBriefV2_SetBrs),
+                                       cmocka_unit_test(Test_CanBriefV2_SetFdf),
+                                       cmocka_unit_test(Test_CanBriefV2_SetEsi),
+                                       cmocka_unit_test(Test_CanBriefV2_SetCanIdentifier),
+                                       cmocka_unit_test(Test_CanBriefV2_SetPayloadLength),
+                                       cmocka_unit_test(Test_CanBriefV2_SetPayloadLength_NoPadding),
+                                       cmocka_unit_test(Test_CanBriefV2_Payload),
+                                       cmocka_unit_test(Test_CanBriefV2_CreateAcfMessage),
+                                       cmocka_unit_test(Test_CanBriefV2_IsValid)};
 
     return cmocka_run_group_tests(tests, NULL, NULL);
 }

--- a/unit/test-can-brief-v2.c
+++ b/unit/test-can-brief-v2.c
@@ -44,15 +44,43 @@ static void Test_CanBriefV2_Init(void** state)
     const size_t msg_len = AVTP_CAN_BRIEF_V2_HEADER_LEN + 4;
     uint8_t msg[msg_len] = {0};
     Avtp_CanBriefV2_t* canV2 = (Avtp_CanBriefV2_t*)msg;
+
+    // Check init function while passing in a null pointer
+    Avtp_CanBriefV2_Init(NULL);
+
     Avtp_CanBriefV2_Init(canV2);
 
     uint8_t expected_msg[msg_len] = {
-        0x44, 0x02, 0x0,  0x0,
+        0x44, 0x00, 0x0,  0x0,
         0x0,  0x0,  0x0,  0x0,
         0x0,  0x0,  0x0,  0x0
     };
 
     assert_memory_equal(msg, expected_msg, msg_len);
+}
+
+static void Test_CanBriefV2_GetAcfMsgType(void** state)
+{
+    const size_t msg_len = AVTP_CAN_BRIEF_V2_HEADER_LEN + 4;
+    uint8_t msg[msg_len] = {
+        0x44, 0x02, 0x0,  0x0,
+        0x0,  0x0,  0x0,  0x0,
+        0x0,  0x0,  0x0,  0x0
+    };
+    Avtp_CanBriefV2_t* canV2 = (Avtp_CanBriefV2_t*)msg;
+    assert_int_equal(Avtp_CanBriefV2_GetAcfMsgType(canV2), AVTP_ACF_TYPE_CAN_BRIEF_V2);
+}
+
+static void Test_CanBriefV2_GetAcfMsgLength(void** state)
+{
+    const size_t msg_len = AVTP_CAN_BRIEF_V2_HEADER_LEN + 4;
+    uint8_t msg[msg_len] = {
+        0x44, 0x02, 0x0,  0x0,
+        0x0,  0x0,  0x0,  0x0,
+        0x0,  0x0,  0x0,  0x0
+    };
+    Avtp_CanBriefV2_t* canV2 = (Avtp_CanBriefV2_t*)msg;
+    assert_int_equal(Avtp_CanBriefV2_GetAcfMsgLength(canV2), 2);
 }
 
 static void Test_CanBriefV2_GetPad(void** state)
@@ -163,7 +191,7 @@ static void Test_CanBriefV2_GetCanIdentifier(void** state)
     assert_int_equal(Avtp_CanBriefV2_GetCanIdentifier(canV2), 0x17FFFFFFul);
 }
 
-static void Test_CanBriefV2_GetPayloadLen(void** state)
+static void Test_CanBriefV2_GetPayloadLength(void** state)
 {
     const size_t msg_len = AVTP_CAN_BRIEF_V2_HEADER_LEN + 4;
     uint8_t msg[msg_len] = {
@@ -172,10 +200,10 @@ static void Test_CanBriefV2_GetPayloadLen(void** state)
         0x0,  0x0,  0x0,  0x0
     };
     Avtp_CanBriefV2_t* canV2 = (Avtp_CanBriefV2_t*)msg;
-    assert_int_equal(Avtp_CanBriefV2_GetPayloadLen(canV2), 1);
+    assert_int_equal(Avtp_CanBriefV2_GetPayloadLength(canV2), 1);
 }
 
-static void Test_CanBriefV2_GetPayloadLen_NoPadding(void** state)
+static void Test_CanBriefV2_GetPayloadLength_NoPadding(void** state)
 {
     const size_t msg_len = AVTP_CAN_BRIEF_V2_HEADER_LEN + 4;
     uint8_t msg[msg_len] = {
@@ -184,10 +212,10 @@ static void Test_CanBriefV2_GetPayloadLen_NoPadding(void** state)
         0x0,  0x0,  0x0,  0x0
     };
     Avtp_CanBriefV2_t* canV2 = (Avtp_CanBriefV2_t*)msg;
-    assert_int_equal(Avtp_CanBriefV2_GetPayloadLen(canV2), 4);
+    assert_int_equal(Avtp_CanBriefV2_GetPayloadLength(canV2), 4);
 }
 
-static void Test_CanBriefV2_GetLen(void** state)
+static void Test_CanBriefV2_GetAcfMsgLengthInBytes(void** state)
 {
     const size_t msg_len = AVTP_CAN_BRIEF_V2_HEADER_LEN + 4;
     uint8_t msg[msg_len] = {
@@ -196,7 +224,28 @@ static void Test_CanBriefV2_GetLen(void** state)
         0x0,  0x0,  0x0,  0x0
     };
     Avtp_CanBriefV2_t* canV2 = (Avtp_CanBriefV2_t*)msg;
-    assert_int_equal(Avtp_CanBriefV2_GetLen(canV2), 3 * 4);
+    assert_int_equal(Avtp_CanBriefV2_GetAcfMsgLengthInBytes(canV2), 3 * 4);
+}
+
+static void Test_CanBriefV2_SetAcfMsgType(void** state)
+{
+    const size_t msg_len = AVTP_CAN_BRIEF_V2_HEADER_LEN + 4;
+    uint8_t msg[msg_len] = {0};
+    Avtp_CanBriefV2_t* canV2 = (Avtp_CanBriefV2_t*)msg;
+    Avtp_CanBriefV2_Init(canV2);
+    Avtp_CanBriefV2_SetAcfMsgType(canV2, AVTP_ACF_TYPE_CAN_BRIEF_V2);
+    assert_int_equal(Avtp_CanBriefV2_GetAcfMsgType(canV2), AVTP_ACF_TYPE_CAN_BRIEF_V2);
+}
+
+static void Test_CanBriefV2_SetAcfMsgLength(void** state)
+{
+    const size_t msg_len = AVTP_CAN_BRIEF_V2_HEADER_LEN + 4;
+    uint8_t msg[msg_len] = {0};
+    Avtp_CanBriefV2_t* canV2 = (Avtp_CanBriefV2_t*)msg;
+    Avtp_CanBriefV2_Init(canV2);
+    Avtp_CanBriefV2_SetAcfMsgLength(canV2, 5);
+    assert_int_equal(Avtp_CanBriefV2_GetAcfMsgLength(canV2), 5);
+    assert_int_equal(Avtp_CanBriefV2_GetAcfMsgLengthInBytes(canV2), 20);
 }
 
 static void Test_CanBriefV2_SetMtv(void** state)
@@ -208,7 +257,7 @@ static void Test_CanBriefV2_SetMtv(void** state)
     Avtp_CanBriefV2_SetMtv(canV2, true);
 
     uint8_t expected_msg[msg_len] = {
-        0x44, 0x02, 0x20, 0x0,
+        0x44, 0x00, 0x20, 0x0,
         0x0,  0x0,  0x0,  0x0,
         0x0,  0x0,  0x0,  0x0
     };
@@ -224,7 +273,7 @@ static void Test_CanBriefV2_SetRtr(void** state)
     Avtp_CanBriefV2_SetRtr(canV2, true);
 
     uint8_t expected_msg[msg_len] = {
-        0x44, 0x02, 0x10, 0x0,
+        0x44, 0x00, 0x10, 0x0,
         0x0,  0x0,  0x0,  0x0,
         0x0,  0x0,  0x0,  0x0
     };
@@ -240,7 +289,7 @@ static void Test_CanBriefV2_SetEff(void** state)
     Avtp_CanBriefV2_SetEff(canV2, true);
 
     uint8_t expected_msg[msg_len] = {
-        0x44, 0x02, 0x08, 0x0,
+        0x44, 0x00, 0x08, 0x0,
         0x0,  0x0,  0x0,  0x0,
         0x0,  0x0,  0x0,  0x0
     };
@@ -256,7 +305,7 @@ static void Test_CanBriefV2_SetCanBusId(void** state)
     Avtp_CanBriefV2_SetCanBusId(canV2, 0x5FF);
 
     uint8_t expected_msg[msg_len] = {
-        0x44, 0x02, 0x05, 0xFF,
+        0x44, 0x00, 0x05, 0xFF,
         0x0,  0x0,  0x0,  0x0,
         0x0,  0x0,  0x0,  0x0
     };
@@ -272,7 +321,7 @@ static void Test_CanBriefV2_SetBrs(void** state)
     Avtp_CanBriefV2_SetBrs(canV2, true);
 
     uint8_t expected_msg[msg_len] = {
-        0x44, 0x02, 0x0,  0x0,
+        0x44, 0x00, 0x0,  0x0,
         0x80, 0x0,  0x0,  0x0,
         0x0,  0x0,  0x0,  0x0
     };
@@ -288,7 +337,7 @@ static void Test_CanBriefV2_SetFdf(void** state)
     Avtp_CanBriefV2_SetFdf(canV2, true);
 
     uint8_t expected_msg[msg_len] = {
-        0x44, 0x02, 0x0,  0x0,
+        0x44, 0x00, 0x0,  0x0,
         0x40, 0x0,  0x0,  0x0,
         0x0,  0x0,  0x0,  0x0
     };
@@ -304,7 +353,7 @@ static void Test_CanBriefV2_SetEsi(void** state)
     Avtp_CanBriefV2_SetEsi(canV2, true);
 
     uint8_t expected_msg[msg_len] = {
-        0x44, 0x02, 0x0,  0x0,
+        0x44, 0x00, 0x0,  0x0,
         0x20, 0x0,  0x0,  0x0,
         0x0,  0x0,  0x0,  0x0
     };
@@ -320,20 +369,20 @@ static void Test_CanBriefV2_SetCanIdentifier(void** state)
     Avtp_CanBriefV2_SetCanIdentifier(canV2, 0x17FFFFFFul);
 
     uint8_t expected_msg[msg_len] = {
-        0x44, 0x02, 0x0,  0x0,
+        0x44, 0x00, 0x0,  0x0,
         0x17, 0xFF, 0xFF, 0xFF,
         0x0,  0x0,  0x0,  0x0
     };
     assert_memory_equal(msg, expected_msg, msg_len);
 }
 
-static void Test_CanBriefV2_SetPayloadLen(void** state)
+static void Test_CanBriefV2_SetPayloadLength(void** state)
 {
     const size_t msg_len = AVTP_CAN_BRIEF_V2_HEADER_LEN + 4;
     uint8_t msg[msg_len] = {0};
     Avtp_CanBriefV2_t* canV2 = (Avtp_CanBriefV2_t*)msg;
     Avtp_CanBriefV2_Init(canV2);
-    Avtp_CanBriefV2_SetPayloadLen(canV2, 3);
+    Avtp_CanBriefV2_SetPayloadLength(canV2, 3);
 
     uint8_t expected_msg[msg_len] = {
         0x44, 0x03, 0x40, 0x0,
@@ -343,13 +392,13 @@ static void Test_CanBriefV2_SetPayloadLen(void** state)
     assert_memory_equal(msg, expected_msg, msg_len);
 }
 
-static void Test_CanBriefV2_SetPayloadLen_NoPadding(void** state)
+static void Test_CanBriefV2_SetPayloadLength_NoPadding(void** state)
 {
     const size_t msg_len = AVTP_CAN_BRIEF_V2_HEADER_LEN + 4;
     uint8_t msg[msg_len] = {0};
     Avtp_CanBriefV2_t* canV2 = (Avtp_CanBriefV2_t*)msg;
     Avtp_CanBriefV2_Init(canV2);
-    Avtp_CanBriefV2_SetPayloadLen(canV2, 4);
+    Avtp_CanBriefV2_SetPayloadLength(canV2, 4);
 
     uint8_t expected_msg[msg_len] = {
         0x44, 0x03, 0x0,  0x0,
@@ -359,10 +408,94 @@ static void Test_CanBriefV2_SetPayloadLen_NoPadding(void** state)
     assert_memory_equal(msg, expected_msg, msg_len);
 }
 
+static void Test_CanBriefV2_Payload(void** state)
+{
+    const size_t msg_len = AVTP_CAN_BRIEF_V2_HEADER_LEN + 8;
+    uint8_t msg[msg_len] = {0};
+    Avtp_CanBriefV2_t* canV2 = (Avtp_CanBriefV2_t*)msg;
+    uint8_t payload[8] = {0,1,2,3,4,5,6,7};
+
+    Avtp_CanBriefV2_Init(canV2);
+    Avtp_CanBriefV2_SetPayload(canV2, payload, sizeof(payload));
+
+    assert_ptr_equal(Avtp_CanBriefV2_GetPayload(canV2), msg + AVTP_CAN_BRIEF_V2_HEADER_LEN);
+    assert_memory_equal(payload, Avtp_CanBriefV2_GetPayload(canV2), sizeof(payload));
+}
+
+static void Test_CanBriefV2_CreateAcfMessage(void** state)
+{
+    const size_t msg_len = AVTP_CAN_BRIEF_V2_HEADER_LEN + 8;
+    uint8_t msg[msg_len] = {0};
+    Avtp_CanBriefV2_t* canV2 = (Avtp_CanBriefV2_t*)msg;
+    uint8_t payload[8] = {0,1,2,3,4,5,6,7};
+
+    Avtp_CanBriefV2_Init(canV2);
+    Avtp_CanBriefV2_CreateAcfMessage(canV2, 0x7ff, 0x5FF, payload, sizeof(payload), AVTP_CAN_CLASSIC);
+
+    assert_int_equal(Avtp_CanBriefV2_GetCanIdentifier(canV2), 0x7ff);
+    assert_int_equal(Avtp_CanBriefV2_GetCanBusId(canV2), 0x5FF);
+    assert_int_equal(Avtp_CanBriefV2_IsEff(canV2), false);
+    assert_memory_equal(payload, msg + AVTP_CAN_BRIEF_V2_HEADER_LEN, sizeof(payload));
+    assert_int_equal(Avtp_CanBriefV2_GetPayloadLength(canV2), 8);
+
+    // Extended Frame IDs set the EFF flag
+    Avtp_CanBriefV2_CreateAcfMessage(canV2, 0x800, 0x5FF, payload, sizeof(payload), AVTP_CAN_CLASSIC);
+    assert_int_equal(Avtp_CanBriefV2_GetCanIdentifier(canV2), 0x800);
+    assert_int_equal(Avtp_CanBriefV2_IsEff(canV2), true);
+}
+
+static void Test_CanBriefV2_IsValid(void** state)
+{
+    const size_t msg_len = AVTP_CAN_BRIEF_V2_HEADER_LEN + 68;
+    uint8_t msg[msg_len] = {0};
+    Avtp_CanBriefV2_t* canV2 = (Avtp_CanBriefV2_t*)msg;
+    uint32_t frame_id = 0x123;
+
+    // An Init-only PDU has AcfMsgLength == 0, so IsValid must reject it.
+    Avtp_CanBriefV2_Init(canV2);
+    assert_int_equal(Avtp_CanBriefV2_IsValid(canV2, msg_len), 0);
+
+    // A properly-formed classic CAN frame with an 8-byte payload is valid.
+    {
+        uint8_t payload[8] = {0,1,2,3,4,5,6,7};
+        Avtp_CanBriefV2_Init(canV2);
+        Avtp_CanBriefV2_CreateAcfMessage(canV2, frame_id, 0x0, payload, sizeof(payload), AVTP_CAN_CLASSIC);
+        assert_int_equal(Avtp_CanBriefV2_IsValid(canV2, msg_len), 1);
+    }
+
+    // Not a CAN Brief V2 message (zero buffer, AcfMsgType != CAN_BRIEF_V2).
+    memset(msg, 0, msg_len);
+    assert_int_equal(Avtp_CanBriefV2_IsValid(canV2, msg_len), 0);
+
+    // Classic CAN payload bound: a 12-byte payload as classic CAN is invalid.
+    {
+        uint8_t too_big[12] = {0};
+        Avtp_CanBriefV2_Init(canV2);
+        Avtp_CanBriefV2_CreateAcfMessage(canV2, frame_id, 0x0, too_big, sizeof(too_big), AVTP_CAN_CLASSIC);
+        assert_int_equal(Avtp_CanBriefV2_IsValid(canV2, msg_len), 0);
+    }
+
+    // CAN-FD payload bound: 64 bytes valid, 68 bytes invalid.
+    {
+        uint8_t fd_max[64] = {0};
+        Avtp_CanBriefV2_Init(canV2);
+        Avtp_CanBriefV2_CreateAcfMessage(canV2, frame_id, 0x0, fd_max, sizeof(fd_max), AVTP_CAN_FD);
+        assert_int_equal(Avtp_CanBriefV2_IsValid(canV2, msg_len), 1);
+    }
+    {
+        uint8_t fd_too_big[68] = {0};
+        Avtp_CanBriefV2_Init(canV2);
+        Avtp_CanBriefV2_CreateAcfMessage(canV2, frame_id, 0x0, fd_too_big, sizeof(fd_too_big), AVTP_CAN_FD);
+        assert_int_equal(Avtp_CanBriefV2_IsValid(canV2, msg_len), 0);
+    }
+}
+
 int main(void)
 {
     const struct CMUnitTest tests[] = {
         cmocka_unit_test(Test_CanBriefV2_Init),
+        cmocka_unit_test(Test_CanBriefV2_GetAcfMsgType),
+        cmocka_unit_test(Test_CanBriefV2_GetAcfMsgLength),
         cmocka_unit_test(Test_CanBriefV2_GetPad),
         cmocka_unit_test(Test_CanBriefV2_IsMtv),
         cmocka_unit_test(Test_CanBriefV2_IsRtr),
@@ -372,9 +505,11 @@ int main(void)
         cmocka_unit_test(Test_CanBriefV2_IsFdf),
         cmocka_unit_test(Test_CanBriefV2_IsEsi),
         cmocka_unit_test(Test_CanBriefV2_GetCanIdentifier),
-        cmocka_unit_test(Test_CanBriefV2_GetPayloadLen),
-        cmocka_unit_test(Test_CanBriefV2_GetPayloadLen_NoPadding),
-        cmocka_unit_test(Test_CanBriefV2_GetLen),
+        cmocka_unit_test(Test_CanBriefV2_GetPayloadLength),
+        cmocka_unit_test(Test_CanBriefV2_GetPayloadLength_NoPadding),
+        cmocka_unit_test(Test_CanBriefV2_GetAcfMsgLengthInBytes),
+        cmocka_unit_test(Test_CanBriefV2_SetAcfMsgType),
+        cmocka_unit_test(Test_CanBriefV2_SetAcfMsgLength),
         cmocka_unit_test(Test_CanBriefV2_SetMtv),
         cmocka_unit_test(Test_CanBriefV2_SetRtr),
         cmocka_unit_test(Test_CanBriefV2_SetEff),
@@ -383,8 +518,11 @@ int main(void)
         cmocka_unit_test(Test_CanBriefV2_SetFdf),
         cmocka_unit_test(Test_CanBriefV2_SetEsi),
         cmocka_unit_test(Test_CanBriefV2_SetCanIdentifier),
-        cmocka_unit_test(Test_CanBriefV2_SetPayloadLen),
-        cmocka_unit_test(Test_CanBriefV2_SetPayloadLen_NoPadding)
+        cmocka_unit_test(Test_CanBriefV2_SetPayloadLength),
+        cmocka_unit_test(Test_CanBriefV2_SetPayloadLength_NoPadding),
+        cmocka_unit_test(Test_CanBriefV2_Payload),
+        cmocka_unit_test(Test_CanBriefV2_CreateAcfMessage),
+        cmocka_unit_test(Test_CanBriefV2_IsValid)
     };
 
     return cmocka_run_group_tests(tests, NULL, NULL);


### PR DESCRIPTION

 - Renamed functions and fields to follow other ACF
 - some const added
 - Added isValid and CreateMEssage
    - note: This was already header only so I added this to the header instead of adding a C file. I will make another PR making this the standard for all unified ACF (and update API design accordingly)
   