### PR TITLE
CanV2 apply API guidelines

### DIFF
--- a/include/avtp/acf/CanV2.h
+++ b/include/avtp/acf/CanV2.h
@@ -44,9 +44,14 @@ extern "C" {
 #include <stdbool.h>
 #include <string.h>
 
+#include "avtp/Utils.h"
 #include "avtp/Defines.h"
 #include "avtp/acf/AcfCommon.h"
-#include "avtp/Utils.h"
+
+#define GET_CAN_V2_FIELD(field)                                                                    \
+    (Avtp_GetField(Avtp_CanV2FieldDesc, AVTP_CAN_V2_FIELD_MAX, (uint8_t *)pdu, field))
+#define SET_CAN_V2_FIELD(field, value)                                                             \
+    (Avtp_SetField(Avtp_CanV2FieldDesc, AVTP_CAN_V2_FIELD_MAX, (uint8_t *)pdu, field, value))
 
 /**
  * Length of ACF_CAN_V2 message header in bytes.
@@ -60,7 +65,7 @@ extern "C" {
 typedef struct {
     uint8_t header[AVTP_CAN_V2_HEADER_LEN];
     uint8_t payload[0];
-} Avtp_CanV2_t;
+} __attribute__((packed)) Avtp_CanV2_t;
 
 /**
  * Fields encoded in the ACF_CAN_V2 header.
@@ -82,12 +87,12 @@ typedef enum {
     AVTP_CAN_V2_FIELD_CAN_IDENTIFIER,
     /* Count number of fields for bound checks */
     AVTP_CAN_V2_FIELD_MAX
-} Avtp_CanV2Field_t;
+} Avtp_CanV2Fields_t;
 
 /**
  * This table describes all the offsets of the ACF_CAN_V2 header fields.
  */
-static const Avtp_FieldDescriptor_t __AVTP_CAN_V2_FIELDS[AVTP_CAN_V2_FIELD_MAX] =
+static const Avtp_FieldDescriptor_t Avtp_CanV2FieldDesc[AVTP_CAN_V2_FIELD_MAX] =
 {
     /* ACF common header fields */
     [AVTP_CAN_V2_FIELD_ACF_MSG_TYPE]       = { .quadlet = 0, .offset =  0, .bits =  7 },
@@ -106,268 +111,416 @@ static const Avtp_FieldDescriptor_t __AVTP_CAN_V2_FIELDS[AVTP_CAN_V2_FIELD_MAX] 
 };
 
 /**
- * Macro to get the value of a field from an ACF_CAN_V2 message header.
+ * Return the value of the ACF message type field as specified in the IEEE 1722 Specification.
  *
- * @note This macro should not be used directly, instead use the field specific
- * getter functions defined below.
+ * @param pdu Pointer to the first bit of a 1722 ACF CAN V2 PDU.
+ * @returns Value of the ACF message type field.
  */
-#define __Avtp_CanV2_GetField(field) \
-        (Avtp_GetField(__AVTP_CAN_V2_FIELDS, AVTP_CAN_V2_FIELD_MAX, (uint8_t*)msg, field))
+OPEN1722_INLINE uint8_t Avtp_CanV2_GetAcfMsgType(const Avtp_CanV2_t* const pdu) {
+    return (uint8_t) GET_CAN_V2_FIELD(AVTP_CAN_V2_FIELD_ACF_MSG_TYPE);
+}
 
 /**
- * Macro to set the value of a field in an ACF_CAN_V2 message header.
+ * Return the value of the ACF message length field as specified in the IEEE 1722 Specification.
+ * This returns the length in Quadlets as specified in the IEEE 1722 Specification.
  *
- * @note This macro should not be used directly, instead use the field specific
- * setter functions defined below.
+ * You can use Avtp_CanV2_GetPayloadLength to get the length in bytes without padding.
+ *
+ * @param pdu Pointer to the first bit of a 1722 ACF CAN V2 PDU.
+ * @returns Value of the ACF message length field.
  */
-#define __Avtp_CanV2_SetField(field, value) \
-        (Avtp_SetField(__AVTP_CAN_V2_FIELDS, AVTP_CAN_V2_FIELD_MAX, (uint8_t*)msg, field, value))
+OPEN1722_INLINE uint16_t Avtp_CanV2_GetAcfMsgLength(const Avtp_CanV2_t* const pdu) {
+    return (uint16_t) GET_CAN_V2_FIELD(AVTP_CAN_V2_FIELD_ACF_MSG_LENGTH);
+}
 
 /**
- * Initializes an ACF_CAN_V2 message with default values for the header fields
- * including acf_msg_type and acf_msg_length.
+ * Return the ACF message length in bytes.
  *
- * @param msg Pointer to the ACF_CAN_V2 message to initialize.
+ * @param pdu Pointer to the first bit of a 1722 ACF CAN V2 PDU.
+ * @returns Length of the ACF message in bytes.
  */
-OPEN1722_INLINE void Avtp_CanV2_Init(Avtp_CanV2_t* msg) {
-    memset(msg, 0, sizeof(Avtp_CanV2_t));
-    __Avtp_CanV2_SetField(AVTP_CAN_V2_FIELD_ACF_MSG_TYPE, AVTP_ACF_TYPE_CAN_V2);
-    __Avtp_CanV2_SetField(AVTP_CAN_V2_FIELD_ACF_MSG_LENGTH, AVTP_CAN_V2_HEADER_LEN / AVTP_QUADLET_SIZE);
+OPEN1722_INLINE uint16_t Avtp_CanV2_GetAcfMsgLengthInBytes(const Avtp_CanV2_t* const pdu) {
+    return (uint16_t) GET_CAN_V2_FIELD(AVTP_CAN_V2_FIELD_ACF_MSG_LENGTH) * 4;
+}
+
+/**
+ * Set the value of the ACF message type field as specified in the IEEE 1722 Specification.
+ *
+ * @param pdu Pointer to the first bit of a 1722 ACF CAN V2 PDU.
+ * @param value Value to set the ACF message type field to.
+ */
+OPEN1722_INLINE void Avtp_CanV2_SetAcfMsgType(Avtp_CanV2_t* pdu, uint8_t value) {
+    SET_CAN_V2_FIELD(AVTP_CAN_V2_FIELD_ACF_MSG_TYPE, value);
+}
+
+/**
+ * Set the value of the ACF message length field as specified in the IEEE 1722 Specification.
+ * Note: the size is in Quadlets as specified in the IEEE 1722 Specification.
+ * You can use Avtp_CanV2_SetPayloadLength to set length in bytes and automatically set the
+ * correct padding.
+ *
+ * @param pdu Pointer to the first bit of a 1722 ACF CAN V2 PDU.
+ * @param value Value to set the ACF message length field to.
+ */
+OPEN1722_INLINE void Avtp_CanV2_SetAcfMsgLength(Avtp_CanV2_t* pdu, uint16_t value) {
+    SET_CAN_V2_FIELD(AVTP_CAN_V2_FIELD_ACF_MSG_LENGTH, value);
 }
 
 /**
  * Returns the pad field from an ACF_CAN_V2 message header.
  *
- * @param msg Pointer to an ACF_CAN_V2 message.
+ * @param pdu Pointer to an ACF_CAN_V2 message.
  * @returns The value of the pad field.
  */
-OPEN1722_INLINE uint8_t Avtp_CanV2_GetPad(const Avtp_CanV2_t* msg) {
-    return (uint8_t) __Avtp_CanV2_GetField(AVTP_CAN_V2_FIELD_PAD);
+OPEN1722_INLINE uint8_t Avtp_CanV2_GetPad(const Avtp_CanV2_t* const pdu) {
+    return (uint8_t) GET_CAN_V2_FIELD(AVTP_CAN_V2_FIELD_PAD);
 }
 
 /**
- * Returns the message timestamp valid flag (mtv) from an ACF_CAN_V2 message
- * header.
+ * Sets the pad field in an ACF_CAN_V2 message header.
  *
- * @param msg Pointer to an ACF_CAN_V2 message.
+ * @param pdu Pointer to an ACF_CAN_V2 message.
+ * @param pad The value to set.
+ */
+OPEN1722_INLINE void Avtp_CanV2_SetPad(Avtp_CanV2_t* pdu, uint8_t pad) {
+    SET_CAN_V2_FIELD(AVTP_CAN_V2_FIELD_PAD, pad);
+}
+
+/**
+ * Returns the message timestamp valid flag (mtv) from an ACF_CAN_V2 message header.
+ *
+ * @param pdu Pointer to an ACF_CAN_V2 message.
  * @returns The value of the mtv flag.
  */
-OPEN1722_INLINE bool Avtp_CanV2_IsMtv(const Avtp_CanV2_t* msg) {
-    return (bool) __Avtp_CanV2_GetField(AVTP_CAN_V2_FIELD_MTV);
+OPEN1722_INLINE bool Avtp_CanV2_IsMtv(const Avtp_CanV2_t* const pdu) {
+    return (bool) GET_CAN_V2_FIELD(AVTP_CAN_V2_FIELD_MTV);
 }
 
 /**
- * Returns the remote transmission request flag (rtr) from an ACF_CAN_V2 message
- * header.
+ * Returns the remote transmission request flag (rtr) from an ACF_CAN_V2 message header.
  *
- * @param msg Pointer to an ACF_CAN_V2 message.
+ * @param pdu Pointer to an ACF_CAN_V2 message.
  * @returns The value of the rtr flag.
  */
-OPEN1722_INLINE bool Avtp_CanV2_IsRtr(const Avtp_CanV2_t* msg) {
-    return (bool) __Avtp_CanV2_GetField(AVTP_CAN_V2_FIELD_RTR);
+OPEN1722_INLINE bool Avtp_CanV2_IsRtr(const Avtp_CanV2_t* const pdu) {
+    return (bool) GET_CAN_V2_FIELD(AVTP_CAN_V2_FIELD_RTR);
 }
 
 /**
- * Returns the extended frame format flag (eff) from an ACF_CAN_V2 message
- * header.
+ * Returns the extended frame format flag (eff) from an ACF_CAN_V2 message header.
  *
- * @param msg Pointer to an ACF_CAN_V2 message.
+ * @param pdu Pointer to an ACF_CAN_V2 message.
  * @returns The value of the eff flag.
  */
-OPEN1722_INLINE bool Avtp_CanV2_IsEff(const Avtp_CanV2_t* msg) {
-    return (bool) __Avtp_CanV2_GetField(AVTP_CAN_V2_FIELD_EFF);
+OPEN1722_INLINE bool Avtp_CanV2_IsEff(const Avtp_CanV2_t* const pdu) {
+    return (bool) GET_CAN_V2_FIELD(AVTP_CAN_V2_FIELD_EFF);
 }
 
 /**
  * Returns the value of the can_bus_id field from an ACF_CAN_V2 message header.
  *
- * @param msg Pointer to an ACF_CAN_V2 message.
+ * @param pdu Pointer to an ACF_CAN_V2 message.
  * @returns The value of the can_bus_id field.
  */
-OPEN1722_INLINE uint16_t Avtp_CanV2_GetCanBusId(const Avtp_CanV2_t* msg) {
-    return (uint16_t) __Avtp_CanV2_GetField(AVTP_CAN_V2_FIELD_CAN_BUS_ID);
+OPEN1722_INLINE uint16_t Avtp_CanV2_GetCanBusId(const Avtp_CanV2_t* const pdu) {
+    return (uint16_t) GET_CAN_V2_FIELD(AVTP_CAN_V2_FIELD_CAN_BUS_ID);
 }
 
 /**
- * Returns the value of the message_timestamp field from an ACF_CAN_V2 message
- * header.
+ * Returns the value of the message_timestamp field from an ACF_CAN_V2 message header.
  *
- * @param msg Pointer to an ACF_CAN_V2 message.
+ * @param pdu Pointer to an ACF_CAN_V2 message.
  * @returns The value of the message_timestamp field.
  */
-OPEN1722_INLINE uint64_t Avtp_CanV2_GetMessageTimestamp(const Avtp_CanV2_t* msg) {
-    return (uint64_t) __Avtp_CanV2_GetField(AVTP_CAN_V2_FIELD_MESSAGE_TIMESTAMP);
+OPEN1722_INLINE uint64_t Avtp_CanV2_GetMessageTimestamp(const Avtp_CanV2_t* const pdu) {
+    return (uint64_t) GET_CAN_V2_FIELD(AVTP_CAN_V2_FIELD_MESSAGE_TIMESTAMP);
 }
 
 /**
  * Returns the bit rate switch flag (brs) from an ACF_CAN_V2 message header.
  *
- * @param msg Pointer to an ACF_CAN_V2 message.
+ * @param pdu Pointer to an ACF_CAN_V2 message.
  * @returns The value of the brs flag.
  */
-OPEN1722_INLINE bool Avtp_CanV2_IsBrs(const Avtp_CanV2_t* msg) {
-    return (bool) __Avtp_CanV2_GetField(AVTP_CAN_V2_FIELD_BRS);
+OPEN1722_INLINE bool Avtp_CanV2_IsBrs(const Avtp_CanV2_t* const pdu) {
+    return (bool) GET_CAN_V2_FIELD(AVTP_CAN_V2_FIELD_BRS);
 }
 
 /**
  * Returns the FD frame flag (fdf) from an ACF_CAN_V2 message header.
  *
- * @param msg Pointer to an ACF_CAN_V2 message.
+ * @param pdu Pointer to an ACF_CAN_V2 message.
  * @returns The value of the fdf flag.
  */
-OPEN1722_INLINE bool Avtp_CanV2_IsFdf(const Avtp_CanV2_t* msg) {
-    return (bool) __Avtp_CanV2_GetField(AVTP_CAN_V2_FIELD_FDF);
+OPEN1722_INLINE bool Avtp_CanV2_IsFdf(const Avtp_CanV2_t* const pdu) {
+    return (bool) GET_CAN_V2_FIELD(AVTP_CAN_V2_FIELD_FDF);
 }
 
 /**
  * Returns the error state indicator flag (esi) from an ACF_CAN_V2 message header.
  *
- * @param msg Pointer to an ACF_CAN_V2 message.
+ * @param pdu Pointer to an ACF_CAN_V2 message.
  * @returns The value of the esi flag.
  */
-OPEN1722_INLINE bool Avtp_CanV2_IsEsi(const Avtp_CanV2_t* msg) {
-    return (bool) __Avtp_CanV2_GetField(AVTP_CAN_V2_FIELD_ESI);
+OPEN1722_INLINE bool Avtp_CanV2_IsEsi(const Avtp_CanV2_t* const pdu) {
+    return (bool) GET_CAN_V2_FIELD(AVTP_CAN_V2_FIELD_ESI);
 }
 
 /**
  * Returns the value of the can_identifier field from an ACF_CAN_V2 message header.
  *
- * @param msg Pointer to an ACF_CAN_V2 message.
+ * @param pdu Pointer to an ACF_CAN_V2 message.
  * @returns The value of the can_identifier field.
  */
-OPEN1722_INLINE uint32_t Avtp_CanV2_GetCanIdentifier(const Avtp_CanV2_t* msg) {
-    return (uint32_t) __Avtp_CanV2_GetField(AVTP_CAN_V2_FIELD_CAN_IDENTIFIER);
-}
-
-/**
- * Returns the payload length from an ACF_CAN_V2 message (in bytes). This is
- * calculated based on the value of the acf_msg_length field in the header
- * as well as the value of the pad field.
- *
- * @param msg Pointer to an ACF_CAN_V2 message.
- * @returns The payload length in bytes.
- */
-OPEN1722_INLINE uint16_t Avtp_CanV2_GetPayloadLen(const Avtp_CanV2_t* msg) {
-    return (uint16_t) (__Avtp_CanV2_GetField(AVTP_CAN_V2_FIELD_ACF_MSG_LENGTH) * AVTP_QUADLET_SIZE
-           - AVTP_CAN_V2_HEADER_LEN
-           - __Avtp_CanV2_GetField(AVTP_CAN_V2_FIELD_PAD));
-}
-
-/**
- * Returns the total message length from an ACF_CAN_V2 message (in bytes)
- * including header and payload section.
- *
- * @param msg Pointer to an ACF_CAN_V2 message.
- * @returns The total message length in bytes.
- */
-OPEN1722_INLINE uint16_t Avtp_CanV2_GetLen(const Avtp_CanV2_t* msg) {
-    return (uint16_t) (__Avtp_CanV2_GetField(AVTP_CAN_V2_FIELD_ACF_MSG_LENGTH) * AVTP_QUADLET_SIZE);
+OPEN1722_INLINE uint32_t Avtp_CanV2_GetCanIdentifier(const Avtp_CanV2_t* const pdu) {
+    return (uint32_t) GET_CAN_V2_FIELD(AVTP_CAN_V2_FIELD_CAN_IDENTIFIER);
 }
 
 /**
  * Sets the value of the mtv flag in an ACF_CAN_V2 message header.
  *
- * @param msg Pointer to an ACF_CAN_V2 message.
+ * @param pdu Pointer to an ACF_CAN_V2 message.
  * @param mtv The value to set.
  */
-OPEN1722_INLINE void Avtp_CanV2_SetMtv(Avtp_CanV2_t* msg, bool mtv) {
-    __Avtp_CanV2_SetField(AVTP_CAN_V2_FIELD_MTV, mtv);
+OPEN1722_INLINE void Avtp_CanV2_SetMtv(Avtp_CanV2_t* pdu, bool mtv) {
+    SET_CAN_V2_FIELD(AVTP_CAN_V2_FIELD_MTV, mtv);
 }
 
 /**
  * Sets the value of the rtr flag in an ACF_CAN_V2 message header.
  *
- * @param msg Pointer to an ACF_CAN_V2 message.
+ * @param pdu Pointer to an ACF_CAN_V2 message.
  * @param rtr The value to set.
  */
-OPEN1722_INLINE void Avtp_CanV2_SetRtr(Avtp_CanV2_t* msg, bool rtr) {
-    __Avtp_CanV2_SetField(AVTP_CAN_V2_FIELD_RTR, rtr);
+OPEN1722_INLINE void Avtp_CanV2_SetRtr(Avtp_CanV2_t* pdu, bool rtr) {
+    SET_CAN_V2_FIELD(AVTP_CAN_V2_FIELD_RTR, rtr);
 }
 
 /**
  * Sets the value of the eff flag in an ACF_CAN_V2 message header.
  *
- * @param msg Pointer to an ACF_CAN_V2 message.
+ * @param pdu Pointer to an ACF_CAN_V2 message.
  * @param eff The value to set.
  */
-OPEN1722_INLINE void Avtp_CanV2_SetEff(Avtp_CanV2_t* msg, bool eff) {
-    __Avtp_CanV2_SetField(AVTP_CAN_V2_FIELD_EFF, eff);
+OPEN1722_INLINE void Avtp_CanV2_SetEff(Avtp_CanV2_t* pdu, bool eff) {
+    SET_CAN_V2_FIELD(AVTP_CAN_V2_FIELD_EFF, eff);
 }
 
 /**
  * Sets the value of the can_bus_id field in an ACF_CAN_V2 message header.
  *
- * @param msg Pointer to an ACF_CAN_V2 message.
+ * @param pdu Pointer to an ACF_CAN_V2 message.
  * @param canBusId The value to set.
  */
-OPEN1722_INLINE void Avtp_CanV2_SetCanBusId(Avtp_CanV2_t* msg, uint16_t canBusId) {
-    __Avtp_CanV2_SetField(AVTP_CAN_V2_FIELD_CAN_BUS_ID, canBusId);
+OPEN1722_INLINE void Avtp_CanV2_SetCanBusId(Avtp_CanV2_t* pdu, uint16_t canBusId) {
+    SET_CAN_V2_FIELD(AVTP_CAN_V2_FIELD_CAN_BUS_ID, canBusId);
 }
 
 /**
  * Sets the value of the message_timestamp field in an ACF_CAN_V2 message header.
  *
- * @param msg Pointer to an ACF_CAN_V2 message.
+ * @param pdu Pointer to an ACF_CAN_V2 message.
  * @param messageTimestamp The value to set.
  */
-OPEN1722_INLINE void Avtp_CanV2_SetMessageTimestamp(Avtp_CanV2_t* msg, uint64_t messageTimestamp) {
-    __Avtp_CanV2_SetField(AVTP_CAN_V2_FIELD_MESSAGE_TIMESTAMP, messageTimestamp);
+OPEN1722_INLINE void Avtp_CanV2_SetMessageTimestamp(Avtp_CanV2_t* pdu, uint64_t messageTimestamp) {
+    SET_CAN_V2_FIELD(AVTP_CAN_V2_FIELD_MESSAGE_TIMESTAMP, messageTimestamp);
 }
 
 /**
  * Sets the value of the brs flag in an ACF_CAN_V2 message header.
  *
- * @param msg Pointer to an ACF_CAN_V2 message.
+ * @param pdu Pointer to an ACF_CAN_V2 message.
  * @param brs The value to set.
  */
-OPEN1722_INLINE void Avtp_CanV2_SetBrs(Avtp_CanV2_t* msg, bool brs) {
-    __Avtp_CanV2_SetField(AVTP_CAN_V2_FIELD_BRS, brs);
+OPEN1722_INLINE void Avtp_CanV2_SetBrs(Avtp_CanV2_t* pdu, bool brs) {
+    SET_CAN_V2_FIELD(AVTP_CAN_V2_FIELD_BRS, brs);
 }
 
 /**
  * Sets the value of the fdf flag in an ACF_CAN_V2 message header.
  *
- * @param msg Pointer to an ACF_CAN_V2 message.
+ * @param pdu Pointer to an ACF_CAN_V2 message.
  * @param fdf The value to set.
  */
-OPEN1722_INLINE void Avtp_CanV2_SetFdf(Avtp_CanV2_t* msg, bool fdf) {
-    __Avtp_CanV2_SetField(AVTP_CAN_V2_FIELD_FDF, fdf);
+OPEN1722_INLINE void Avtp_CanV2_SetFdf(Avtp_CanV2_t* pdu, bool fdf) {
+    SET_CAN_V2_FIELD(AVTP_CAN_V2_FIELD_FDF, fdf);
 }
 
 /**
  * Sets the value of the esi flag in an ACF_CAN_V2 message header.
  *
- * @param msg Pointer to an ACF_CAN_V2 message.
+ * @param pdu Pointer to an ACF_CAN_V2 message.
  * @param esi The value to set.
  */
-OPEN1722_INLINE void Avtp_CanV2_SetEsi(Avtp_CanV2_t* msg, bool esi) {
-    __Avtp_CanV2_SetField(AVTP_CAN_V2_FIELD_ESI, esi);
+OPEN1722_INLINE void Avtp_CanV2_SetEsi(Avtp_CanV2_t* pdu, bool esi) {
+    SET_CAN_V2_FIELD(AVTP_CAN_V2_FIELD_ESI, esi);
 }
 
 /**
  * Sets the value of the can_identifier field in an ACF_CAN_V2 message header.
  *
- * @param msg Pointer to an ACF_CAN_V2 message.
+ * @param pdu Pointer to an ACF_CAN_V2 message.
  * @param canIdentifier The value to set.
  */
-OPEN1722_INLINE void Avtp_CanV2_SetCanIdentifier(Avtp_CanV2_t* msg, uint32_t canIdentifier) {
-    __Avtp_CanV2_SetField(AVTP_CAN_V2_FIELD_CAN_IDENTIFIER, canIdentifier);
+OPEN1722_INLINE void Avtp_CanV2_SetCanIdentifier(Avtp_CanV2_t* pdu, uint32_t canIdentifier) {
+    SET_CAN_V2_FIELD(AVTP_CAN_V2_FIELD_CAN_IDENTIFIER, canIdentifier);
 }
 
 /**
- * Sets the value of the acf_msg_length field in an ACF_CAN_V2 message header
- * based on the given payload length. This function also calculates the
- * required padding and sets the value of the pad field accordingly.
+ * Returns pointer to payload of an ACF CAN V2 frame.
  *
- * @param msg Pointer to an ACF_CAN_V2 message.
- * @param payloadLen The length of the payload in bytes.
+ * @param pdu Pointer to the first bit of a 1722 ACF CAN V2 PDU.
+ * @return Pointer to ACF CAN V2 frame payload
  */
-OPEN1722_INLINE void Avtp_CanV2_SetPayloadLen(Avtp_CanV2_t* msg, uint16_t payloadLen) {
-    uint16_t msgLenBytes = AVTP_CAN_V2_HEADER_LEN + payloadLen;
-    uint8_t pad = (uint8_t) (4 - (msgLenBytes % 4)) % 4;
-    uint16_t msgLenQuadlets = (uint16_t) ((msgLenBytes + pad) / 4);
-    __Avtp_CanV2_SetField(AVTP_CAN_V2_FIELD_ACF_MSG_LENGTH, msgLenQuadlets);
-    __Avtp_CanV2_SetField(AVTP_CAN_V2_FIELD_PAD, pad);
+OPEN1722_INLINE const uint8_t *Avtp_CanV2_GetPayload(const Avtp_CanV2_t* const pdu)
+{
+    return pdu->payload;
+}
+
+/**
+ * Sets the CAN payload in an ACF CAN V2 frame.
+ *
+ * @param pdu Pointer to the first bit of a 1722 ACF CAN V2 PDU.
+ * @param payload Pointer to the payload byte array
+ * @param payload_length Length of the payload
+ */
+OPEN1722_INLINE void Avtp_CanV2_SetPayload(Avtp_CanV2_t *pdu, uint8_t *payload,
+                                           uint16_t payload_length)
+{
+    memcpy(pdu->payload, payload, payload_length);
+}
+
+/**
+ * Finalizes the ACF CAN V2 frame. This function will set the
+ * length and pad fields while inserting the padded bytes. This will also
+ * set padding bytes to zero if the payload length is not a multiple of 4.
+ * to avoid leaking information
+ *
+ * @param pdu Pointer to the first bit of a 1722 ACF CAN V2 PDU.
+ * @param payload_length Length of the CAN frame payload.
+ */
+OPEN1722_INLINE void Avtp_CanV2_SetPayloadLength(Avtp_CanV2_t *pdu, uint16_t payload_length)
+{
+    uint16_t msgLenBytes = AVTP_CAN_V2_HEADER_LEN + payload_length;
+    uint8_t pad = (uint8_t)(4 - (msgLenBytes % 4)) % 4;
+    if (pad > 0) {
+        memset(pdu->payload + payload_length, 0, pad);
+    }
+    uint16_t msgLenQuadlets = (uint16_t)((msgLenBytes + pad) / 4);
+    Avtp_CanV2_SetPad(pdu, pad);
+    Avtp_CanV2_SetAcfMsgLength(pdu, msgLenQuadlets);
+}
+
+/**
+ * Returns the length of the CAN payload without the padding bytes and the
+ * header length of the encapsulating ACF Frame.
+ *
+ * Precondition: the caller must have validated the PDU with
+ * Avtp_CanV2_IsValid(). IsValid checks both buffer-size containment and the
+ * CAN payload-length invariant (<= 8 bytes for classic CAN, <= 64 bytes
+ * for CAN-FD). This function performs no further bounds checking and
+ * assumes those invariants already hold.
+ *
+ * @param pdu Pointer to the first bit of a 1722 ACF CAN V2 PDU.
+ * @return  Length of CAN payload in bytes
+ */
+OPEN1722_INLINE uint8_t Avtp_CanV2_GetPayloadLength(const Avtp_CanV2_t* const pdu)
+{
+    uint8_t pad_length = Avtp_CanV2_GetPad(pdu);
+    uint16_t acf_length_bytes = Avtp_CanV2_GetAcfMsgLengthInBytes(pdu);
+    return (uint8_t)(acf_length_bytes - AVTP_CAN_V2_HEADER_LEN - pad_length);
+}
+
+/**
+ * Initializes an ACF_CAN_V2 message header as specified in the IEEE 1722 Specification.
+ *
+ * @param pdu Pointer to the first bit of a 1722 ACF CAN V2 PDU.
+ */
+OPEN1722_INLINE void Avtp_CanV2_Init(Avtp_CanV2_t* pdu)
+{
+    if (pdu != NULL) {
+        memset(pdu, 0, sizeof(Avtp_CanV2_t));
+        Avtp_CanV2_SetAcfMsgType(pdu, AVTP_ACF_TYPE_CAN_V2);
+    }
+}
+
+/**
+ * Copies the payload data and CAN frame ID into the ACF CAN V2 frame. This function will
+ * also set the length and pad fields while inserting the padded bytes.
+ *
+ * @param pdu Pointer to the first bit of a 1722 ACF CAN V2 PDU.
+ * @param frame_id ID of the CAN frame
+ * @param payload Pointer to the payload byte array
+ * @param payload_length Length of the payload.
+ * @param can_variant Classic CAN or CAN-FD
+ */
+OPEN1722_INLINE void Avtp_CanV2_CreateAcfMessage(Avtp_CanV2_t *pdu, uint32_t frame_id,
+                                                 uint8_t *payload, uint16_t payload_length,
+                                                 Avtp_CanVariant_t can_variant)
+{
+    // Initialize the ACF CAN V2 header
+    Avtp_CanV2_Init(pdu);
+
+    // Copy the payload into the CAN PDU
+    Avtp_CanV2_SetPayload(pdu, payload, payload_length);
+
+    // Set the Frame ID and CAN variant
+    if (frame_id > 0x7ff) {
+        Avtp_CanV2_SetEff(pdu, true);
+    }
+
+    Avtp_CanV2_SetCanIdentifier(pdu, frame_id);
+    if (can_variant == AVTP_CAN_FD) {
+        Avtp_CanV2_SetFdf(pdu, true);
+    }
+
+    // Finalize the AVTP CAN Frame
+    Avtp_CanV2_SetPayloadLength(pdu, payload_length);
+}
+
+/**
+ * Checks if the ACF CAN V2 frame is valid by checking:
+ *     1) if the length field of AVTP/ACF messages contains a value larger than the actual size of
+ * the buffer that contains the AVTP message. 2) if other format specific invariants are not upheld
+ * @param pdu Pointer to the first bit of a 1722 ACF CAN V2 PDU.
+ * @param bufferSize Size of the buffer containing the ACF CAN V2 frame.
+ * @return true if the ACF CAN V2 frame is valid, false otherwise.
+ */
+OPEN1722_INLINE bool Avtp_CanV2_IsValid(const Avtp_CanV2_t* const pdu, size_t bufferSize)
+{
+    if (pdu == NULL) {
+        return false;
+    }
+
+    if (bufferSize < AVTP_CAN_V2_HEADER_LEN) {
+        return false;
+    }
+
+    if (Avtp_CanV2_GetAcfMsgType(pdu) != AVTP_ACF_TYPE_CAN_V2) {
+        return false;
+    }
+
+    // Avtp_CanV2_GetAcfMsgLength returns quadlets. Convert the length field to octets.
+    uint16_t msg_length_bytes = (uint16_t)Avtp_CanV2_GetAcfMsgLength(pdu) * 4;
+    if (msg_length_bytes > bufferSize) {
+        return false;
+    }
+
+    /* CAN payload-length invariant: classic CAN ≤ 8 bytes, CAN-FD ≤ 64
+     * bytes (selected by the FDF bit). The encoded message length must
+     * also accommodate header + declared padding so the payload
+     * computation in Avtp_CanV2_GetPayloadLength() doesn't underflow. */
+    uint8_t pad_length = Avtp_CanV2_GetPad(pdu);
+    uint16_t header_and_pad = (uint16_t)AVTP_CAN_V2_HEADER_LEN + pad_length;
+    if (msg_length_bytes < header_and_pad) {
+        return false;
+    }
+    uint16_t payload_length = msg_length_bytes - header_and_pad;
+    uint16_t max_payload = Avtp_CanV2_IsFdf(pdu) ? 64u : 8u;
+    if (payload_length > max_payload) {
+        return false;
+    }
+    return true;
 }
 
 #ifdef __cplusplus

--- a/include/avtp/acf/CanV2.h
+++ b/include/avtp/acf/CanV2.h
@@ -92,22 +92,21 @@ typedef enum {
 /**
  * This table describes all the offsets of the ACF_CAN_V2 header fields.
  */
-static const Avtp_FieldDescriptor_t Avtp_CanV2FieldDesc[AVTP_CAN_V2_FIELD_MAX] =
-{
+static const Avtp_FieldDescriptor_t Avtp_CanV2FieldDesc[AVTP_CAN_V2_FIELD_MAX] = {
     /* ACF common header fields */
-    [AVTP_CAN_V2_FIELD_ACF_MSG_TYPE]       = { .quadlet = 0, .offset =  0, .bits =  7 },
-    [AVTP_CAN_V2_FIELD_ACF_MSG_LENGTH]     = { .quadlet = 0, .offset =  7, .bits =  9 },
+    [AVTP_CAN_V2_FIELD_ACF_MSG_TYPE] = {.quadlet = 0, .offset = 0, .bits = 7},
+    [AVTP_CAN_V2_FIELD_ACF_MSG_LENGTH] = {.quadlet = 0, .offset = 7, .bits = 9},
     /* ACF CAN header fields */
-    [AVTP_CAN_V2_FIELD_PAD]                = { .quadlet = 0, .offset = 16, .bits =  2 },
-    [AVTP_CAN_V2_FIELD_MTV]                = { .quadlet = 0, .offset = 18, .bits =  1 },
-    [AVTP_CAN_V2_FIELD_RTR]                = { .quadlet = 0, .offset = 19, .bits =  1 },
-    [AVTP_CAN_V2_FIELD_EFF]                = { .quadlet = 0, .offset = 20, .bits =  1 },
-    [AVTP_CAN_V2_FIELD_CAN_BUS_ID]         = { .quadlet = 0, .offset = 21, .bits = 11 },
-    [AVTP_CAN_V2_FIELD_MESSAGE_TIMESTAMP]  = { .quadlet = 1, .offset =  0, .bits = 64 },
-    [AVTP_CAN_V2_FIELD_BRS]                = { .quadlet = 3, .offset =  0, .bits =  1 },
-    [AVTP_CAN_V2_FIELD_FDF]                = { .quadlet = 3, .offset =  1, .bits =  1 },
-    [AVTP_CAN_V2_FIELD_ESI]                = { .quadlet = 3, .offset =  2, .bits =  1 },
-    [AVTP_CAN_V2_FIELD_CAN_IDENTIFIER]     = { .quadlet = 3, .offset =  3, .bits = 29 },
+    [AVTP_CAN_V2_FIELD_PAD] = {.quadlet = 0, .offset = 16, .bits = 2},
+    [AVTP_CAN_V2_FIELD_MTV] = {.quadlet = 0, .offset = 18, .bits = 1},
+    [AVTP_CAN_V2_FIELD_RTR] = {.quadlet = 0, .offset = 19, .bits = 1},
+    [AVTP_CAN_V2_FIELD_EFF] = {.quadlet = 0, .offset = 20, .bits = 1},
+    [AVTP_CAN_V2_FIELD_CAN_BUS_ID] = {.quadlet = 0, .offset = 21, .bits = 11},
+    [AVTP_CAN_V2_FIELD_MESSAGE_TIMESTAMP] = {.quadlet = 1, .offset = 0, .bits = 64},
+    [AVTP_CAN_V2_FIELD_BRS] = {.quadlet = 3, .offset = 0, .bits = 1},
+    [AVTP_CAN_V2_FIELD_FDF] = {.quadlet = 3, .offset = 1, .bits = 1},
+    [AVTP_CAN_V2_FIELD_ESI] = {.quadlet = 3, .offset = 2, .bits = 1},
+    [AVTP_CAN_V2_FIELD_CAN_IDENTIFIER] = {.quadlet = 3, .offset = 3, .bits = 29},
 };
 
 /**
@@ -116,8 +115,9 @@ static const Avtp_FieldDescriptor_t Avtp_CanV2FieldDesc[AVTP_CAN_V2_FIELD_MAX] =
  * @param pdu Pointer to the first bit of a 1722 ACF CAN V2 PDU.
  * @returns Value of the ACF message type field.
  */
-OPEN1722_INLINE uint8_t Avtp_CanV2_GetAcfMsgType(const Avtp_CanV2_t* const pdu) {
-    return (uint8_t) GET_CAN_V2_FIELD(AVTP_CAN_V2_FIELD_ACF_MSG_TYPE);
+OPEN1722_INLINE uint8_t Avtp_CanV2_GetAcfMsgType(const Avtp_CanV2_t *const pdu)
+{
+    return (uint8_t)GET_CAN_V2_FIELD(AVTP_CAN_V2_FIELD_ACF_MSG_TYPE);
 }
 
 /**
@@ -129,8 +129,9 @@ OPEN1722_INLINE uint8_t Avtp_CanV2_GetAcfMsgType(const Avtp_CanV2_t* const pdu) 
  * @param pdu Pointer to the first bit of a 1722 ACF CAN V2 PDU.
  * @returns Value of the ACF message length field.
  */
-OPEN1722_INLINE uint16_t Avtp_CanV2_GetAcfMsgLength(const Avtp_CanV2_t* const pdu) {
-    return (uint16_t) GET_CAN_V2_FIELD(AVTP_CAN_V2_FIELD_ACF_MSG_LENGTH);
+OPEN1722_INLINE uint16_t Avtp_CanV2_GetAcfMsgLength(const Avtp_CanV2_t *const pdu)
+{
+    return (uint16_t)GET_CAN_V2_FIELD(AVTP_CAN_V2_FIELD_ACF_MSG_LENGTH);
 }
 
 /**
@@ -139,8 +140,9 @@ OPEN1722_INLINE uint16_t Avtp_CanV2_GetAcfMsgLength(const Avtp_CanV2_t* const pd
  * @param pdu Pointer to the first bit of a 1722 ACF CAN V2 PDU.
  * @returns Length of the ACF message in bytes.
  */
-OPEN1722_INLINE uint16_t Avtp_CanV2_GetAcfMsgLengthInBytes(const Avtp_CanV2_t* const pdu) {
-    return (uint16_t) GET_CAN_V2_FIELD(AVTP_CAN_V2_FIELD_ACF_MSG_LENGTH) * 4;
+OPEN1722_INLINE uint16_t Avtp_CanV2_GetAcfMsgLengthInBytes(const Avtp_CanV2_t *const pdu)
+{
+    return (uint16_t)GET_CAN_V2_FIELD(AVTP_CAN_V2_FIELD_ACF_MSG_LENGTH) * 4;
 }
 
 /**
@@ -149,7 +151,8 @@ OPEN1722_INLINE uint16_t Avtp_CanV2_GetAcfMsgLengthInBytes(const Avtp_CanV2_t* c
  * @param pdu Pointer to the first bit of a 1722 ACF CAN V2 PDU.
  * @param value Value to set the ACF message type field to.
  */
-OPEN1722_INLINE void Avtp_CanV2_SetAcfMsgType(Avtp_CanV2_t* pdu, uint8_t value) {
+OPEN1722_INLINE void Avtp_CanV2_SetAcfMsgType(Avtp_CanV2_t *pdu, uint8_t value)
+{
     SET_CAN_V2_FIELD(AVTP_CAN_V2_FIELD_ACF_MSG_TYPE, value);
 }
 
@@ -162,7 +165,8 @@ OPEN1722_INLINE void Avtp_CanV2_SetAcfMsgType(Avtp_CanV2_t* pdu, uint8_t value) 
  * @param pdu Pointer to the first bit of a 1722 ACF CAN V2 PDU.
  * @param value Value to set the ACF message length field to.
  */
-OPEN1722_INLINE void Avtp_CanV2_SetAcfMsgLength(Avtp_CanV2_t* pdu, uint16_t value) {
+OPEN1722_INLINE void Avtp_CanV2_SetAcfMsgLength(Avtp_CanV2_t *pdu, uint16_t value)
+{
     SET_CAN_V2_FIELD(AVTP_CAN_V2_FIELD_ACF_MSG_LENGTH, value);
 }
 
@@ -172,8 +176,9 @@ OPEN1722_INLINE void Avtp_CanV2_SetAcfMsgLength(Avtp_CanV2_t* pdu, uint16_t valu
  * @param pdu Pointer to an ACF_CAN_V2 message.
  * @returns The value of the pad field.
  */
-OPEN1722_INLINE uint8_t Avtp_CanV2_GetPad(const Avtp_CanV2_t* const pdu) {
-    return (uint8_t) GET_CAN_V2_FIELD(AVTP_CAN_V2_FIELD_PAD);
+OPEN1722_INLINE uint8_t Avtp_CanV2_GetPad(const Avtp_CanV2_t *const pdu)
+{
+    return (uint8_t)GET_CAN_V2_FIELD(AVTP_CAN_V2_FIELD_PAD);
 }
 
 /**
@@ -182,7 +187,8 @@ OPEN1722_INLINE uint8_t Avtp_CanV2_GetPad(const Avtp_CanV2_t* const pdu) {
  * @param pdu Pointer to an ACF_CAN_V2 message.
  * @param pad The value to set.
  */
-OPEN1722_INLINE void Avtp_CanV2_SetPad(Avtp_CanV2_t* pdu, uint8_t pad) {
+OPEN1722_INLINE void Avtp_CanV2_SetPad(Avtp_CanV2_t *pdu, uint8_t pad)
+{
     SET_CAN_V2_FIELD(AVTP_CAN_V2_FIELD_PAD, pad);
 }
 
@@ -192,8 +198,9 @@ OPEN1722_INLINE void Avtp_CanV2_SetPad(Avtp_CanV2_t* pdu, uint8_t pad) {
  * @param pdu Pointer to an ACF_CAN_V2 message.
  * @returns The value of the mtv flag.
  */
-OPEN1722_INLINE bool Avtp_CanV2_IsMtv(const Avtp_CanV2_t* const pdu) {
-    return (bool) GET_CAN_V2_FIELD(AVTP_CAN_V2_FIELD_MTV);
+OPEN1722_INLINE bool Avtp_CanV2_IsMtv(const Avtp_CanV2_t *const pdu)
+{
+    return (bool)GET_CAN_V2_FIELD(AVTP_CAN_V2_FIELD_MTV);
 }
 
 /**
@@ -202,8 +209,9 @@ OPEN1722_INLINE bool Avtp_CanV2_IsMtv(const Avtp_CanV2_t* const pdu) {
  * @param pdu Pointer to an ACF_CAN_V2 message.
  * @returns The value of the rtr flag.
  */
-OPEN1722_INLINE bool Avtp_CanV2_IsRtr(const Avtp_CanV2_t* const pdu) {
-    return (bool) GET_CAN_V2_FIELD(AVTP_CAN_V2_FIELD_RTR);
+OPEN1722_INLINE bool Avtp_CanV2_IsRtr(const Avtp_CanV2_t *const pdu)
+{
+    return (bool)GET_CAN_V2_FIELD(AVTP_CAN_V2_FIELD_RTR);
 }
 
 /**
@@ -212,8 +220,9 @@ OPEN1722_INLINE bool Avtp_CanV2_IsRtr(const Avtp_CanV2_t* const pdu) {
  * @param pdu Pointer to an ACF_CAN_V2 message.
  * @returns The value of the eff flag.
  */
-OPEN1722_INLINE bool Avtp_CanV2_IsEff(const Avtp_CanV2_t* const pdu) {
-    return (bool) GET_CAN_V2_FIELD(AVTP_CAN_V2_FIELD_EFF);
+OPEN1722_INLINE bool Avtp_CanV2_IsEff(const Avtp_CanV2_t *const pdu)
+{
+    return (bool)GET_CAN_V2_FIELD(AVTP_CAN_V2_FIELD_EFF);
 }
 
 /**
@@ -222,8 +231,9 @@ OPEN1722_INLINE bool Avtp_CanV2_IsEff(const Avtp_CanV2_t* const pdu) {
  * @param pdu Pointer to an ACF_CAN_V2 message.
  * @returns The value of the can_bus_id field.
  */
-OPEN1722_INLINE uint16_t Avtp_CanV2_GetCanBusId(const Avtp_CanV2_t* const pdu) {
-    return (uint16_t) GET_CAN_V2_FIELD(AVTP_CAN_V2_FIELD_CAN_BUS_ID);
+OPEN1722_INLINE uint16_t Avtp_CanV2_GetCanBusId(const Avtp_CanV2_t *const pdu)
+{
+    return (uint16_t)GET_CAN_V2_FIELD(AVTP_CAN_V2_FIELD_CAN_BUS_ID);
 }
 
 /**
@@ -232,8 +242,9 @@ OPEN1722_INLINE uint16_t Avtp_CanV2_GetCanBusId(const Avtp_CanV2_t* const pdu) {
  * @param pdu Pointer to an ACF_CAN_V2 message.
  * @returns The value of the message_timestamp field.
  */
-OPEN1722_INLINE uint64_t Avtp_CanV2_GetMessageTimestamp(const Avtp_CanV2_t* const pdu) {
-    return (uint64_t) GET_CAN_V2_FIELD(AVTP_CAN_V2_FIELD_MESSAGE_TIMESTAMP);
+OPEN1722_INLINE uint64_t Avtp_CanV2_GetMessageTimestamp(const Avtp_CanV2_t *const pdu)
+{
+    return (uint64_t)GET_CAN_V2_FIELD(AVTP_CAN_V2_FIELD_MESSAGE_TIMESTAMP);
 }
 
 /**
@@ -242,8 +253,9 @@ OPEN1722_INLINE uint64_t Avtp_CanV2_GetMessageTimestamp(const Avtp_CanV2_t* cons
  * @param pdu Pointer to an ACF_CAN_V2 message.
  * @returns The value of the brs flag.
  */
-OPEN1722_INLINE bool Avtp_CanV2_IsBrs(const Avtp_CanV2_t* const pdu) {
-    return (bool) GET_CAN_V2_FIELD(AVTP_CAN_V2_FIELD_BRS);
+OPEN1722_INLINE bool Avtp_CanV2_IsBrs(const Avtp_CanV2_t *const pdu)
+{
+    return (bool)GET_CAN_V2_FIELD(AVTP_CAN_V2_FIELD_BRS);
 }
 
 /**
@@ -252,8 +264,9 @@ OPEN1722_INLINE bool Avtp_CanV2_IsBrs(const Avtp_CanV2_t* const pdu) {
  * @param pdu Pointer to an ACF_CAN_V2 message.
  * @returns The value of the fdf flag.
  */
-OPEN1722_INLINE bool Avtp_CanV2_IsFdf(const Avtp_CanV2_t* const pdu) {
-    return (bool) GET_CAN_V2_FIELD(AVTP_CAN_V2_FIELD_FDF);
+OPEN1722_INLINE bool Avtp_CanV2_IsFdf(const Avtp_CanV2_t *const pdu)
+{
+    return (bool)GET_CAN_V2_FIELD(AVTP_CAN_V2_FIELD_FDF);
 }
 
 /**
@@ -262,8 +275,9 @@ OPEN1722_INLINE bool Avtp_CanV2_IsFdf(const Avtp_CanV2_t* const pdu) {
  * @param pdu Pointer to an ACF_CAN_V2 message.
  * @returns The value of the esi flag.
  */
-OPEN1722_INLINE bool Avtp_CanV2_IsEsi(const Avtp_CanV2_t* const pdu) {
-    return (bool) GET_CAN_V2_FIELD(AVTP_CAN_V2_FIELD_ESI);
+OPEN1722_INLINE bool Avtp_CanV2_IsEsi(const Avtp_CanV2_t *const pdu)
+{
+    return (bool)GET_CAN_V2_FIELD(AVTP_CAN_V2_FIELD_ESI);
 }
 
 /**
@@ -272,8 +286,9 @@ OPEN1722_INLINE bool Avtp_CanV2_IsEsi(const Avtp_CanV2_t* const pdu) {
  * @param pdu Pointer to an ACF_CAN_V2 message.
  * @returns The value of the can_identifier field.
  */
-OPEN1722_INLINE uint32_t Avtp_CanV2_GetCanIdentifier(const Avtp_CanV2_t* const pdu) {
-    return (uint32_t) GET_CAN_V2_FIELD(AVTP_CAN_V2_FIELD_CAN_IDENTIFIER);
+OPEN1722_INLINE uint32_t Avtp_CanV2_GetCanIdentifier(const Avtp_CanV2_t *const pdu)
+{
+    return (uint32_t)GET_CAN_V2_FIELD(AVTP_CAN_V2_FIELD_CAN_IDENTIFIER);
 }
 
 /**
@@ -282,7 +297,8 @@ OPEN1722_INLINE uint32_t Avtp_CanV2_GetCanIdentifier(const Avtp_CanV2_t* const p
  * @param pdu Pointer to an ACF_CAN_V2 message.
  * @param mtv The value to set.
  */
-OPEN1722_INLINE void Avtp_CanV2_SetMtv(Avtp_CanV2_t* pdu, bool mtv) {
+OPEN1722_INLINE void Avtp_CanV2_SetMtv(Avtp_CanV2_t *pdu, bool mtv)
+{
     SET_CAN_V2_FIELD(AVTP_CAN_V2_FIELD_MTV, mtv);
 }
 
@@ -292,7 +308,8 @@ OPEN1722_INLINE void Avtp_CanV2_SetMtv(Avtp_CanV2_t* pdu, bool mtv) {
  * @param pdu Pointer to an ACF_CAN_V2 message.
  * @param rtr The value to set.
  */
-OPEN1722_INLINE void Avtp_CanV2_SetRtr(Avtp_CanV2_t* pdu, bool rtr) {
+OPEN1722_INLINE void Avtp_CanV2_SetRtr(Avtp_CanV2_t *pdu, bool rtr)
+{
     SET_CAN_V2_FIELD(AVTP_CAN_V2_FIELD_RTR, rtr);
 }
 
@@ -302,7 +319,8 @@ OPEN1722_INLINE void Avtp_CanV2_SetRtr(Avtp_CanV2_t* pdu, bool rtr) {
  * @param pdu Pointer to an ACF_CAN_V2 message.
  * @param eff The value to set.
  */
-OPEN1722_INLINE void Avtp_CanV2_SetEff(Avtp_CanV2_t* pdu, bool eff) {
+OPEN1722_INLINE void Avtp_CanV2_SetEff(Avtp_CanV2_t *pdu, bool eff)
+{
     SET_CAN_V2_FIELD(AVTP_CAN_V2_FIELD_EFF, eff);
 }
 
@@ -312,7 +330,8 @@ OPEN1722_INLINE void Avtp_CanV2_SetEff(Avtp_CanV2_t* pdu, bool eff) {
  * @param pdu Pointer to an ACF_CAN_V2 message.
  * @param canBusId The value to set.
  */
-OPEN1722_INLINE void Avtp_CanV2_SetCanBusId(Avtp_CanV2_t* pdu, uint16_t canBusId) {
+OPEN1722_INLINE void Avtp_CanV2_SetCanBusId(Avtp_CanV2_t *pdu, uint16_t canBusId)
+{
     SET_CAN_V2_FIELD(AVTP_CAN_V2_FIELD_CAN_BUS_ID, canBusId);
 }
 
@@ -322,7 +341,8 @@ OPEN1722_INLINE void Avtp_CanV2_SetCanBusId(Avtp_CanV2_t* pdu, uint16_t canBusId
  * @param pdu Pointer to an ACF_CAN_V2 message.
  * @param messageTimestamp The value to set.
  */
-OPEN1722_INLINE void Avtp_CanV2_SetMessageTimestamp(Avtp_CanV2_t* pdu, uint64_t messageTimestamp) {
+OPEN1722_INLINE void Avtp_CanV2_SetMessageTimestamp(Avtp_CanV2_t *pdu, uint64_t messageTimestamp)
+{
     SET_CAN_V2_FIELD(AVTP_CAN_V2_FIELD_MESSAGE_TIMESTAMP, messageTimestamp);
 }
 
@@ -332,7 +352,8 @@ OPEN1722_INLINE void Avtp_CanV2_SetMessageTimestamp(Avtp_CanV2_t* pdu, uint64_t 
  * @param pdu Pointer to an ACF_CAN_V2 message.
  * @param brs The value to set.
  */
-OPEN1722_INLINE void Avtp_CanV2_SetBrs(Avtp_CanV2_t* pdu, bool brs) {
+OPEN1722_INLINE void Avtp_CanV2_SetBrs(Avtp_CanV2_t *pdu, bool brs)
+{
     SET_CAN_V2_FIELD(AVTP_CAN_V2_FIELD_BRS, brs);
 }
 
@@ -342,7 +363,8 @@ OPEN1722_INLINE void Avtp_CanV2_SetBrs(Avtp_CanV2_t* pdu, bool brs) {
  * @param pdu Pointer to an ACF_CAN_V2 message.
  * @param fdf The value to set.
  */
-OPEN1722_INLINE void Avtp_CanV2_SetFdf(Avtp_CanV2_t* pdu, bool fdf) {
+OPEN1722_INLINE void Avtp_CanV2_SetFdf(Avtp_CanV2_t *pdu, bool fdf)
+{
     SET_CAN_V2_FIELD(AVTP_CAN_V2_FIELD_FDF, fdf);
 }
 
@@ -352,7 +374,8 @@ OPEN1722_INLINE void Avtp_CanV2_SetFdf(Avtp_CanV2_t* pdu, bool fdf) {
  * @param pdu Pointer to an ACF_CAN_V2 message.
  * @param esi The value to set.
  */
-OPEN1722_INLINE void Avtp_CanV2_SetEsi(Avtp_CanV2_t* pdu, bool esi) {
+OPEN1722_INLINE void Avtp_CanV2_SetEsi(Avtp_CanV2_t *pdu, bool esi)
+{
     SET_CAN_V2_FIELD(AVTP_CAN_V2_FIELD_ESI, esi);
 }
 
@@ -362,7 +385,8 @@ OPEN1722_INLINE void Avtp_CanV2_SetEsi(Avtp_CanV2_t* pdu, bool esi) {
  * @param pdu Pointer to an ACF_CAN_V2 message.
  * @param canIdentifier The value to set.
  */
-OPEN1722_INLINE void Avtp_CanV2_SetCanIdentifier(Avtp_CanV2_t* pdu, uint32_t canIdentifier) {
+OPEN1722_INLINE void Avtp_CanV2_SetCanIdentifier(Avtp_CanV2_t *pdu, uint32_t canIdentifier)
+{
     SET_CAN_V2_FIELD(AVTP_CAN_V2_FIELD_CAN_IDENTIFIER, canIdentifier);
 }
 
@@ -372,7 +396,7 @@ OPEN1722_INLINE void Avtp_CanV2_SetCanIdentifier(Avtp_CanV2_t* pdu, uint32_t can
  * @param pdu Pointer to the first bit of a 1722 ACF CAN V2 PDU.
  * @return Pointer to ACF CAN V2 frame payload
  */
-OPEN1722_INLINE const uint8_t *Avtp_CanV2_GetPayload(const Avtp_CanV2_t* const pdu)
+OPEN1722_INLINE const uint8_t *Avtp_CanV2_GetPayload(const Avtp_CanV2_t *const pdu)
 {
     return pdu->payload;
 }
@@ -424,7 +448,7 @@ OPEN1722_INLINE void Avtp_CanV2_SetPayloadLength(Avtp_CanV2_t *pdu, uint16_t pay
  * @param pdu Pointer to the first bit of a 1722 ACF CAN V2 PDU.
  * @return  Length of CAN payload in bytes
  */
-OPEN1722_INLINE uint8_t Avtp_CanV2_GetPayloadLength(const Avtp_CanV2_t* const pdu)
+OPEN1722_INLINE uint8_t Avtp_CanV2_GetPayloadLength(const Avtp_CanV2_t *const pdu)
 {
     uint8_t pad_length = Avtp_CanV2_GetPad(pdu);
     uint16_t acf_length_bytes = Avtp_CanV2_GetAcfMsgLengthInBytes(pdu);
@@ -436,7 +460,7 @@ OPEN1722_INLINE uint8_t Avtp_CanV2_GetPayloadLength(const Avtp_CanV2_t* const pd
  *
  * @param pdu Pointer to the first bit of a 1722 ACF CAN V2 PDU.
  */
-OPEN1722_INLINE void Avtp_CanV2_Init(Avtp_CanV2_t* pdu)
+OPEN1722_INLINE void Avtp_CanV2_Init(Avtp_CanV2_t *pdu)
 {
     if (pdu != NULL) {
         memset(pdu, 0, sizeof(Avtp_CanV2_t));
@@ -486,7 +510,7 @@ OPEN1722_INLINE void Avtp_CanV2_CreateAcfMessage(Avtp_CanV2_t *pdu, uint32_t fra
  * @param bufferSize Size of the buffer containing the ACF CAN V2 frame.
  * @return true if the ACF CAN V2 frame is valid, false otherwise.
  */
-OPEN1722_INLINE bool Avtp_CanV2_IsValid(const Avtp_CanV2_t* const pdu, size_t bufferSize)
+OPEN1722_INLINE bool Avtp_CanV2_IsValid(const Avtp_CanV2_t *const pdu, size_t bufferSize)
 {
     if (pdu == NULL) {
         return false;

--- a/unit/test-can-v2.c
+++ b/unit/test-can-v2.c
@@ -44,10 +44,14 @@ static void Test_CanV2_Init(void** state)
     const size_t msg_len = AVTP_CAN_V2_HEADER_LEN + 4;
     uint8_t msg[msg_len] = {0};
     Avtp_CanV2_t* canV2 = (Avtp_CanV2_t*)msg;
+
+    // Check init function while passing in a null pointer
+    Avtp_CanV2_Init(NULL);
+
     Avtp_CanV2_Init(canV2);
 
     uint8_t expected_msg[msg_len] = {
-        0x42, 0x04, 0x0,  0x0,
+        0x42, 0x00, 0x0,  0x0,
         0x0,  0x0,  0x0,  0x0,
         0x0,  0x0,  0x0,  0x0,
         0x0,  0x0,  0x0,  0x0,
@@ -55,6 +59,34 @@ static void Test_CanV2_Init(void** state)
     };
 
     assert_memory_equal(msg, expected_msg, msg_len);
+}
+
+static void Test_CanV2_GetAcfMsgType(void** state)
+{
+    const size_t msg_len = AVTP_CAN_V2_HEADER_LEN + 4;
+    uint8_t msg[msg_len] = {
+        0x42, 0x04, 0x0,  0x0,
+        0x0,  0x0,  0x0,  0x0,
+        0x0,  0x0,  0x0,  0x0,
+        0x0,  0x0,  0x0,  0x0,
+        0x0,  0x0,  0x0,  0x0
+    };
+    Avtp_CanV2_t* canV2 = (Avtp_CanV2_t*)msg;
+    assert_int_equal(Avtp_CanV2_GetAcfMsgType(canV2), AVTP_ACF_TYPE_CAN_V2);
+}
+
+static void Test_CanV2_GetAcfMsgLength(void** state)
+{
+    const size_t msg_len = AVTP_CAN_V2_HEADER_LEN + 4;
+    uint8_t msg[msg_len] = {
+        0x42, 0x04, 0x0,  0x0,
+        0x0,  0x0,  0x0,  0x0,
+        0x0,  0x0,  0x0,  0x0,
+        0x0,  0x0,  0x0,  0x0,
+        0x0,  0x0,  0x0,  0x0
+    };
+    Avtp_CanV2_t* canV2 = (Avtp_CanV2_t*)msg;
+    assert_int_equal(Avtp_CanV2_GetAcfMsgLength(canV2), 4);
 }
 
 static void Test_CanV2_GetPad(void** state)
@@ -197,7 +229,7 @@ static void Test_CanV2_GetCanIdentifier(void** state)
     assert_int_equal(Avtp_CanV2_GetCanIdentifier(canV2), 0x17FFFFFFul);
 }
 
-static void Test_CanV2_GetPayloadLen(void** state)
+static void Test_CanV2_GetPayloadLength(void** state)
 {
     const size_t msg_len = AVTP_CAN_V2_HEADER_LEN + 4;
     uint8_t msg[msg_len] = {
@@ -208,10 +240,10 @@ static void Test_CanV2_GetPayloadLen(void** state)
         0x0,  0x0,  0x0,  0x0
     };
     Avtp_CanV2_t* canV2 = (Avtp_CanV2_t*)msg;
-    assert_int_equal(Avtp_CanV2_GetPayloadLen(canV2), 1);
+    assert_int_equal(Avtp_CanV2_GetPayloadLength(canV2), 1);
 }
 
-static void Test_CanV2_GetPayloadLen_NoPadding(void** state)
+static void Test_CanV2_GetPayloadLength_NoPadding(void** state)
 {
     const size_t msg_len = AVTP_CAN_V2_HEADER_LEN + 4;
     uint8_t msg[msg_len] = {
@@ -222,10 +254,10 @@ static void Test_CanV2_GetPayloadLen_NoPadding(void** state)
         0x0,  0x0,  0x0,  0x0
     };
     Avtp_CanV2_t* canV2 = (Avtp_CanV2_t*)msg;
-    assert_int_equal(Avtp_CanV2_GetPayloadLen(canV2), 4);
+    assert_int_equal(Avtp_CanV2_GetPayloadLength(canV2), 4);
 }
 
-static void Test_CanV2_GetLen(void** state)
+static void Test_CanV2_GetAcfMsgLengthInBytes(void** state)
 {
     const size_t msg_len = AVTP_CAN_V2_HEADER_LEN + 4;
     uint8_t msg[msg_len] = {
@@ -236,7 +268,28 @@ static void Test_CanV2_GetLen(void** state)
         0x0,  0x0,  0x0,  0x0
     };
     Avtp_CanV2_t* canV2 = (Avtp_CanV2_t*)msg;
-    assert_int_equal(Avtp_CanV2_GetLen(canV2), 5 * 4);
+    assert_int_equal(Avtp_CanV2_GetAcfMsgLengthInBytes(canV2), 5 * 4);
+}
+
+static void Test_CanV2_SetAcfMsgType(void** state)
+{
+    const size_t msg_len = AVTP_CAN_V2_HEADER_LEN + 4;
+    uint8_t msg[msg_len] = {0};
+    Avtp_CanV2_t* canV2 = (Avtp_CanV2_t*)msg;
+    Avtp_CanV2_Init(canV2);
+    Avtp_CanV2_SetAcfMsgType(canV2, AVTP_ACF_TYPE_CAN_V2);
+    assert_int_equal(Avtp_CanV2_GetAcfMsgType(canV2), AVTP_ACF_TYPE_CAN_V2);
+}
+
+static void Test_CanV2_SetAcfMsgLength(void** state)
+{
+    const size_t msg_len = AVTP_CAN_V2_HEADER_LEN + 4;
+    uint8_t msg[msg_len] = {0};
+    Avtp_CanV2_t* canV2 = (Avtp_CanV2_t*)msg;
+    Avtp_CanV2_Init(canV2);
+    Avtp_CanV2_SetAcfMsgLength(canV2, 5);
+    assert_int_equal(Avtp_CanV2_GetAcfMsgLength(canV2), 5);
+    assert_int_equal(Avtp_CanV2_GetAcfMsgLengthInBytes(canV2), 20);
 }
 
 static void Test_CanV2_SetMtv(void** state)
@@ -248,7 +301,7 @@ static void Test_CanV2_SetMtv(void** state)
     Avtp_CanV2_SetMtv(canV2, true);
 
     uint8_t expected_msg[msg_len] = {
-        0x42, 0x04, 0x20, 0x0,
+        0x42, 0x00, 0x20, 0x0,
         0x0,  0x0,  0x0,  0x0,
         0x0,  0x0,  0x0,  0x0,
         0x0,  0x0,  0x0,  0x0,
@@ -266,7 +319,7 @@ static void Test_CanV2_SetRtr(void** state)
     Avtp_CanV2_SetRtr(canV2, true);
 
     uint8_t expected_msg[msg_len] = {
-        0x42, 0x04, 0x10, 0x0,
+        0x42, 0x00, 0x10, 0x0,
         0x0,  0x0,  0x0,  0x0,
         0x0,  0x0,  0x0,  0x0,
         0x0,  0x0,  0x0,  0x0,
@@ -284,7 +337,7 @@ static void Test_CanV2_SetEff(void** state)
     Avtp_CanV2_SetEff(canV2, true);
 
     uint8_t expected_msg[msg_len] = {
-        0x42, 0x04, 0x08, 0x0,
+        0x42, 0x00, 0x08, 0x0,
         0x0,  0x0,  0x0,  0x0,
         0x0,  0x0,  0x0,  0x0,
         0x0,  0x0,  0x0,  0x0,
@@ -302,7 +355,7 @@ static void Test_CanV2_SetCanBusId(void** state)
     Avtp_CanV2_SetCanBusId(canV2, 0x5FF);
 
     uint8_t expected_msg[msg_len] = {
-        0x42, 0x04, 0x05, 0xFF,
+        0x42, 0x00, 0x05, 0xFF,
         0x0,  0x0,  0x0,  0x0,
         0x0,  0x0,  0x0,  0x0,
         0x0,  0x0,  0x0,  0x0,
@@ -320,7 +373,7 @@ static void Test_CanV2_SetMessageTimestamp(void** state)
     Avtp_CanV2_SetMessageTimestamp(canV2, 0xBFFFFFFFFFFFFFFFull);
 
     uint8_t expected_msg[msg_len] = {
-        0x42, 0x04, 0x0,  0x0,
+        0x42, 0x00, 0x0,  0x0,
         0xBF, 0xFF, 0xFF, 0xFF,
         0xFF, 0xFF, 0xFF, 0xFF,
         0x0,  0x0,  0x0,  0x0,
@@ -338,7 +391,7 @@ static void Test_CanV2_SetBrs(void** state)
     Avtp_CanV2_SetBrs(canV2, true);
 
     uint8_t expected_msg[msg_len] = {
-        0x42, 0x04, 0x0,  0x0,
+        0x42, 0x00, 0x0,  0x0,
         0x0,  0x0,  0x0,  0x0,
         0x0,  0x0,  0x0,  0x0,
         0x80, 0x0,  0x0,  0x0,
@@ -356,7 +409,7 @@ static void Test_CanV2_SetFdf(void** state)
     Avtp_CanV2_SetFdf(canV2, true);
 
     uint8_t expected_msg[msg_len] = {
-        0x42, 0x04, 0x0,  0x0,
+        0x42, 0x00, 0x0,  0x0,
         0x0,  0x0,  0x0,  0x0,
         0x0,  0x0,  0x0,  0x0,
         0x40, 0x0,  0x0,  0x0,
@@ -374,7 +427,7 @@ static void Test_CanV2_SetEsi(void** state)
     Avtp_CanV2_SetEsi(canV2, true);
 
     uint8_t expected_msg[msg_len] = {
-        0x42, 0x04, 0x0,  0x0,
+        0x42, 0x00, 0x0,  0x0,
         0x0,  0x0,  0x0,  0x0,
         0x0,  0x0,  0x0,  0x0,
         0x20, 0x0,  0x0,  0x0,
@@ -392,7 +445,7 @@ static void Test_CanV2_SetCanIdentifier(void** state)
     Avtp_CanV2_SetCanIdentifier(canV2, 0x17FFFFFFul);
 
     uint8_t expected_msg[msg_len] = {
-        0x42, 0x04, 0x0,  0x0,
+        0x42, 0x00, 0x0,  0x0,
         0x0,  0x0,  0x0,  0x0,
         0x0,  0x0,  0x0,  0x0,
         0x17, 0xFF, 0xFF, 0xFF,
@@ -401,13 +454,13 @@ static void Test_CanV2_SetCanIdentifier(void** state)
     assert_memory_equal(msg, expected_msg, msg_len);
 }
 
-static void Test_CanV2_SetPayloadLen(void** state)
+static void Test_CanV2_SetPayloadLength(void** state)
 {
     const size_t msg_len = AVTP_CAN_V2_HEADER_LEN + 4;
     uint8_t msg[msg_len] = {0};
     Avtp_CanV2_t* canV2 = (Avtp_CanV2_t*)msg;
     Avtp_CanV2_Init(canV2);
-    Avtp_CanV2_SetPayloadLen(canV2, 3);
+    Avtp_CanV2_SetPayloadLength(canV2, 3);
 
     uint8_t expected_msg[msg_len] = {
         0x42, 0x05, 0x40, 0x0,
@@ -419,13 +472,13 @@ static void Test_CanV2_SetPayloadLen(void** state)
     assert_memory_equal(msg, expected_msg, msg_len);
 }
 
-static void Test_CanV2_SetPayloadLen_NoPadding(void** state)
+static void Test_CanV2_SetPayloadLength_NoPadding(void** state)
 {
     const size_t msg_len = AVTP_CAN_V2_HEADER_LEN + 4;
     uint8_t msg[msg_len] = {0};
     Avtp_CanV2_t* canV2 = (Avtp_CanV2_t*)msg;
     Avtp_CanV2_Init(canV2);
-    Avtp_CanV2_SetPayloadLen(canV2, 4);
+    Avtp_CanV2_SetPayloadLength(canV2, 4);
 
     uint8_t expected_msg[msg_len] = {
         0x42, 0x05, 0x0,  0x0,
@@ -437,10 +490,124 @@ static void Test_CanV2_SetPayloadLen_NoPadding(void** state)
     assert_memory_equal(msg, expected_msg, msg_len);
 }
 
+static void Test_CanV2_Payload(void** state)
+{
+    const size_t msg_len = AVTP_CAN_V2_HEADER_LEN + 8;
+    uint8_t msg[msg_len] = {0};
+    Avtp_CanV2_t* canV2 = (Avtp_CanV2_t*)msg;
+    uint8_t payload[8] = {0,1,2,3,4,5,6,7};
+
+    Avtp_CanV2_Init(canV2);
+    Avtp_CanV2_SetPayload(canV2, payload, sizeof(payload));
+
+    assert_ptr_equal(Avtp_CanV2_GetPayload(canV2), msg + AVTP_CAN_V2_HEADER_LEN);
+    assert_memory_equal(payload, Avtp_CanV2_GetPayload(canV2), sizeof(payload));
+}
+
+static void Test_CanV2_CreateAcfMessage(void** state)
+{
+    const size_t msg_len = AVTP_CAN_V2_HEADER_LEN + 8;
+    uint8_t msg[msg_len] = {0};
+    Avtp_CanV2_t* canV2 = (Avtp_CanV2_t*)msg;
+    uint8_t payload[8] = {0,1,2,3,4,5,6,7};
+
+    Avtp_CanV2_CreateAcfMessage(canV2, 0x7ff, payload, sizeof(payload), AVTP_CAN_CLASSIC);
+
+    assert_int_equal(Avtp_CanV2_GetAcfMsgType(canV2), AVTP_ACF_TYPE_CAN_V2);
+    assert_int_equal(Avtp_CanV2_GetCanIdentifier(canV2), 0x7ff);
+    assert_int_equal(Avtp_CanV2_IsEff(canV2), false);
+    assert_memory_equal(payload, msg + AVTP_CAN_V2_HEADER_LEN, sizeof(payload));
+    assert_int_equal(Avtp_CanV2_GetPayloadLength(canV2), 8);
+
+    // Extended Frame IDs set the EFF flag
+    Avtp_CanV2_CreateAcfMessage(canV2, 0x800, payload, sizeof(payload), AVTP_CAN_CLASSIC);
+    assert_int_equal(Avtp_CanV2_GetCanIdentifier(canV2), 0x800);
+    assert_int_equal(Avtp_CanV2_IsEff(canV2), true);
+
+    // can_bus_id, message_timestamp and mtv are set by the caller afterwards
+    Avtp_CanV2_SetCanBusId(canV2, 0x5FF);
+    Avtp_CanV2_SetMessageTimestamp(canV2, 0x123456789ABCDEF0ULL);
+    Avtp_CanV2_SetMtv(canV2, true);
+    assert_int_equal(Avtp_CanV2_GetCanBusId(canV2), 0x5FF);
+    assert_int_equal(Avtp_CanV2_GetMessageTimestamp(canV2), 0x123456789ABCDEF0ULL);
+    assert_int_equal(Avtp_CanV2_IsMtv(canV2), true);
+}
+
+static void Test_CanV2_CreateFromGarbage(void** state)
+{
+    const size_t msg_len = AVTP_CAN_V2_HEADER_LEN + 8;
+    uint8_t msg[msg_len];
+    Avtp_CanV2_t* canV2 = (Avtp_CanV2_t*)msg;
+    uint8_t payload[8] = {0,1,2,3,4,5,6,7};
+
+    // CreateAcfMessage must fully initialize the header even on garbage input.
+    memset(msg, 0xAA, msg_len);
+    Avtp_CanV2_CreateAcfMessage(canV2, 0x123, payload, sizeof(payload), AVTP_CAN_CLASSIC);
+
+    assert_int_equal(Avtp_CanV2_GetAcfMsgType(canV2), AVTP_ACF_TYPE_CAN_V2);
+    assert_int_equal(Avtp_CanV2_IsMtv(canV2), false);
+    assert_int_equal(Avtp_CanV2_IsRtr(canV2), false);
+    assert_int_equal(Avtp_CanV2_IsBrs(canV2), false);
+    assert_int_equal(Avtp_CanV2_IsFdf(canV2), false);
+    assert_int_equal(Avtp_CanV2_IsEsi(canV2), false);
+    assert_int_equal(Avtp_CanV2_GetCanBusId(canV2), 0);
+    assert_int_equal(Avtp_CanV2_GetMessageTimestamp(canV2), 0);
+    assert_memory_equal(payload, msg + AVTP_CAN_V2_HEADER_LEN, sizeof(payload));
+    assert_int_equal(Avtp_CanV2_IsValid(canV2, msg_len), 1);
+}
+
+static void Test_CanV2_IsValid(void** state)
+{
+    const size_t msg_len = AVTP_CAN_V2_HEADER_LEN + 68;
+    uint8_t msg[msg_len] = {0};
+    Avtp_CanV2_t* canV2 = (Avtp_CanV2_t*)msg;
+    uint32_t frame_id = 0x123;
+
+    // An Init-only PDU has AcfMsgLength == 0, so IsValid must reject it.
+    Avtp_CanV2_Init(canV2);
+    assert_int_equal(Avtp_CanV2_IsValid(canV2, msg_len), 0);
+
+    // A properly-formed classic CAN frame with an 8-byte payload is valid.
+    {
+        uint8_t payload[8] = {0,1,2,3,4,5,6,7};
+        Avtp_CanV2_Init(canV2);
+        Avtp_CanV2_CreateAcfMessage(canV2, frame_id, payload, sizeof(payload), AVTP_CAN_CLASSIC);
+        assert_int_equal(Avtp_CanV2_IsValid(canV2, msg_len), 1);
+    }
+
+    // Not a CAN V2 message (zero buffer, AcfMsgType != CAN_V2).
+    memset(msg, 0, msg_len);
+    assert_int_equal(Avtp_CanV2_IsValid(canV2, msg_len), 0);
+
+    // Classic CAN payload bound: a 12-byte payload as classic CAN is invalid.
+    {
+        uint8_t too_big[12] = {0};
+        Avtp_CanV2_Init(canV2);
+        Avtp_CanV2_CreateAcfMessage(canV2, frame_id, too_big, sizeof(too_big), AVTP_CAN_CLASSIC);
+        assert_int_equal(Avtp_CanV2_IsValid(canV2, msg_len), 0);
+    }
+
+    // CAN-FD payload bound: 64 bytes valid, 68 bytes invalid.
+    {
+        uint8_t fd_max[64] = {0};
+        Avtp_CanV2_Init(canV2);
+        Avtp_CanV2_CreateAcfMessage(canV2, frame_id, fd_max, sizeof(fd_max), AVTP_CAN_FD);
+        assert_int_equal(Avtp_CanV2_IsValid(canV2, msg_len), 1);
+    }
+    {
+        uint8_t fd_too_big[68] = {0};
+        Avtp_CanV2_Init(canV2);
+        Avtp_CanV2_CreateAcfMessage(canV2, frame_id, fd_too_big, sizeof(fd_too_big), AVTP_CAN_FD);
+        assert_int_equal(Avtp_CanV2_IsValid(canV2, msg_len), 0);
+    }
+}
+
 int main(void)
 {
     const struct CMUnitTest tests[] = {
         cmocka_unit_test(Test_CanV2_Init),
+        cmocka_unit_test(Test_CanV2_GetAcfMsgType),
+        cmocka_unit_test(Test_CanV2_GetAcfMsgLength),
         cmocka_unit_test(Test_CanV2_GetPad),
         cmocka_unit_test(Test_CanV2_IsMtv),
         cmocka_unit_test(Test_CanV2_IsRtr),
@@ -451,9 +618,11 @@ int main(void)
         cmocka_unit_test(Test_CanV2_IsFdf),
         cmocka_unit_test(Test_CanV2_IsEsi),
         cmocka_unit_test(Test_CanV2_GetCanIdentifier),
-        cmocka_unit_test(Test_CanV2_GetPayloadLen),
-        cmocka_unit_test(Test_CanV2_GetPayloadLen_NoPadding),
-        cmocka_unit_test(Test_CanV2_GetLen),
+        cmocka_unit_test(Test_CanV2_GetPayloadLength),
+        cmocka_unit_test(Test_CanV2_GetPayloadLength_NoPadding),
+        cmocka_unit_test(Test_CanV2_GetAcfMsgLengthInBytes),
+        cmocka_unit_test(Test_CanV2_SetAcfMsgType),
+        cmocka_unit_test(Test_CanV2_SetAcfMsgLength),
         cmocka_unit_test(Test_CanV2_SetMtv),
         cmocka_unit_test(Test_CanV2_SetRtr),
         cmocka_unit_test(Test_CanV2_SetEff),
@@ -463,8 +632,12 @@ int main(void)
         cmocka_unit_test(Test_CanV2_SetFdf),
         cmocka_unit_test(Test_CanV2_SetEsi),
         cmocka_unit_test(Test_CanV2_SetCanIdentifier),
-        cmocka_unit_test(Test_CanV2_SetPayloadLen),
-        cmocka_unit_test(Test_CanV2_SetPayloadLen_NoPadding)
+        cmocka_unit_test(Test_CanV2_SetPayloadLength),
+        cmocka_unit_test(Test_CanV2_SetPayloadLength_NoPadding),
+        cmocka_unit_test(Test_CanV2_Payload),
+        cmocka_unit_test(Test_CanV2_CreateAcfMessage),
+        cmocka_unit_test(Test_CanV2_CreateFromGarbage),
+        cmocka_unit_test(Test_CanV2_IsValid)
     };
 
     return cmocka_run_group_tests(tests, NULL, NULL);

--- a/unit/test-can-v2.c
+++ b/unit/test-can-v2.c
@@ -39,463 +39,328 @@ extern "C" {
 #include <cmocka.h>
 #include <stdio.h>
 
-static void Test_CanV2_Init(void** state)
+static void Test_CanV2_Init(void **state)
 {
     const size_t msg_len = AVTP_CAN_V2_HEADER_LEN + 4;
     uint8_t msg[msg_len] = {0};
-    Avtp_CanV2_t* canV2 = (Avtp_CanV2_t*)msg;
+    Avtp_CanV2_t *canV2 = (Avtp_CanV2_t *)msg;
 
     // Check init function while passing in a null pointer
     Avtp_CanV2_Init(NULL);
 
     Avtp_CanV2_Init(canV2);
 
-    uint8_t expected_msg[msg_len] = {
-        0x42, 0x00, 0x0,  0x0,
-        0x0,  0x0,  0x0,  0x0,
-        0x0,  0x0,  0x0,  0x0,
-        0x0,  0x0,  0x0,  0x0,
-        0x0,  0x0,  0x0,  0x0
-    };
+    uint8_t expected_msg[msg_len] = {0x42, 0x00, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0,
+                                     0x0,  0x0,  0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0};
 
     assert_memory_equal(msg, expected_msg, msg_len);
 }
 
-static void Test_CanV2_GetAcfMsgType(void** state)
+static void Test_CanV2_GetAcfMsgType(void **state)
 {
     const size_t msg_len = AVTP_CAN_V2_HEADER_LEN + 4;
-    uint8_t msg[msg_len] = {
-        0x42, 0x04, 0x0,  0x0,
-        0x0,  0x0,  0x0,  0x0,
-        0x0,  0x0,  0x0,  0x0,
-        0x0,  0x0,  0x0,  0x0,
-        0x0,  0x0,  0x0,  0x0
-    };
-    Avtp_CanV2_t* canV2 = (Avtp_CanV2_t*)msg;
+    uint8_t msg[msg_len] = {0x42, 0x04, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0,
+                            0x0,  0x0,  0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0};
+    Avtp_CanV2_t *canV2 = (Avtp_CanV2_t *)msg;
     assert_int_equal(Avtp_CanV2_GetAcfMsgType(canV2), AVTP_ACF_TYPE_CAN_V2);
 }
 
-static void Test_CanV2_GetAcfMsgLength(void** state)
+static void Test_CanV2_GetAcfMsgLength(void **state)
 {
     const size_t msg_len = AVTP_CAN_V2_HEADER_LEN + 4;
-    uint8_t msg[msg_len] = {
-        0x42, 0x04, 0x0,  0x0,
-        0x0,  0x0,  0x0,  0x0,
-        0x0,  0x0,  0x0,  0x0,
-        0x0,  0x0,  0x0,  0x0,
-        0x0,  0x0,  0x0,  0x0
-    };
-    Avtp_CanV2_t* canV2 = (Avtp_CanV2_t*)msg;
+    uint8_t msg[msg_len] = {0x42, 0x04, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0,
+                            0x0,  0x0,  0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0};
+    Avtp_CanV2_t *canV2 = (Avtp_CanV2_t *)msg;
     assert_int_equal(Avtp_CanV2_GetAcfMsgLength(canV2), 4);
 }
 
-static void Test_CanV2_GetPad(void** state)
+static void Test_CanV2_GetPad(void **state)
 {
     const size_t msg_len = AVTP_CAN_V2_HEADER_LEN + 4;
-    uint8_t msg[msg_len] = {
-        0x42, 0x04, 0xC0, 0x0,
-        0x0,  0x0,  0x0,  0x0,
-        0x0,  0x0,  0x0,  0x0,
-        0x0,  0x0,  0x0,  0x0,
-        0x0,  0x0,  0x0,  0x0
-    };
-    Avtp_CanV2_t* canV2 = (Avtp_CanV2_t*)msg;
+    uint8_t msg[msg_len] = {0x42, 0x04, 0xC0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0,
+                            0x0,  0x0,  0x0,  0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0};
+    Avtp_CanV2_t *canV2 = (Avtp_CanV2_t *)msg;
     assert_int_equal(Avtp_CanV2_GetPad(canV2), 3);
 }
 
-static void Test_CanV2_IsMtv(void** state)
+static void Test_CanV2_IsMtv(void **state)
 {
     const size_t msg_len = AVTP_CAN_V2_HEADER_LEN + 4;
-    uint8_t msg[msg_len] = {
-        0x42, 0x04, 0x20, 0x0,
-        0x0,  0x0,  0x0,  0x0,
-        0x0,  0x0,  0x0,  0x0,
-        0x0,  0x0,  0x0,  0x0,
-        0x0,  0x0,  0x0,  0x0
-    };
-    Avtp_CanV2_t* canV2 = (Avtp_CanV2_t*)msg;
+    uint8_t msg[msg_len] = {0x42, 0x04, 0x20, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0,
+                            0x0,  0x0,  0x0,  0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0};
+    Avtp_CanV2_t *canV2 = (Avtp_CanV2_t *)msg;
     assert_int_equal(Avtp_CanV2_IsMtv(canV2), true);
 }
 
-static void Test_CanV2_IsRtr(void** state)
+static void Test_CanV2_IsRtr(void **state)
 {
     const size_t msg_len = AVTP_CAN_V2_HEADER_LEN + 4;
-    uint8_t msg[msg_len] = {
-        0x42, 0x04, 0x10, 0x0,
-        0x0,  0x0,  0x0,  0x0,
-        0x0,  0x0,  0x0,  0x0,
-        0x0,  0x0,  0x0,  0x0,
-        0x0,  0x0,  0x0,  0x0
-    };
-    Avtp_CanV2_t* canV2 = (Avtp_CanV2_t*)msg;
+    uint8_t msg[msg_len] = {0x42, 0x04, 0x10, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0,
+                            0x0,  0x0,  0x0,  0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0};
+    Avtp_CanV2_t *canV2 = (Avtp_CanV2_t *)msg;
     assert_int_equal(Avtp_CanV2_IsRtr(canV2), true);
 }
 
-static void Test_CanV2_IsEff(void** state)
+static void Test_CanV2_IsEff(void **state)
 {
     const size_t msg_len = AVTP_CAN_V2_HEADER_LEN + 4;
-    uint8_t msg[msg_len] = {
-        0x42, 0x04, 0x08, 0x0,
-        0x0,  0x0,  0x0,  0x0,
-        0x0,  0x0,  0x0,  0x0,
-        0x0,  0x0,  0x0,  0x0,
-        0x0,  0x0,  0x0,  0x0
-    };
-    Avtp_CanV2_t* canV2 = (Avtp_CanV2_t*)msg;
+    uint8_t msg[msg_len] = {0x42, 0x04, 0x08, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0,
+                            0x0,  0x0,  0x0,  0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0};
+    Avtp_CanV2_t *canV2 = (Avtp_CanV2_t *)msg;
     assert_int_equal(Avtp_CanV2_IsEff(canV2), true);
 }
 
-static void Test_CanV2_GetCanBusId(void** state)
+static void Test_CanV2_GetCanBusId(void **state)
 {
     const size_t msg_len = AVTP_CAN_V2_HEADER_LEN + 4;
-    uint8_t msg[msg_len] = {
-        0x42, 0x04, 0x05, 0xFF,
-        0x0,  0x0,  0x0,  0x0,
-        0x0,  0x0,  0x0,  0x0,
-        0x0,  0x0,  0x0,  0x0,
-        0x0,  0x0,  0x0,  0x0
-    };
-    Avtp_CanV2_t* canV2 = (Avtp_CanV2_t*)msg;
+    uint8_t msg[msg_len] = {0x42, 0x04, 0x05, 0xFF, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0,
+                            0x0,  0x0,  0x0,  0x0,  0x0, 0x0, 0x0, 0x0, 0x0, 0x0};
+    Avtp_CanV2_t *canV2 = (Avtp_CanV2_t *)msg;
     assert_int_equal(Avtp_CanV2_GetCanBusId(canV2), 0x5FF);
 }
 
-static void Test_CanV2_GetMessageTimestamp(void** state)
+static void Test_CanV2_GetMessageTimestamp(void **state)
 {
     const size_t msg_len = AVTP_CAN_V2_HEADER_LEN + 4;
-    uint8_t msg[msg_len] = {
-        0x42, 0x04, 0x0,  0x0,
-        0xBF, 0xFF, 0xFF, 0xFF,
-        0xFF, 0xFF, 0xFF, 0xFF,
-        0x0,  0x0,  0x0,  0x0,
-        0x0,  0x0,  0x0,  0x0
-    };
-    Avtp_CanV2_t* canV2 = (Avtp_CanV2_t*)msg;
+    uint8_t msg[msg_len] = {0x42, 0x04, 0x0, 0x0, 0xBF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF,
+                            0xFF, 0xFF, 0x0, 0x0, 0x0,  0x0,  0x0,  0x0,  0x0,  0x0};
+    Avtp_CanV2_t *canV2 = (Avtp_CanV2_t *)msg;
     assert_int_equal(Avtp_CanV2_GetMessageTimestamp(canV2), 0xBFFFFFFFFFFFFFFFull);
 }
 
-static void Test_CanV2_IsBrs(void** state)
+static void Test_CanV2_IsBrs(void **state)
 {
     const size_t msg_len = AVTP_CAN_V2_HEADER_LEN + 4;
-    uint8_t msg[msg_len] = {
-        0x42, 0x04, 0x0,  0x0,
-        0x0,  0x0,  0x0,  0x0,
-        0x0,  0x0,  0x0,  0x0,
-        0x80, 0x0,  0x0,  0x0,
-        0x0,  0x0,  0x0,  0x0
-    };
-    Avtp_CanV2_t* canV2 = (Avtp_CanV2_t*)msg;
+    uint8_t msg[msg_len] = {0x42, 0x04, 0x0,  0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0,
+                            0x0,  0x0,  0x80, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0};
+    Avtp_CanV2_t *canV2 = (Avtp_CanV2_t *)msg;
     assert_int_equal(Avtp_CanV2_IsBrs(canV2), true);
 }
 
-static void Test_CanV2_IsFdf(void** state)
+static void Test_CanV2_IsFdf(void **state)
 {
     const size_t msg_len = AVTP_CAN_V2_HEADER_LEN + 4;
-    uint8_t msg[msg_len] = {
-        0x42, 0x04, 0x0,  0x0,
-        0x0,  0x0,  0x0,  0x0,
-        0x0,  0x0,  0x0,  0x0,
-        0x40, 0x0,  0x0,  0x0,
-        0x0,  0x0,  0x0,  0x0
-    };
-    Avtp_CanV2_t* canV2 = (Avtp_CanV2_t*)msg;
+    uint8_t msg[msg_len] = {0x42, 0x04, 0x0,  0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0,
+                            0x0,  0x0,  0x40, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0};
+    Avtp_CanV2_t *canV2 = (Avtp_CanV2_t *)msg;
     assert_int_equal(Avtp_CanV2_IsFdf(canV2), true);
 }
 
-static void Test_CanV2_IsEsi(void** state)
+static void Test_CanV2_IsEsi(void **state)
 {
     const size_t msg_len = AVTP_CAN_V2_HEADER_LEN + 4;
-    uint8_t msg[msg_len] = {
-        0x42, 0x04, 0x0,  0x0,
-        0x0,  0x0,  0x0,  0x0,
-        0x0,  0x0,  0x0,  0x0,
-        0x20, 0x0,  0x0,  0x0,
-        0x0,  0x0,  0x0,  0x0
-    };
-    Avtp_CanV2_t* canV2 = (Avtp_CanV2_t*)msg;
+    uint8_t msg[msg_len] = {0x42, 0x04, 0x0,  0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0,
+                            0x0,  0x0,  0x20, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0};
+    Avtp_CanV2_t *canV2 = (Avtp_CanV2_t *)msg;
     assert_int_equal(Avtp_CanV2_IsEsi(canV2), true);
 }
 
-static void Test_CanV2_GetCanIdentifier(void** state)
+static void Test_CanV2_GetCanIdentifier(void **state)
 {
     const size_t msg_len = AVTP_CAN_V2_HEADER_LEN + 4;
-    uint8_t msg[msg_len] = {
-        0x42, 0x04, 0x0,  0x0,
-        0x0,  0x0,  0x0,  0x0,
-        0x0,  0x0,  0x0,  0x0,
-        0x17, 0xFF, 0xFF, 0xFF,
-        0x0,  0x0,  0x0,  0x0
-    };
-    Avtp_CanV2_t* canV2 = (Avtp_CanV2_t*)msg;
+    uint8_t msg[msg_len] = {0x42, 0x04, 0x0,  0x0,  0x0,  0x0,  0x0, 0x0, 0x0, 0x0,
+                            0x0,  0x0,  0x17, 0xFF, 0xFF, 0xFF, 0x0, 0x0, 0x0, 0x0};
+    Avtp_CanV2_t *canV2 = (Avtp_CanV2_t *)msg;
     assert_int_equal(Avtp_CanV2_GetCanIdentifier(canV2), 0x17FFFFFFul);
 }
 
-static void Test_CanV2_GetPayloadLength(void** state)
+static void Test_CanV2_GetPayloadLength(void **state)
 {
     const size_t msg_len = AVTP_CAN_V2_HEADER_LEN + 4;
-    uint8_t msg[msg_len] = {
-        0x42, 0x05, 0xC0, 0x0,
-        0x0,  0x0,  0x0,  0x0,
-        0x0,  0x0,  0x0,  0x0,
-        0x0,  0x0,  0x0,  0x0,
-        0x0,  0x0,  0x0,  0x0
-    };
-    Avtp_CanV2_t* canV2 = (Avtp_CanV2_t*)msg;
+    uint8_t msg[msg_len] = {0x42, 0x05, 0xC0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0,
+                            0x0,  0x0,  0x0,  0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0};
+    Avtp_CanV2_t *canV2 = (Avtp_CanV2_t *)msg;
     assert_int_equal(Avtp_CanV2_GetPayloadLength(canV2), 1);
 }
 
-static void Test_CanV2_GetPayloadLength_NoPadding(void** state)
+static void Test_CanV2_GetPayloadLength_NoPadding(void **state)
 {
     const size_t msg_len = AVTP_CAN_V2_HEADER_LEN + 4;
-    uint8_t msg[msg_len] = {
-        0x42, 0x05, 0x0,  0x0,
-        0x0,  0x0,  0x0,  0x0,
-        0x0,  0x0,  0x0,  0x0,
-        0x0,  0x0,  0x0,  0x0,
-        0x0,  0x0,  0x0,  0x0
-    };
-    Avtp_CanV2_t* canV2 = (Avtp_CanV2_t*)msg;
+    uint8_t msg[msg_len] = {0x42, 0x05, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0,
+                            0x0,  0x0,  0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0};
+    Avtp_CanV2_t *canV2 = (Avtp_CanV2_t *)msg;
     assert_int_equal(Avtp_CanV2_GetPayloadLength(canV2), 4);
 }
 
-static void Test_CanV2_GetAcfMsgLengthInBytes(void** state)
+static void Test_CanV2_GetAcfMsgLengthInBytes(void **state)
 {
     const size_t msg_len = AVTP_CAN_V2_HEADER_LEN + 4;
-    uint8_t msg[msg_len] = {
-        0x42, 0x05, 0x0,  0x0,
-        0x0,  0x0,  0x0,  0x0,
-        0x0,  0x0,  0x0,  0x0,
-        0x0,  0x0,  0x0,  0x0,
-        0x0,  0x0,  0x0,  0x0
-    };
-    Avtp_CanV2_t* canV2 = (Avtp_CanV2_t*)msg;
+    uint8_t msg[msg_len] = {0x42, 0x05, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0,
+                            0x0,  0x0,  0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0};
+    Avtp_CanV2_t *canV2 = (Avtp_CanV2_t *)msg;
     assert_int_equal(Avtp_CanV2_GetAcfMsgLengthInBytes(canV2), 5 * 4);
 }
 
-static void Test_CanV2_SetAcfMsgType(void** state)
+static void Test_CanV2_SetAcfMsgType(void **state)
 {
     const size_t msg_len = AVTP_CAN_V2_HEADER_LEN + 4;
     uint8_t msg[msg_len] = {0};
-    Avtp_CanV2_t* canV2 = (Avtp_CanV2_t*)msg;
+    Avtp_CanV2_t *canV2 = (Avtp_CanV2_t *)msg;
     Avtp_CanV2_Init(canV2);
     Avtp_CanV2_SetAcfMsgType(canV2, AVTP_ACF_TYPE_CAN_V2);
     assert_int_equal(Avtp_CanV2_GetAcfMsgType(canV2), AVTP_ACF_TYPE_CAN_V2);
 }
 
-static void Test_CanV2_SetAcfMsgLength(void** state)
+static void Test_CanV2_SetAcfMsgLength(void **state)
 {
     const size_t msg_len = AVTP_CAN_V2_HEADER_LEN + 4;
     uint8_t msg[msg_len] = {0};
-    Avtp_CanV2_t* canV2 = (Avtp_CanV2_t*)msg;
+    Avtp_CanV2_t *canV2 = (Avtp_CanV2_t *)msg;
     Avtp_CanV2_Init(canV2);
     Avtp_CanV2_SetAcfMsgLength(canV2, 5);
     assert_int_equal(Avtp_CanV2_GetAcfMsgLength(canV2), 5);
     assert_int_equal(Avtp_CanV2_GetAcfMsgLengthInBytes(canV2), 20);
 }
 
-static void Test_CanV2_SetMtv(void** state)
+static void Test_CanV2_SetMtv(void **state)
 {
     const size_t msg_len = AVTP_CAN_V2_HEADER_LEN + 4;
     uint8_t msg[msg_len] = {0};
-    Avtp_CanV2_t* canV2 = (Avtp_CanV2_t*)msg;
+    Avtp_CanV2_t *canV2 = (Avtp_CanV2_t *)msg;
     Avtp_CanV2_Init(canV2);
     Avtp_CanV2_SetMtv(canV2, true);
 
-    uint8_t expected_msg[msg_len] = {
-        0x42, 0x00, 0x20, 0x0,
-        0x0,  0x0,  0x0,  0x0,
-        0x0,  0x0,  0x0,  0x0,
-        0x0,  0x0,  0x0,  0x0,
-        0x0,  0x0,  0x0,  0x0
-    };
+    uint8_t expected_msg[msg_len] = {0x42, 0x00, 0x20, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0,
+                                     0x0,  0x0,  0x0,  0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0};
     assert_memory_equal(msg, expected_msg, msg_len);
 }
 
-static void Test_CanV2_SetRtr(void** state)
+static void Test_CanV2_SetRtr(void **state)
 {
     const size_t msg_len = AVTP_CAN_V2_HEADER_LEN + 4;
     uint8_t msg[msg_len] = {0};
-    Avtp_CanV2_t* canV2 = (Avtp_CanV2_t*)msg;
+    Avtp_CanV2_t *canV2 = (Avtp_CanV2_t *)msg;
     Avtp_CanV2_Init(canV2);
     Avtp_CanV2_SetRtr(canV2, true);
 
-    uint8_t expected_msg[msg_len] = {
-        0x42, 0x00, 0x10, 0x0,
-        0x0,  0x0,  0x0,  0x0,
-        0x0,  0x0,  0x0,  0x0,
-        0x0,  0x0,  0x0,  0x0,
-        0x0,  0x0,  0x0,  0x0
-    };
+    uint8_t expected_msg[msg_len] = {0x42, 0x00, 0x10, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0,
+                                     0x0,  0x0,  0x0,  0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0};
     assert_memory_equal(msg, expected_msg, msg_len);
 }
 
-static void Test_CanV2_SetEff(void** state)
+static void Test_CanV2_SetEff(void **state)
 {
     const size_t msg_len = AVTP_CAN_V2_HEADER_LEN + 4;
     uint8_t msg[msg_len] = {0};
-    Avtp_CanV2_t* canV2 = (Avtp_CanV2_t*)msg;
+    Avtp_CanV2_t *canV2 = (Avtp_CanV2_t *)msg;
     Avtp_CanV2_Init(canV2);
     Avtp_CanV2_SetEff(canV2, true);
 
-    uint8_t expected_msg[msg_len] = {
-        0x42, 0x00, 0x08, 0x0,
-        0x0,  0x0,  0x0,  0x0,
-        0x0,  0x0,  0x0,  0x0,
-        0x0,  0x0,  0x0,  0x0,
-        0x0,  0x0,  0x0,  0x0
-    };
+    uint8_t expected_msg[msg_len] = {0x42, 0x00, 0x08, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0,
+                                     0x0,  0x0,  0x0,  0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0};
     assert_memory_equal(msg, expected_msg, msg_len);
 }
 
-static void Test_CanV2_SetCanBusId(void** state)
+static void Test_CanV2_SetCanBusId(void **state)
 {
     const size_t msg_len = AVTP_CAN_V2_HEADER_LEN + 4;
     uint8_t msg[msg_len] = {0};
-    Avtp_CanV2_t* canV2 = (Avtp_CanV2_t*)msg;
+    Avtp_CanV2_t *canV2 = (Avtp_CanV2_t *)msg;
     Avtp_CanV2_Init(canV2);
     Avtp_CanV2_SetCanBusId(canV2, 0x5FF);
 
-    uint8_t expected_msg[msg_len] = {
-        0x42, 0x00, 0x05, 0xFF,
-        0x0,  0x0,  0x0,  0x0,
-        0x0,  0x0,  0x0,  0x0,
-        0x0,  0x0,  0x0,  0x0,
-        0x0,  0x0,  0x0,  0x0
-    };
+    uint8_t expected_msg[msg_len] = {0x42, 0x00, 0x05, 0xFF, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0,
+                                     0x0,  0x0,  0x0,  0x0,  0x0, 0x0, 0x0, 0x0, 0x0, 0x0};
     assert_memory_equal(msg, expected_msg, msg_len);
 }
 
-static void Test_CanV2_SetMessageTimestamp(void** state)
+static void Test_CanV2_SetMessageTimestamp(void **state)
 {
     const size_t msg_len = AVTP_CAN_V2_HEADER_LEN + 4;
     uint8_t msg[msg_len] = {0};
-    Avtp_CanV2_t* canV2 = (Avtp_CanV2_t*)msg;
+    Avtp_CanV2_t *canV2 = (Avtp_CanV2_t *)msg;
     Avtp_CanV2_Init(canV2);
     Avtp_CanV2_SetMessageTimestamp(canV2, 0xBFFFFFFFFFFFFFFFull);
 
-    uint8_t expected_msg[msg_len] = {
-        0x42, 0x00, 0x0,  0x0,
-        0xBF, 0xFF, 0xFF, 0xFF,
-        0xFF, 0xFF, 0xFF, 0xFF,
-        0x0,  0x0,  0x0,  0x0,
-        0x0,  0x0,  0x0,  0x0
-    };
+    uint8_t expected_msg[msg_len] = {0x42, 0x00, 0x0, 0x0, 0xBF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF,
+                                     0xFF, 0xFF, 0x0, 0x0, 0x0,  0x0,  0x0,  0x0,  0x0,  0x0};
     assert_memory_equal(msg, expected_msg, msg_len);
 }
 
-static void Test_CanV2_SetBrs(void** state)
+static void Test_CanV2_SetBrs(void **state)
 {
     const size_t msg_len = AVTP_CAN_V2_HEADER_LEN + 4;
     uint8_t msg[msg_len] = {0};
-    Avtp_CanV2_t* canV2 = (Avtp_CanV2_t*)msg;
+    Avtp_CanV2_t *canV2 = (Avtp_CanV2_t *)msg;
     Avtp_CanV2_Init(canV2);
     Avtp_CanV2_SetBrs(canV2, true);
 
-    uint8_t expected_msg[msg_len] = {
-        0x42, 0x00, 0x0,  0x0,
-        0x0,  0x0,  0x0,  0x0,
-        0x0,  0x0,  0x0,  0x0,
-        0x80, 0x0,  0x0,  0x0,
-        0x0,  0x0,  0x0,  0x0
-    };
+    uint8_t expected_msg[msg_len] = {0x42, 0x00, 0x0,  0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0,
+                                     0x0,  0x0,  0x80, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0};
     assert_memory_equal(msg, expected_msg, msg_len);
 }
 
-static void Test_CanV2_SetFdf(void** state)
+static void Test_CanV2_SetFdf(void **state)
 {
     const size_t msg_len = AVTP_CAN_V2_HEADER_LEN + 4;
     uint8_t msg[msg_len] = {0};
-    Avtp_CanV2_t* canV2 = (Avtp_CanV2_t*)msg;
+    Avtp_CanV2_t *canV2 = (Avtp_CanV2_t *)msg;
     Avtp_CanV2_Init(canV2);
     Avtp_CanV2_SetFdf(canV2, true);
 
-    uint8_t expected_msg[msg_len] = {
-        0x42, 0x00, 0x0,  0x0,
-        0x0,  0x0,  0x0,  0x0,
-        0x0,  0x0,  0x0,  0x0,
-        0x40, 0x0,  0x0,  0x0,
-        0x0,  0x0,  0x0,  0x0
-    };
+    uint8_t expected_msg[msg_len] = {0x42, 0x00, 0x0,  0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0,
+                                     0x0,  0x0,  0x40, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0};
     assert_memory_equal(msg, expected_msg, msg_len);
 }
 
-static void Test_CanV2_SetEsi(void** state)
+static void Test_CanV2_SetEsi(void **state)
 {
     const size_t msg_len = AVTP_CAN_V2_HEADER_LEN + 4;
     uint8_t msg[msg_len] = {0};
-    Avtp_CanV2_t* canV2 = (Avtp_CanV2_t*)msg;
+    Avtp_CanV2_t *canV2 = (Avtp_CanV2_t *)msg;
     Avtp_CanV2_Init(canV2);
     Avtp_CanV2_SetEsi(canV2, true);
 
-    uint8_t expected_msg[msg_len] = {
-        0x42, 0x00, 0x0,  0x0,
-        0x0,  0x0,  0x0,  0x0,
-        0x0,  0x0,  0x0,  0x0,
-        0x20, 0x0,  0x0,  0x0,
-        0x0,  0x0,  0x0,  0x0
-    };
+    uint8_t expected_msg[msg_len] = {0x42, 0x00, 0x0,  0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0,
+                                     0x0,  0x0,  0x20, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0};
     assert_memory_equal(msg, expected_msg, msg_len);
 }
 
-static void Test_CanV2_SetCanIdentifier(void** state)
+static void Test_CanV2_SetCanIdentifier(void **state)
 {
     const size_t msg_len = AVTP_CAN_V2_HEADER_LEN + 4;
     uint8_t msg[msg_len] = {0};
-    Avtp_CanV2_t* canV2 = (Avtp_CanV2_t*)msg;
+    Avtp_CanV2_t *canV2 = (Avtp_CanV2_t *)msg;
     Avtp_CanV2_Init(canV2);
     Avtp_CanV2_SetCanIdentifier(canV2, 0x17FFFFFFul);
 
-    uint8_t expected_msg[msg_len] = {
-        0x42, 0x00, 0x0,  0x0,
-        0x0,  0x0,  0x0,  0x0,
-        0x0,  0x0,  0x0,  0x0,
-        0x17, 0xFF, 0xFF, 0xFF,
-        0x0,  0x0,  0x0,  0x0
-    };
+    uint8_t expected_msg[msg_len] = {0x42, 0x00, 0x0,  0x0,  0x0,  0x0,  0x0, 0x0, 0x0, 0x0,
+                                     0x0,  0x0,  0x17, 0xFF, 0xFF, 0xFF, 0x0, 0x0, 0x0, 0x0};
     assert_memory_equal(msg, expected_msg, msg_len);
 }
 
-static void Test_CanV2_SetPayloadLength(void** state)
+static void Test_CanV2_SetPayloadLength(void **state)
 {
     const size_t msg_len = AVTP_CAN_V2_HEADER_LEN + 4;
     uint8_t msg[msg_len] = {0};
-    Avtp_CanV2_t* canV2 = (Avtp_CanV2_t*)msg;
+    Avtp_CanV2_t *canV2 = (Avtp_CanV2_t *)msg;
     Avtp_CanV2_Init(canV2);
     Avtp_CanV2_SetPayloadLength(canV2, 3);
 
-    uint8_t expected_msg[msg_len] = {
-        0x42, 0x05, 0x40, 0x0,
-        0x0,  0x0,  0x0,  0x0,
-        0x0,  0x0,  0x0,  0x0,
-        0x0,  0x0,  0x0,  0x0,
-        0x0,  0x0,  0x0,  0x0
-    };
+    uint8_t expected_msg[msg_len] = {0x42, 0x05, 0x40, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0,
+                                     0x0,  0x0,  0x0,  0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0};
     assert_memory_equal(msg, expected_msg, msg_len);
 }
 
-static void Test_CanV2_SetPayloadLength_NoPadding(void** state)
+static void Test_CanV2_SetPayloadLength_NoPadding(void **state)
 {
     const size_t msg_len = AVTP_CAN_V2_HEADER_LEN + 4;
     uint8_t msg[msg_len] = {0};
-    Avtp_CanV2_t* canV2 = (Avtp_CanV2_t*)msg;
+    Avtp_CanV2_t *canV2 = (Avtp_CanV2_t *)msg;
     Avtp_CanV2_Init(canV2);
     Avtp_CanV2_SetPayloadLength(canV2, 4);
 
-    uint8_t expected_msg[msg_len] = {
-        0x42, 0x05, 0x0,  0x0,
-        0x0,  0x0,  0x0,  0x0,
-        0x0,  0x0,  0x0,  0x0,
-        0x0,  0x0,  0x0,  0x0,
-        0x0,  0x0,  0x0,  0x0
-    };
+    uint8_t expected_msg[msg_len] = {0x42, 0x05, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0,
+                                     0x0,  0x0,  0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0};
     assert_memory_equal(msg, expected_msg, msg_len);
 }
 
-static void Test_CanV2_Payload(void** state)
+static void Test_CanV2_Payload(void **state)
 {
     const size_t msg_len = AVTP_CAN_V2_HEADER_LEN + 8;
     uint8_t msg[msg_len] = {0};
-    Avtp_CanV2_t* canV2 = (Avtp_CanV2_t*)msg;
-    uint8_t payload[8] = {0,1,2,3,4,5,6,7};
+    Avtp_CanV2_t *canV2 = (Avtp_CanV2_t *)msg;
+    uint8_t payload[8] = {0, 1, 2, 3, 4, 5, 6, 7};
 
     Avtp_CanV2_Init(canV2);
     Avtp_CanV2_SetPayload(canV2, payload, sizeof(payload));
@@ -504,12 +369,12 @@ static void Test_CanV2_Payload(void** state)
     assert_memory_equal(payload, Avtp_CanV2_GetPayload(canV2), sizeof(payload));
 }
 
-static void Test_CanV2_CreateAcfMessage(void** state)
+static void Test_CanV2_CreateAcfMessage(void **state)
 {
     const size_t msg_len = AVTP_CAN_V2_HEADER_LEN + 8;
     uint8_t msg[msg_len] = {0};
-    Avtp_CanV2_t* canV2 = (Avtp_CanV2_t*)msg;
-    uint8_t payload[8] = {0,1,2,3,4,5,6,7};
+    Avtp_CanV2_t *canV2 = (Avtp_CanV2_t *)msg;
+    uint8_t payload[8] = {0, 1, 2, 3, 4, 5, 6, 7};
 
     Avtp_CanV2_CreateAcfMessage(canV2, 0x7ff, payload, sizeof(payload), AVTP_CAN_CLASSIC);
 
@@ -533,12 +398,12 @@ static void Test_CanV2_CreateAcfMessage(void** state)
     assert_int_equal(Avtp_CanV2_IsMtv(canV2), true);
 }
 
-static void Test_CanV2_CreateFromGarbage(void** state)
+static void Test_CanV2_CreateFromGarbage(void **state)
 {
     const size_t msg_len = AVTP_CAN_V2_HEADER_LEN + 8;
     uint8_t msg[msg_len];
-    Avtp_CanV2_t* canV2 = (Avtp_CanV2_t*)msg;
-    uint8_t payload[8] = {0,1,2,3,4,5,6,7};
+    Avtp_CanV2_t *canV2 = (Avtp_CanV2_t *)msg;
+    uint8_t payload[8] = {0, 1, 2, 3, 4, 5, 6, 7};
 
     // CreateAcfMessage must fully initialize the header even on garbage input.
     memset(msg, 0xAA, msg_len);
@@ -556,11 +421,11 @@ static void Test_CanV2_CreateFromGarbage(void** state)
     assert_int_equal(Avtp_CanV2_IsValid(canV2, msg_len), 1);
 }
 
-static void Test_CanV2_IsValid(void** state)
+static void Test_CanV2_IsValid(void **state)
 {
     const size_t msg_len = AVTP_CAN_V2_HEADER_LEN + 68;
     uint8_t msg[msg_len] = {0};
-    Avtp_CanV2_t* canV2 = (Avtp_CanV2_t*)msg;
+    Avtp_CanV2_t *canV2 = (Avtp_CanV2_t *)msg;
     uint32_t frame_id = 0x123;
 
     // An Init-only PDU has AcfMsgLength == 0, so IsValid must reject it.
@@ -569,7 +434,7 @@ static void Test_CanV2_IsValid(void** state)
 
     // A properly-formed classic CAN frame with an 8-byte payload is valid.
     {
-        uint8_t payload[8] = {0,1,2,3,4,5,6,7};
+        uint8_t payload[8] = {0, 1, 2, 3, 4, 5, 6, 7};
         Avtp_CanV2_Init(canV2);
         Avtp_CanV2_CreateAcfMessage(canV2, frame_id, payload, sizeof(payload), AVTP_CAN_CLASSIC);
         assert_int_equal(Avtp_CanV2_IsValid(canV2, msg_len), 1);
@@ -604,41 +469,39 @@ static void Test_CanV2_IsValid(void** state)
 
 int main(void)
 {
-    const struct CMUnitTest tests[] = {
-        cmocka_unit_test(Test_CanV2_Init),
-        cmocka_unit_test(Test_CanV2_GetAcfMsgType),
-        cmocka_unit_test(Test_CanV2_GetAcfMsgLength),
-        cmocka_unit_test(Test_CanV2_GetPad),
-        cmocka_unit_test(Test_CanV2_IsMtv),
-        cmocka_unit_test(Test_CanV2_IsRtr),
-        cmocka_unit_test(Test_CanV2_IsEff),
-        cmocka_unit_test(Test_CanV2_GetCanBusId),
-        cmocka_unit_test(Test_CanV2_GetMessageTimestamp),
-        cmocka_unit_test(Test_CanV2_IsBrs),
-        cmocka_unit_test(Test_CanV2_IsFdf),
-        cmocka_unit_test(Test_CanV2_IsEsi),
-        cmocka_unit_test(Test_CanV2_GetCanIdentifier),
-        cmocka_unit_test(Test_CanV2_GetPayloadLength),
-        cmocka_unit_test(Test_CanV2_GetPayloadLength_NoPadding),
-        cmocka_unit_test(Test_CanV2_GetAcfMsgLengthInBytes),
-        cmocka_unit_test(Test_CanV2_SetAcfMsgType),
-        cmocka_unit_test(Test_CanV2_SetAcfMsgLength),
-        cmocka_unit_test(Test_CanV2_SetMtv),
-        cmocka_unit_test(Test_CanV2_SetRtr),
-        cmocka_unit_test(Test_CanV2_SetEff),
-        cmocka_unit_test(Test_CanV2_SetCanBusId),
-        cmocka_unit_test(Test_CanV2_SetMessageTimestamp),
-        cmocka_unit_test(Test_CanV2_SetBrs),
-        cmocka_unit_test(Test_CanV2_SetFdf),
-        cmocka_unit_test(Test_CanV2_SetEsi),
-        cmocka_unit_test(Test_CanV2_SetCanIdentifier),
-        cmocka_unit_test(Test_CanV2_SetPayloadLength),
-        cmocka_unit_test(Test_CanV2_SetPayloadLength_NoPadding),
-        cmocka_unit_test(Test_CanV2_Payload),
-        cmocka_unit_test(Test_CanV2_CreateAcfMessage),
-        cmocka_unit_test(Test_CanV2_CreateFromGarbage),
-        cmocka_unit_test(Test_CanV2_IsValid)
-    };
+    const struct CMUnitTest tests[] = {cmocka_unit_test(Test_CanV2_Init),
+                                       cmocka_unit_test(Test_CanV2_GetAcfMsgType),
+                                       cmocka_unit_test(Test_CanV2_GetAcfMsgLength),
+                                       cmocka_unit_test(Test_CanV2_GetPad),
+                                       cmocka_unit_test(Test_CanV2_IsMtv),
+                                       cmocka_unit_test(Test_CanV2_IsRtr),
+                                       cmocka_unit_test(Test_CanV2_IsEff),
+                                       cmocka_unit_test(Test_CanV2_GetCanBusId),
+                                       cmocka_unit_test(Test_CanV2_GetMessageTimestamp),
+                                       cmocka_unit_test(Test_CanV2_IsBrs),
+                                       cmocka_unit_test(Test_CanV2_IsFdf),
+                                       cmocka_unit_test(Test_CanV2_IsEsi),
+                                       cmocka_unit_test(Test_CanV2_GetCanIdentifier),
+                                       cmocka_unit_test(Test_CanV2_GetPayloadLength),
+                                       cmocka_unit_test(Test_CanV2_GetPayloadLength_NoPadding),
+                                       cmocka_unit_test(Test_CanV2_GetAcfMsgLengthInBytes),
+                                       cmocka_unit_test(Test_CanV2_SetAcfMsgType),
+                                       cmocka_unit_test(Test_CanV2_SetAcfMsgLength),
+                                       cmocka_unit_test(Test_CanV2_SetMtv),
+                                       cmocka_unit_test(Test_CanV2_SetRtr),
+                                       cmocka_unit_test(Test_CanV2_SetEff),
+                                       cmocka_unit_test(Test_CanV2_SetCanBusId),
+                                       cmocka_unit_test(Test_CanV2_SetMessageTimestamp),
+                                       cmocka_unit_test(Test_CanV2_SetBrs),
+                                       cmocka_unit_test(Test_CanV2_SetFdf),
+                                       cmocka_unit_test(Test_CanV2_SetEsi),
+                                       cmocka_unit_test(Test_CanV2_SetCanIdentifier),
+                                       cmocka_unit_test(Test_CanV2_SetPayloadLength),
+                                       cmocka_unit_test(Test_CanV2_SetPayloadLength_NoPadding),
+                                       cmocka_unit_test(Test_CanV2_Payload),
+                                       cmocka_unit_test(Test_CanV2_CreateAcfMessage),
+                                       cmocka_unit_test(Test_CanV2_CreateFromGarbage),
+                                       cmocka_unit_test(Test_CanV2_IsValid)};
 
     return cmocka_run_group_tests(tests, NULL, NULL);
 }


### PR DESCRIPTION
- packed struct; 
- renamed field desscriptor and accessor defines according to other modules
- added Get/SetAcfMsgType, Get/SetAcfMsgLength, GetAcfMsgLengthInBytes, GetPayload, SetPayload, SetPad; renamed GetLen→GetAcfMsgLengthInBytes, GetPayloadLen→GetPayloadLength (uint8_t), SetPayloadLen→SetPayloadLength (pad-zeroing); 
- added inline CreateAcfMessage (minimal builder, calls Init) and IsValid; 
- tests: updated to new names, adjusted Init expectation, and added coverage for common-field accessors, payload helpers, CreateAcfMessage round-trip, IsValid, and garbage-buffer input.

Functional changes in first commit https://github.com/COVESA/Open1722/pull/172/commits/32ac8952a10a0e47eb44045c97efe04a6990c8e6