### PR TITLE
CanXl and CanXlBrief apply API guidelines 

### DIFF
--- a/include/avtp/acf/CanXl.h
+++ b/include/avtp/acf/CanXl.h
@@ -44,9 +44,14 @@ extern "C" {
 #include <stdbool.h>
 #include <string.h>
 
+#include "avtp/Utils.h"
 #include "avtp/Defines.h"
 #include "avtp/acf/AcfCommon.h"
-#include "avtp/Utils.h"
+
+#define GET_CANXL_FIELD(field)                                                                     \
+    (Avtp_GetField(Avtp_CanXlFieldDesc, AVTP_CANXL_FIELD_MAX, (uint8_t *)pdu, field))
+#define SET_CANXL_FIELD(field, value)                                                              \
+    (Avtp_SetField(Avtp_CanXlFieldDesc, AVTP_CANXL_FIELD_MAX, (uint8_t *)pdu, field, value))
 
 /**
  * Length of ACF_CANXL message header in bytes.
@@ -60,7 +65,7 @@ extern "C" {
 typedef struct {
     uint8_t header[AVTP_CANXL_HEADER_LEN];
     uint8_t payload[0];
-} Avtp_CanXl_t;
+} __attribute__((packed)) Avtp_CanXl_t;
 
 /**
  * Fields encoded in the ACF_CANXL header.
@@ -85,12 +90,12 @@ typedef enum {
     AVTP_CANXL_FIELD_SEGMENT_NUM,
     /* Count number of fields for bound checks */
     AVTP_CANXL_FIELD_MAX
-} Avtp_CanXlField_t;
+} Avtp_CanXlFields_t;
 
 /**
  * This table describes all the offsets of the ACF_CANXL header fields.
  */
-static const Avtp_FieldDescriptor_t __AVTP_CANXL_FIELDS[AVTP_CANXL_FIELD_MAX] =
+static const Avtp_FieldDescriptor_t Avtp_CanXlFieldDesc[AVTP_CANXL_FIELD_MAX] =
 {
     /* ACF common header fields */
     [AVTP_CANXL_FIELD_ACF_MSG_TYPE]           = { .quadlet = 0, .offset =  0, .bits = 7 },
@@ -112,327 +117,464 @@ static const Avtp_FieldDescriptor_t __AVTP_CANXL_FIELDS[AVTP_CANXL_FIELD_MAX] =
 };
 
 /**
- * Macro to get the value of a field from an ACF_CANXL message header.
- * 
- * @note This macro should not be used directly, instead use the field specific
- * getter functions defined below.
- */
-#define __Avtp_CanXl_GetField(field) \
-        (Avtp_GetField(__AVTP_CANXL_FIELDS, AVTP_CANXL_FIELD_MAX, (uint8_t*)msg, field))
-
-/**
- * Macro to set the value of a field in an ACF_CANXL message header.
- * 
- * @note This macro should not be used directly, instead use the field specific
- * setter functions defined below.
- */
-#define __Avtp_CanXl_SetField(field, value) \
-        (Avtp_SetField(__AVTP_CANXL_FIELDS, AVTP_CANXL_FIELD_MAX, (uint8_t*)msg, field, value))
-
-/**
- * Initializes an ACF_CANXL message with default values for the header fields
- * including acf_msg_type and acf_msg_length.
+ * Return the value of the ACF message type field as specified in the IEEE 1722 Specification.
  *
- * @param msg Pointer to the ACF_CANXL message to initialize.
+ * @param pdu Pointer to the first bit of a 1722 ACF CANXL PDU.
+ * @returns Value of the ACF message type field.
  */
-OPEN1722_INLINE void Avtp_CanXl_Init(Avtp_CanXl_t* msg) {
-    memset(msg, 0, sizeof(Avtp_CanXl_t));
-    __Avtp_CanXl_SetField(AVTP_CANXL_FIELD_ACF_MSG_TYPE, AVTP_ACF_TYPE_CAN_XL);
-    __Avtp_CanXl_SetField(AVTP_CANXL_FIELD_ACF_MSG_LENGTH, AVTP_CANXL_HEADER_LEN / AVTP_QUADLET_SIZE);
+OPEN1722_INLINE uint8_t Avtp_CanXl_GetAcfMsgType(const Avtp_CanXl_t* const pdu) {
+    return (uint8_t) GET_CANXL_FIELD(AVTP_CANXL_FIELD_ACF_MSG_TYPE);
+}
+
+/**
+ * Return the value of the ACF message length field as specified in the IEEE 1722 Specification.
+ * This returns the length in Quadlets as specified in the IEEE 1722 Specification.
+ *
+ * You can use Avtp_CanXl_GetPayloadLength to get the length in bytes without padding.
+ *
+ * @param pdu Pointer to the first bit of a 1722 ACF CANXL PDU.
+ * @returns Value of the ACF message length field.
+ */
+OPEN1722_INLINE uint16_t Avtp_CanXl_GetAcfMsgLength(const Avtp_CanXl_t* const pdu) {
+    return (uint16_t) GET_CANXL_FIELD(AVTP_CANXL_FIELD_ACF_MSG_LENGTH);
+}
+
+/**
+ * Return the ACF message length in bytes.
+ *
+ * @param pdu Pointer to the first bit of a 1722 ACF CANXL PDU.
+ * @returns Length of the ACF message in bytes.
+ */
+OPEN1722_INLINE uint16_t Avtp_CanXl_GetAcfMsgLengthInBytes(const Avtp_CanXl_t* const pdu) {
+    return (uint16_t) GET_CANXL_FIELD(AVTP_CANXL_FIELD_ACF_MSG_LENGTH) * 4;
+}
+
+/**
+ * Set the value of the ACF message type field as specified in the IEEE 1722 Specification.
+ *
+ * @param pdu Pointer to the first bit of a 1722 ACF CANXL PDU.
+ * @param value Value to set the ACF message type field to.
+ */
+OPEN1722_INLINE void Avtp_CanXl_SetAcfMsgType(Avtp_CanXl_t* pdu, uint8_t value) {
+    SET_CANXL_FIELD(AVTP_CANXL_FIELD_ACF_MSG_TYPE, value);
+}
+
+/**
+ * Set the value of the ACF message length field as specified in the IEEE 1722 Specification.
+ * Note: the size is in Quadlets as specified in the IEEE 1722 Specification.
+ * You can use Avtp_CanXl_SetPayloadLength to set length in bytes and automatically set the
+ * correct padding.
+ *
+ * @param pdu Pointer to the first bit of a 1722 ACF CANXL PDU.
+ * @param value Value to set the ACF message length field to.
+ */
+OPEN1722_INLINE void Avtp_CanXl_SetAcfMsgLength(Avtp_CanXl_t* pdu, uint16_t value) {
+    SET_CANXL_FIELD(AVTP_CANXL_FIELD_ACF_MSG_LENGTH, value);
 }
 
 /**
  * Returns the pad field from an ACF_CANXL message header.
- * 
- * @param msg Pointer to an ACF_CANXL message.
+ *
+ * @param pdu Pointer to an ACF_CANXL message.
  * @returns The value of the pad field.
  */
-OPEN1722_INLINE uint8_t Avtp_CanXl_GetPad(const Avtp_CanXl_t* msg) {
-    return (uint8_t) __Avtp_CanXl_GetField(AVTP_CANXL_FIELD_PAD);
+OPEN1722_INLINE uint8_t Avtp_CanXl_GetPad(const Avtp_CanXl_t* const pdu) {
+    return (uint8_t) GET_CANXL_FIELD(AVTP_CANXL_FIELD_PAD);
 }
 
 /**
- * Returns the message timestamp valid flag (mtv) from an ACF_CANXL message
- * header.
- * 
- * @param msg Pointer to an ACF_CANXL message.
+ * Sets the pad field in an ACF_CANXL message header.
+ *
+ * @param pdu Pointer to an ACF_CANXL message.
+ * @param pad The value to set.
+ */
+OPEN1722_INLINE void Avtp_CanXl_SetPad(Avtp_CanXl_t* pdu, uint8_t pad) {
+    SET_CANXL_FIELD(AVTP_CANXL_FIELD_PAD, pad);
+}
+
+/**
+ * Returns the message timestamp valid flag (mtv) from an ACF_CANXL message header.
+ *
+ * @param pdu Pointer to an ACF_CANXL message.
  * @returns The value of the mtv flag.
  */
-OPEN1722_INLINE bool Avtp_CanXl_IsMtv(const Avtp_CanXl_t* msg) {
-    return (bool) __Avtp_CanXl_GetField(AVTP_CANXL_FIELD_MTV);
+OPEN1722_INLINE bool Avtp_CanXl_IsMtv(const Avtp_CanXl_t* const pdu) {
+    return (bool) GET_CANXL_FIELD(AVTP_CANXL_FIELD_MTV);
 }
 
 /**
  * Returns the value of the can_bus_id field from an ACF_CANXL message header.
- * 
- * @param msg Pointer to an ACF_CANXL message.
+ *
+ * @param pdu Pointer to an ACF_CANXL message.
  * @returns The value of the can_bus_id field.
  */
-OPEN1722_INLINE uint16_t Avtp_CanXl_GetCanBusId(const Avtp_CanXl_t* msg) {
-    return (uint16_t) __Avtp_CanXl_GetField(AVTP_CANXL_FIELD_CAN_BUS_ID);
+OPEN1722_INLINE uint16_t Avtp_CanXl_GetCanBusId(const Avtp_CanXl_t* const pdu) {
+    return (uint16_t) GET_CANXL_FIELD(AVTP_CANXL_FIELD_CAN_BUS_ID);
 }
 
 /**
- * Returns the value of the message_timestamp field from an ACF_CANXL message
- * header.
- * 
- * @param msg Pointer to an ACF_CANXL message.
+ * Returns the value of the message_timestamp field from an ACF_CANXL message header.
+ *
+ * @param pdu Pointer to an ACF_CANXL message.
  * @returns The value of the message_timestamp field.
  */
-OPEN1722_INLINE uint64_t Avtp_CanXl_GetMessageTimestamp(const Avtp_CanXl_t* msg) {
-    return (uint64_t) __Avtp_CanXl_GetField(AVTP_CANXL_FIELD_MESSAGE_TIMESTAMP);
+OPEN1722_INLINE uint64_t Avtp_CanXl_GetMessageTimestamp(const Avtp_CanXl_t* const pdu) {
+    return (uint64_t) GET_CANXL_FIELD(AVTP_CANXL_FIELD_MESSAGE_TIMESTAMP);
 }
 
 /**
  * Returns the value of the vcid field from an ACF_CANXL message header.
- * 
- * @param msg Pointer to an ACF_CANXL message.
+ *
+ * @param pdu Pointer to an ACF_CANXL message.
  * @returns The value of the vcid field.
  */
-OPEN1722_INLINE uint8_t Avtp_CanXl_GetVcid(const Avtp_CanXl_t* msg) {
-    return (uint8_t) __Avtp_CanXl_GetField(AVTP_CANXL_FIELD_VCID);
+OPEN1722_INLINE uint8_t Avtp_CanXl_GetVcid(const Avtp_CanXl_t* const pdu) {
+    return (uint8_t) GET_CANXL_FIELD(AVTP_CANXL_FIELD_VCID);
 }
 
 /**
  * Returns the value of the sdt field from an ACF_CANXL message header.
- * 
- * @param msg Pointer to an ACF_CANXL message.
+ *
+ * @param pdu Pointer to an ACF_CANXL message.
  * @returns The value of the sdt field.
  */
-OPEN1722_INLINE uint8_t Avtp_CanXl_GetSdt(const Avtp_CanXl_t* msg) {
-    return (uint8_t) __Avtp_CanXl_GetField(AVTP_CANXL_FIELD_SDT);
+OPEN1722_INLINE uint8_t Avtp_CanXl_GetSdt(const Avtp_CanXl_t* const pdu) {
+    return (uint8_t) GET_CANXL_FIELD(AVTP_CANXL_FIELD_SDT);
 }
 
 /**
  * Returns the value of the rrs flag from an ACF_CANXL message header.
- * 
- * @param msg Pointer to an ACF_CANXL message.
+ *
+ * @param pdu Pointer to an ACF_CANXL message.
  * @returns The value of the rrs flag.
  */
-OPEN1722_INLINE bool Avtp_CanXl_IsRrs(const Avtp_CanXl_t* msg) {
-    return (bool) __Avtp_CanXl_GetField(AVTP_CANXL_FIELD_RRS);
+OPEN1722_INLINE bool Avtp_CanXl_IsRrs(const Avtp_CanXl_t* const pdu) {
+    return (bool) GET_CANXL_FIELD(AVTP_CANXL_FIELD_RRS);
 }
 
 /**
  * Returns the value of the sec flag from an ACF_CANXL message header.
- * 
- * @param msg Pointer to an ACF_CANXL message.
+ *
+ * @param pdu Pointer to an ACF_CANXL message.
  * @returns The value of the sec flag.
  */
-OPEN1722_INLINE bool Avtp_CanXl_IsSec(const Avtp_CanXl_t* msg) {
-    return (bool) __Avtp_CanXl_GetField(AVTP_CANXL_FIELD_SEC);
+OPEN1722_INLINE bool Avtp_CanXl_IsSec(const Avtp_CanXl_t* const pdu) {
+    return (bool) GET_CANXL_FIELD(AVTP_CANXL_FIELD_SEC);
 }
 
 /**
  * Returns the value of the priority_id field from an ACF_CANXL message header.
- * 
- * @param msg Pointer to an ACF_CANXL message.
+ *
+ * @param pdu Pointer to an ACF_CANXL message.
  * @returns The value of the priority_id field.
  */
-OPEN1722_INLINE uint16_t Avtp_CanXl_GetPriorityId(const Avtp_CanXl_t* msg) {
-    return (uint16_t) __Avtp_CanXl_GetField(AVTP_CANXL_FIELD_PRIORITY_ID);
+OPEN1722_INLINE uint16_t Avtp_CanXl_GetPriorityId(const Avtp_CanXl_t* const pdu) {
+    return (uint16_t) GET_CANXL_FIELD(AVTP_CANXL_FIELD_PRIORITY_ID);
 }
 
 /**
  * Returns the value of the acceptance_field from an ACF_CANXL message header.
- * 
- * @param msg Pointer to an ACF_CANXL message.
+ *
+ * @param pdu Pointer to an ACF_CANXL message.
  * @returns The value of the acceptance_field.
  */
-OPEN1722_INLINE uint32_t Avtp_CanXl_GetAcceptanceField(const Avtp_CanXl_t* msg) {
-    return (uint32_t) __Avtp_CanXl_GetField(AVTP_CANXL_FIELD_ACCEPTANCE_FIELD);
+OPEN1722_INLINE uint32_t Avtp_CanXl_GetAcceptanceField(const Avtp_CanXl_t* const pdu) {
+    return (uint32_t) GET_CANXL_FIELD(AVTP_CANXL_FIELD_ACCEPTANCE_FIELD);
 }
 
 /**
- * Returns the value of the transaction_num field from an ACF_CANXL message
- * header.
- * 
- * @param msg Pointer to an ACF_CANXL message.
+ * Returns the value of the transaction_num field from an ACF_CANXL message header.
+ *
+ * @param pdu Pointer to an ACF_CANXL message.
  * @returns The value of the transaction_num field.
  */
-OPEN1722_INLINE uint8_t Avtp_CanXl_GetTransactionNum(const Avtp_CanXl_t* msg) {
-    return (uint8_t) __Avtp_CanXl_GetField(AVTP_CANXL_FIELD_TRANSACTION_NUM);
+OPEN1722_INLINE uint8_t Avtp_CanXl_GetTransactionNum(const Avtp_CanXl_t* const pdu) {
+    return (uint8_t) GET_CANXL_FIELD(AVTP_CANXL_FIELD_TRANSACTION_NUM);
 }
 
 /**
  * Returns the value of the ms flag from an ACF_CANXL message header.
- * 
- * @param msg Pointer to an ACF_CANXL message.
+ *
+ * @param pdu Pointer to an ACF_CANXL message.
  * @returns The value of the ms flag.
  */
-OPEN1722_INLINE bool Avtp_CanXl_IsMs(const Avtp_CanXl_t* msg) {
-    return (bool) __Avtp_CanXl_GetField(AVTP_CANXL_FIELD_MS);
+OPEN1722_INLINE bool Avtp_CanXl_IsMs(const Avtp_CanXl_t* const pdu) {
+    return (bool) GET_CANXL_FIELD(AVTP_CANXL_FIELD_MS);
 }
 
 /**
  * Returns the value of the segment_num field from an ACF_CANXL message header.
- * 
- * @param msg Pointer to an ACF_CANXL message.
+ *
+ * @param pdu Pointer to an ACF_CANXL message.
  * @returns The value of the segment_num field.
  */
-OPEN1722_INLINE uint16_t Avtp_CanXl_GetSegmentNum(const Avtp_CanXl_t* msg) {
-    return (uint16_t) __Avtp_CanXl_GetField(AVTP_CANXL_FIELD_SEGMENT_NUM);
-}
-
-/**
- * Returns the payload length from an ACF_CANXL message (in bytes). This is
- * calculated based on the value of the acf_msg_length field in the header
- * as well as the value of the pad field.
- * 
- * @param msg Pointer to an ACF_CANXL message.
- * @returns The payload length in bytes.
- */
-OPEN1722_INLINE uint16_t Avtp_CanXl_GetPayloadLen(const Avtp_CanXl_t* msg) {
-    return (uint16_t) (__Avtp_CanXl_GetField(AVTP_CANXL_FIELD_ACF_MSG_LENGTH) * AVTP_QUADLET_SIZE
-           - AVTP_CANXL_HEADER_LEN
-           - __Avtp_CanXl_GetField(AVTP_CANXL_FIELD_PAD));
-}
-
-/**
- * Returns the total message length from an ACF_CANXL message (in bytes)
- * including header and payload section.
- * 
- * @param msg Pointer to an ACF_CANXL message.
- * @returns The total message length in bytes.
- */
-OPEN1722_INLINE uint16_t Avtp_CanXl_GetLen(const Avtp_CanXl_t* msg) {
-    return (uint16_t) (__Avtp_CanXl_GetField(AVTP_CANXL_FIELD_ACF_MSG_LENGTH) * AVTP_QUADLET_SIZE);
+OPEN1722_INLINE uint16_t Avtp_CanXl_GetSegmentNum(const Avtp_CanXl_t* const pdu) {
+    return (uint16_t) GET_CANXL_FIELD(AVTP_CANXL_FIELD_SEGMENT_NUM);
 }
 
 /**
  * Sets the value of the mtv flag in an ACF_CANXL message header.
- * 
- * @param msg Pointer to an ACF_CANXL message.
+ *
+ * @param pdu Pointer to an ACF_CANXL message.
  * @param mtv The value to set.
  */
-OPEN1722_INLINE void Avtp_CanXl_SetMtv(Avtp_CanXl_t* msg, bool mtv) {
-    __Avtp_CanXl_SetField(AVTP_CANXL_FIELD_MTV, mtv);
+OPEN1722_INLINE void Avtp_CanXl_SetMtv(Avtp_CanXl_t* pdu, bool mtv) {
+    SET_CANXL_FIELD(AVTP_CANXL_FIELD_MTV, mtv);
 }
 
 /**
  * Sets the value of the can_bus_id field in an ACF_CANXL message header.
- * 
- * @param msg Pointer to an ACF_CANXL message.
+ *
+ * @param pdu Pointer to an ACF_CANXL message.
  * @param canBusId The value to set.
  */
-OPEN1722_INLINE void Avtp_CanXl_SetCanBusId(Avtp_CanXl_t* msg, uint16_t canBusId) {
-    __Avtp_CanXl_SetField(AVTP_CANXL_FIELD_CAN_BUS_ID, canBusId);
+OPEN1722_INLINE void Avtp_CanXl_SetCanBusId(Avtp_CanXl_t* pdu, uint16_t canBusId) {
+    SET_CANXL_FIELD(AVTP_CANXL_FIELD_CAN_BUS_ID, canBusId);
 }
 
 /**
  * Sets the value of the message_timestamp field in an ACF_CANXL message header.
- * 
- * @param msg Pointer to an ACF_CANXL message.
+ *
+ * @param pdu Pointer to an ACF_CANXL message.
  * @param messageTimestamp The value to set.
  */
-OPEN1722_INLINE void Avtp_CanXl_SetMessageTimestamp(Avtp_CanXl_t* msg, uint64_t messageTimestamp) {
-    __Avtp_CanXl_SetField(AVTP_CANXL_FIELD_MESSAGE_TIMESTAMP, messageTimestamp);
+OPEN1722_INLINE void Avtp_CanXl_SetMessageTimestamp(Avtp_CanXl_t* pdu, uint64_t messageTimestamp) {
+    SET_CANXL_FIELD(AVTP_CANXL_FIELD_MESSAGE_TIMESTAMP, messageTimestamp);
 }
 
 /**
  * Sets the value of the vcid field in an ACF_CANXL message header.
- * 
- * @param msg Pointer to an ACF_CANXL message.
+ *
+ * @param pdu Pointer to an ACF_CANXL message.
  * @param vcid The value to set.
  */
-OPEN1722_INLINE void Avtp_CanXl_SetVcid(Avtp_CanXl_t* msg, uint8_t vcid) {
-    __Avtp_CanXl_SetField(AVTP_CANXL_FIELD_VCID, vcid);
+OPEN1722_INLINE void Avtp_CanXl_SetVcid(Avtp_CanXl_t* pdu, uint8_t vcid) {
+    SET_CANXL_FIELD(AVTP_CANXL_FIELD_VCID, vcid);
 }
 
 /**
  * Sets the value of the sdt field in an ACF_CANXL message header.
- * 
- * @param msg Pointer to an ACF_CANXL message.
+ *
+ * @param pdu Pointer to an ACF_CANXL message.
  * @param sdt The value to set.
  */
-OPEN1722_INLINE void Avtp_CanXl_SetSdt(Avtp_CanXl_t* msg, uint8_t sdt) {
-    __Avtp_CanXl_SetField(AVTP_CANXL_FIELD_SDT, sdt);
+OPEN1722_INLINE void Avtp_CanXl_SetSdt(Avtp_CanXl_t* pdu, uint8_t sdt) {
+    SET_CANXL_FIELD(AVTP_CANXL_FIELD_SDT, sdt);
 }
 
 /**
  * Sets the value of the rrs flag in an ACF_CANXL message header.
- * 
- * @param msg Pointer to an ACF_CANXL message.
+ *
+ * @param pdu Pointer to an ACF_CANXL message.
  * @param rrs The value to set.
  */
-OPEN1722_INLINE void Avtp_CanXl_SetRrs(Avtp_CanXl_t* msg, bool rrs) {
-    __Avtp_CanXl_SetField(AVTP_CANXL_FIELD_RRS, rrs);
+OPEN1722_INLINE void Avtp_CanXl_SetRrs(Avtp_CanXl_t* pdu, bool rrs) {
+    SET_CANXL_FIELD(AVTP_CANXL_FIELD_RRS, rrs);
 }
 
 /**
  * Sets the value of the sec flag in an ACF_CANXL message header.
- * 
- * @param msg Pointer to an ACF_CANXL message.
+ *
+ * @param pdu Pointer to an ACF_CANXL message.
  * @param sec The value to set.
  */
-OPEN1722_INLINE void Avtp_CanXl_SetSec(Avtp_CanXl_t* msg, bool sec) {
-    __Avtp_CanXl_SetField(AVTP_CANXL_FIELD_SEC, sec);
+OPEN1722_INLINE void Avtp_CanXl_SetSec(Avtp_CanXl_t* pdu, bool sec) {
+    SET_CANXL_FIELD(AVTP_CANXL_FIELD_SEC, sec);
 }
 
 /**
  * Sets the value of the priority_id field in an ACF_CANXL message header.
- * 
- * @param msg Pointer to an ACF_CANXL message.
+ *
+ * @param pdu Pointer to an ACF_CANXL message.
  * @param priorityId The value to set.
  */
-OPEN1722_INLINE void Avtp_CanXl_SetPriorityId(Avtp_CanXl_t* msg, uint16_t priorityId) {
-    __Avtp_CanXl_SetField(AVTP_CANXL_FIELD_PRIORITY_ID, priorityId);
+OPEN1722_INLINE void Avtp_CanXl_SetPriorityId(Avtp_CanXl_t* pdu, uint16_t priorityId) {
+    SET_CANXL_FIELD(AVTP_CANXL_FIELD_PRIORITY_ID, priorityId);
 }
 
 /**
  * Sets the value of the acceptance_field in an ACF_CANXL message header.
- * 
- * @param msg Pointer to an ACF_CANXL message.
+ *
+ * @param pdu Pointer to an ACF_CANXL message.
  * @param acceptanceField The value to set.
  */
-OPEN1722_INLINE void Avtp_CanXl_SetAcceptanceField(Avtp_CanXl_t* msg, uint32_t acceptanceField) {
-    __Avtp_CanXl_SetField(AVTP_CANXL_FIELD_ACCEPTANCE_FIELD, acceptanceField);
+OPEN1722_INLINE void Avtp_CanXl_SetAcceptanceField(Avtp_CanXl_t* pdu, uint32_t acceptanceField) {
+    SET_CANXL_FIELD(AVTP_CANXL_FIELD_ACCEPTANCE_FIELD, acceptanceField);
 }
 
 /**
  * Sets the value of the transaction_num field in an ACF_CANXL message header.
- * 
- * @param msg Pointer to an ACF_CANXL message.
+ *
+ * @param pdu Pointer to an ACF_CANXL message.
  * @param transactionNum The value to set.
  */
-OPEN1722_INLINE void Avtp_CanXl_SetTransactionNum(Avtp_CanXl_t* msg, uint8_t transactionNum) {
-    __Avtp_CanXl_SetField(AVTP_CANXL_FIELD_TRANSACTION_NUM, transactionNum);
+OPEN1722_INLINE void Avtp_CanXl_SetTransactionNum(Avtp_CanXl_t* pdu, uint8_t transactionNum) {
+    SET_CANXL_FIELD(AVTP_CANXL_FIELD_TRANSACTION_NUM, transactionNum);
 }
 
 /**
  * Sets the value of the ms flag in an ACF_CANXL message header.
- * 
- * @param msg Pointer to an ACF_CANXL message.
+ *
+ * @param pdu Pointer to an ACF_CANXL message.
  * @param ms The value to set.
  */
-OPEN1722_INLINE void Avtp_CanXl_SetMs(Avtp_CanXl_t* msg, bool ms) {
-    __Avtp_CanXl_SetField(AVTP_CANXL_FIELD_MS, ms);
+OPEN1722_INLINE void Avtp_CanXl_SetMs(Avtp_CanXl_t* pdu, bool ms) {
+    SET_CANXL_FIELD(AVTP_CANXL_FIELD_MS, ms);
 }
 
 /**
  * Sets the value of the segment_num field in an ACF_CANXL message header.
- * 
- * @param msg Pointer to an ACF_CANXL message.
+ *
+ * @param pdu Pointer to an ACF_CANXL message.
  * @param segmentNum The value to set.
  */
-OPEN1722_INLINE void Avtp_CanXl_SetSegmentNum(Avtp_CanXl_t* msg, uint16_t segmentNum) {
-    __Avtp_CanXl_SetField(AVTP_CANXL_FIELD_SEGMENT_NUM, segmentNum);
+OPEN1722_INLINE void Avtp_CanXl_SetSegmentNum(Avtp_CanXl_t* pdu, uint16_t segmentNum) {
+    SET_CANXL_FIELD(AVTP_CANXL_FIELD_SEGMENT_NUM, segmentNum);
 }
 
 /**
- * Sets the value of the acf_msg_length field in an ACF_CANXL message header
- * based on the given payload length. This function also calculates the
- * required padding and sets the value of the pad field accordingly.
- * 
- * @param msg Pointer to an ACF_CANXL message.
- * @param payloadLen The length of the payload in bytes.
+ * Returns pointer to payload of an ACF CAN XL frame.
+ *
+ * @param pdu Pointer to the first bit of a 1722 ACF CANXL PDU.
+ * @return Pointer to ACF CAN XL frame payload
  */
-OPEN1722_INLINE void Avtp_CanXl_SetPayloadLen(Avtp_CanXl_t* msg, uint16_t payloadLen) {
-    uint16_t msgLenBytes = AVTP_CANXL_HEADER_LEN + payloadLen;
-    uint8_t pad = (uint8_t) (4 - (msgLenBytes % 4)) % 4;
-    uint16_t msgLenQuadlets = (uint16_t) ((msgLenBytes + pad) / 4);
-    __Avtp_CanXl_SetField(AVTP_CANXL_FIELD_ACF_MSG_LENGTH, msgLenQuadlets);
-    __Avtp_CanXl_SetField(AVTP_CANXL_FIELD_PAD, pad);
+OPEN1722_INLINE const uint8_t *Avtp_CanXl_GetPayload(const Avtp_CanXl_t* const pdu)
+{
+    return pdu->payload;
+}
+
+/**
+ * Sets the CAN payload in an ACF CAN XL frame.
+ *
+ * @param pdu Pointer to the first bit of a 1722 ACF CANXL PDU.
+ * @param payload Pointer to the payload byte array
+ * @param payload_length Length of the payload
+ */
+OPEN1722_INLINE void Avtp_CanXl_SetPayload(Avtp_CanXl_t *pdu, uint8_t *payload,
+                                           uint16_t payload_length)
+{
+    memcpy(pdu->payload, payload, payload_length);
+}
+
+/**
+ * Finalizes the ACF CAN XL frame. This function will set the
+ * length and pad fields while inserting the padded bytes. This will also
+ * set padding bytes to zero if the payload length is not a multiple of 4.
+ * to avoid leaking information
+ *
+ * @param pdu Pointer to the first bit of a 1722 ACF CANXL PDU.
+ * @param payload_length Length of the CAN frame payload.
+ */
+OPEN1722_INLINE void Avtp_CanXl_SetPayloadLength(Avtp_CanXl_t *pdu, uint16_t payload_length)
+{
+    uint16_t msgLenBytes = AVTP_CANXL_HEADER_LEN + payload_length;
+    uint8_t pad = (uint8_t)(4 - (msgLenBytes % 4)) % 4;
+    if (pad > 0) {
+        memset(pdu->payload + payload_length, 0, pad);
+    }
+    uint16_t msgLenQuadlets = (uint16_t)((msgLenBytes + pad) / 4);
+    Avtp_CanXl_SetPad(pdu, pad);
+    Avtp_CanXl_SetAcfMsgLength(pdu, msgLenQuadlets);
+}
+
+/**
+ * Returns the length of the CAN payload without the padding bytes and the
+ * header length of the encapsulating ACF Frame.
+ *
+ * Precondition: the caller must have validated the PDU with
+ * Avtp_CanXl_IsValid(). This function performs no further bounds checking
+ * and assumes those invariants already hold.
+ *
+ * @param pdu Pointer to the first bit of a 1722 ACF CANXL PDU.
+ * @return  Length of CAN payload in bytes
+ */
+OPEN1722_INLINE uint8_t Avtp_CanXl_GetPayloadLength(const Avtp_CanXl_t* const pdu)
+{
+    uint8_t pad_length = Avtp_CanXl_GetPad(pdu);
+    uint16_t acf_length_bytes = Avtp_CanXl_GetAcfMsgLengthInBytes(pdu);
+    return (uint8_t)(acf_length_bytes - AVTP_CANXL_HEADER_LEN - pad_length);
+}
+
+/**
+ * Initializes an ACF_CANXL message header as specified in the IEEE 1722 Specification.
+ *
+ * @param pdu Pointer to the first bit of a 1722 ACF CANXL PDU.
+ */
+OPEN1722_INLINE void Avtp_CanXl_Init(Avtp_CanXl_t* pdu)
+{
+    if (pdu != NULL) {
+        memset(pdu, 0, sizeof(Avtp_CanXl_t));
+        Avtp_CanXl_SetAcfMsgType(pdu, AVTP_ACF_TYPE_CAN_XL);
+    }
+}
+
+/**
+ * Copies the payload data, priority ID, acceptance field and SDT into the ACF CAN XL frame. This
+ * function will also set the length and pad fields while inserting the padded bytes.
+ *
+ * @param pdu Pointer to the first bit of a 1722 ACF CANXL PDU.
+ * @param priority_id Priority ID
+ * @param acceptance_field Acceptance field
+ * @param sdt SDT value
+ * @param payload Pointer to the payload byte array
+ * @param payload_length Length of the payload.
+ */
+OPEN1722_INLINE void Avtp_CanXl_CreateAcfMessage(Avtp_CanXl_t *pdu, uint16_t priority_id,
+                                                 uint32_t acceptance_field, uint8_t sdt,
+                                                 uint8_t *payload, uint16_t payload_length)
+{
+    // Initialize the ACF CAN XL header
+    Avtp_CanXl_Init(pdu);
+
+    // Set the priority ID, acceptance field and SDT
+    Avtp_CanXl_SetPriorityId(pdu, priority_id);
+    Avtp_CanXl_SetAcceptanceField(pdu, acceptance_field);
+    Avtp_CanXl_SetSdt(pdu, sdt);
+
+    // Copy the payload into the CAN PDU
+    Avtp_CanXl_SetPayload(pdu, payload, payload_length);
+
+    // Finalize the AVTP CAN XL Frame
+    Avtp_CanXl_SetPayloadLength(pdu, payload_length);
+}
+
+/**
+ * Checks if the ACF CAN XL frame is valid by checking:
+ *     1) if the length field of AVTP/ACF messages contains a value larger than the actual size of
+ * the buffer that contains the AVTP message. 2) if other format specific invariants are not upheld
+ * @param pdu Pointer to the first bit of a 1722 ACF CANXL PDU.
+ * @param bufferSize Size of the buffer containing the ACF CAN XL frame.
+ * @return true if the ACF CAN XL frame is valid, false otherwise.
+ */
+OPEN1722_INLINE bool Avtp_CanXl_IsValid(const Avtp_CanXl_t* const pdu, size_t bufferSize)
+{
+    if (pdu == NULL) {
+        return false;
+    }
+
+    if (bufferSize < AVTP_CANXL_HEADER_LEN) {
+        return false;
+    }
+
+    if (Avtp_CanXl_GetAcfMsgType(pdu) != AVTP_ACF_TYPE_CAN_XL) {
+        return false;
+    }
+
+    // Avtp_CanXl_GetAcfMsgLength returns quadlets. Convert the length field to octets.
+    uint16_t msg_length_bytes = (uint16_t)Avtp_CanXl_GetAcfMsgLength(pdu) * 4;
+    if (msg_length_bytes > bufferSize) {
+        return false;
+    }
+
+    /* The encoded message length must accommodate header + declared padding
+     * so the payload computation in Avtp_CanXl_GetPayloadLength() doesn't
+     * underflow. */
+    uint8_t pad_length = Avtp_CanXl_GetPad(pdu);
+    uint16_t header_and_pad = (uint16_t)AVTP_CANXL_HEADER_LEN + pad_length;
+    if (msg_length_bytes < header_and_pad) {
+        return false;
+    }
+    return true;
 }
 
 #ifdef __cplusplus

--- a/include/avtp/acf/CanXl.h
+++ b/include/avtp/acf/CanXl.h
@@ -95,25 +95,24 @@ typedef enum {
 /**
  * This table describes all the offsets of the ACF_CANXL header fields.
  */
-static const Avtp_FieldDescriptor_t Avtp_CanXlFieldDesc[AVTP_CANXL_FIELD_MAX] =
-{
+static const Avtp_FieldDescriptor_t Avtp_CanXlFieldDesc[AVTP_CANXL_FIELD_MAX] = {
     /* ACF common header fields */
-    [AVTP_CANXL_FIELD_ACF_MSG_TYPE]           = { .quadlet = 0, .offset =  0, .bits = 7 },
-    [AVTP_CANXL_FIELD_ACF_MSG_LENGTH]         = { .quadlet = 0, .offset =  7, .bits = 9 },
+    [AVTP_CANXL_FIELD_ACF_MSG_TYPE] = {.quadlet = 0, .offset = 0, .bits = 7},
+    [AVTP_CANXL_FIELD_ACF_MSG_LENGTH] = {.quadlet = 0, .offset = 7, .bits = 9},
     /* ACF CANXL header fields */
-    [AVTP_CANXL_FIELD_PAD]                    = { .quadlet = 0, .offset = 16, .bits =   2 },
-    [AVTP_CANXL_FIELD_MTV]                    = { .quadlet = 0, .offset = 18, .bits =   1 },
-    [AVTP_CANXL_FIELD_CAN_BUS_ID]             = { .quadlet = 0, .offset = 21, .bits =  11 },
-    [AVTP_CANXL_FIELD_MESSAGE_TIMESTAMP]      = { .quadlet = 1, .offset =  0, .bits =  64 },
-    [AVTP_CANXL_FIELD_VCID]                   = { .quadlet = 3, .offset =  0, .bits =   8 },
-    [AVTP_CANXL_FIELD_SDT]                    = { .quadlet = 3, .offset =  8, .bits =   8 },
-    [AVTP_CANXL_FIELD_RRS]                    = { .quadlet = 3, .offset = 19, .bits =   1 },
-    [AVTP_CANXL_FIELD_SEC]                    = { .quadlet = 3, .offset = 20, .bits =   1 },
-    [AVTP_CANXL_FIELD_PRIORITY_ID]            = { .quadlet = 3, .offset = 21, .bits =  11 },
-    [AVTP_CANXL_FIELD_ACCEPTANCE_FIELD]       = { .quadlet = 4, .offset =  0, .bits =  32 },
-    [AVTP_CANXL_FIELD_TRANSACTION_NUM]        = { .quadlet = 5, .offset =  8, .bits =   8 },
-    [AVTP_CANXL_FIELD_MS]                     = { .quadlet = 5, .offset = 19, .bits =   1 },
-    [AVTP_CANXL_FIELD_SEGMENT_NUM]            = { .quadlet = 5, .offset = 20, .bits =  12 },
+    [AVTP_CANXL_FIELD_PAD] = {.quadlet = 0, .offset = 16, .bits = 2},
+    [AVTP_CANXL_FIELD_MTV] = {.quadlet = 0, .offset = 18, .bits = 1},
+    [AVTP_CANXL_FIELD_CAN_BUS_ID] = {.quadlet = 0, .offset = 21, .bits = 11},
+    [AVTP_CANXL_FIELD_MESSAGE_TIMESTAMP] = {.quadlet = 1, .offset = 0, .bits = 64},
+    [AVTP_CANXL_FIELD_VCID] = {.quadlet = 3, .offset = 0, .bits = 8},
+    [AVTP_CANXL_FIELD_SDT] = {.quadlet = 3, .offset = 8, .bits = 8},
+    [AVTP_CANXL_FIELD_RRS] = {.quadlet = 3, .offset = 19, .bits = 1},
+    [AVTP_CANXL_FIELD_SEC] = {.quadlet = 3, .offset = 20, .bits = 1},
+    [AVTP_CANXL_FIELD_PRIORITY_ID] = {.quadlet = 3, .offset = 21, .bits = 11},
+    [AVTP_CANXL_FIELD_ACCEPTANCE_FIELD] = {.quadlet = 4, .offset = 0, .bits = 32},
+    [AVTP_CANXL_FIELD_TRANSACTION_NUM] = {.quadlet = 5, .offset = 8, .bits = 8},
+    [AVTP_CANXL_FIELD_MS] = {.quadlet = 5, .offset = 19, .bits = 1},
+    [AVTP_CANXL_FIELD_SEGMENT_NUM] = {.quadlet = 5, .offset = 20, .bits = 12},
 };
 
 /**
@@ -122,8 +121,9 @@ static const Avtp_FieldDescriptor_t Avtp_CanXlFieldDesc[AVTP_CANXL_FIELD_MAX] =
  * @param pdu Pointer to the first bit of a 1722 ACF CANXL PDU.
  * @returns Value of the ACF message type field.
  */
-OPEN1722_INLINE uint8_t Avtp_CanXl_GetAcfMsgType(const Avtp_CanXl_t* const pdu) {
-    return (uint8_t) GET_CANXL_FIELD(AVTP_CANXL_FIELD_ACF_MSG_TYPE);
+OPEN1722_INLINE uint8_t Avtp_CanXl_GetAcfMsgType(const Avtp_CanXl_t *const pdu)
+{
+    return (uint8_t)GET_CANXL_FIELD(AVTP_CANXL_FIELD_ACF_MSG_TYPE);
 }
 
 /**
@@ -135,8 +135,9 @@ OPEN1722_INLINE uint8_t Avtp_CanXl_GetAcfMsgType(const Avtp_CanXl_t* const pdu) 
  * @param pdu Pointer to the first bit of a 1722 ACF CANXL PDU.
  * @returns Value of the ACF message length field.
  */
-OPEN1722_INLINE uint16_t Avtp_CanXl_GetAcfMsgLength(const Avtp_CanXl_t* const pdu) {
-    return (uint16_t) GET_CANXL_FIELD(AVTP_CANXL_FIELD_ACF_MSG_LENGTH);
+OPEN1722_INLINE uint16_t Avtp_CanXl_GetAcfMsgLength(const Avtp_CanXl_t *const pdu)
+{
+    return (uint16_t)GET_CANXL_FIELD(AVTP_CANXL_FIELD_ACF_MSG_LENGTH);
 }
 
 /**
@@ -145,8 +146,9 @@ OPEN1722_INLINE uint16_t Avtp_CanXl_GetAcfMsgLength(const Avtp_CanXl_t* const pd
  * @param pdu Pointer to the first bit of a 1722 ACF CANXL PDU.
  * @returns Length of the ACF message in bytes.
  */
-OPEN1722_INLINE uint16_t Avtp_CanXl_GetAcfMsgLengthInBytes(const Avtp_CanXl_t* const pdu) {
-    return (uint16_t) GET_CANXL_FIELD(AVTP_CANXL_FIELD_ACF_MSG_LENGTH) * 4;
+OPEN1722_INLINE uint16_t Avtp_CanXl_GetAcfMsgLengthInBytes(const Avtp_CanXl_t *const pdu)
+{
+    return (uint16_t)GET_CANXL_FIELD(AVTP_CANXL_FIELD_ACF_MSG_LENGTH) * 4;
 }
 
 /**
@@ -155,7 +157,8 @@ OPEN1722_INLINE uint16_t Avtp_CanXl_GetAcfMsgLengthInBytes(const Avtp_CanXl_t* c
  * @param pdu Pointer to the first bit of a 1722 ACF CANXL PDU.
  * @param value Value to set the ACF message type field to.
  */
-OPEN1722_INLINE void Avtp_CanXl_SetAcfMsgType(Avtp_CanXl_t* pdu, uint8_t value) {
+OPEN1722_INLINE void Avtp_CanXl_SetAcfMsgType(Avtp_CanXl_t *pdu, uint8_t value)
+{
     SET_CANXL_FIELD(AVTP_CANXL_FIELD_ACF_MSG_TYPE, value);
 }
 
@@ -168,7 +171,8 @@ OPEN1722_INLINE void Avtp_CanXl_SetAcfMsgType(Avtp_CanXl_t* pdu, uint8_t value) 
  * @param pdu Pointer to the first bit of a 1722 ACF CANXL PDU.
  * @param value Value to set the ACF message length field to.
  */
-OPEN1722_INLINE void Avtp_CanXl_SetAcfMsgLength(Avtp_CanXl_t* pdu, uint16_t value) {
+OPEN1722_INLINE void Avtp_CanXl_SetAcfMsgLength(Avtp_CanXl_t *pdu, uint16_t value)
+{
     SET_CANXL_FIELD(AVTP_CANXL_FIELD_ACF_MSG_LENGTH, value);
 }
 
@@ -178,8 +182,9 @@ OPEN1722_INLINE void Avtp_CanXl_SetAcfMsgLength(Avtp_CanXl_t* pdu, uint16_t valu
  * @param pdu Pointer to an ACF_CANXL message.
  * @returns The value of the pad field.
  */
-OPEN1722_INLINE uint8_t Avtp_CanXl_GetPad(const Avtp_CanXl_t* const pdu) {
-    return (uint8_t) GET_CANXL_FIELD(AVTP_CANXL_FIELD_PAD);
+OPEN1722_INLINE uint8_t Avtp_CanXl_GetPad(const Avtp_CanXl_t *const pdu)
+{
+    return (uint8_t)GET_CANXL_FIELD(AVTP_CANXL_FIELD_PAD);
 }
 
 /**
@@ -188,7 +193,8 @@ OPEN1722_INLINE uint8_t Avtp_CanXl_GetPad(const Avtp_CanXl_t* const pdu) {
  * @param pdu Pointer to an ACF_CANXL message.
  * @param pad The value to set.
  */
-OPEN1722_INLINE void Avtp_CanXl_SetPad(Avtp_CanXl_t* pdu, uint8_t pad) {
+OPEN1722_INLINE void Avtp_CanXl_SetPad(Avtp_CanXl_t *pdu, uint8_t pad)
+{
     SET_CANXL_FIELD(AVTP_CANXL_FIELD_PAD, pad);
 }
 
@@ -198,8 +204,9 @@ OPEN1722_INLINE void Avtp_CanXl_SetPad(Avtp_CanXl_t* pdu, uint8_t pad) {
  * @param pdu Pointer to an ACF_CANXL message.
  * @returns The value of the mtv flag.
  */
-OPEN1722_INLINE bool Avtp_CanXl_IsMtv(const Avtp_CanXl_t* const pdu) {
-    return (bool) GET_CANXL_FIELD(AVTP_CANXL_FIELD_MTV);
+OPEN1722_INLINE bool Avtp_CanXl_IsMtv(const Avtp_CanXl_t *const pdu)
+{
+    return (bool)GET_CANXL_FIELD(AVTP_CANXL_FIELD_MTV);
 }
 
 /**
@@ -208,8 +215,9 @@ OPEN1722_INLINE bool Avtp_CanXl_IsMtv(const Avtp_CanXl_t* const pdu) {
  * @param pdu Pointer to an ACF_CANXL message.
  * @returns The value of the can_bus_id field.
  */
-OPEN1722_INLINE uint16_t Avtp_CanXl_GetCanBusId(const Avtp_CanXl_t* const pdu) {
-    return (uint16_t) GET_CANXL_FIELD(AVTP_CANXL_FIELD_CAN_BUS_ID);
+OPEN1722_INLINE uint16_t Avtp_CanXl_GetCanBusId(const Avtp_CanXl_t *const pdu)
+{
+    return (uint16_t)GET_CANXL_FIELD(AVTP_CANXL_FIELD_CAN_BUS_ID);
 }
 
 /**
@@ -218,8 +226,9 @@ OPEN1722_INLINE uint16_t Avtp_CanXl_GetCanBusId(const Avtp_CanXl_t* const pdu) {
  * @param pdu Pointer to an ACF_CANXL message.
  * @returns The value of the message_timestamp field.
  */
-OPEN1722_INLINE uint64_t Avtp_CanXl_GetMessageTimestamp(const Avtp_CanXl_t* const pdu) {
-    return (uint64_t) GET_CANXL_FIELD(AVTP_CANXL_FIELD_MESSAGE_TIMESTAMP);
+OPEN1722_INLINE uint64_t Avtp_CanXl_GetMessageTimestamp(const Avtp_CanXl_t *const pdu)
+{
+    return (uint64_t)GET_CANXL_FIELD(AVTP_CANXL_FIELD_MESSAGE_TIMESTAMP);
 }
 
 /**
@@ -228,8 +237,9 @@ OPEN1722_INLINE uint64_t Avtp_CanXl_GetMessageTimestamp(const Avtp_CanXl_t* cons
  * @param pdu Pointer to an ACF_CANXL message.
  * @returns The value of the vcid field.
  */
-OPEN1722_INLINE uint8_t Avtp_CanXl_GetVcid(const Avtp_CanXl_t* const pdu) {
-    return (uint8_t) GET_CANXL_FIELD(AVTP_CANXL_FIELD_VCID);
+OPEN1722_INLINE uint8_t Avtp_CanXl_GetVcid(const Avtp_CanXl_t *const pdu)
+{
+    return (uint8_t)GET_CANXL_FIELD(AVTP_CANXL_FIELD_VCID);
 }
 
 /**
@@ -238,8 +248,9 @@ OPEN1722_INLINE uint8_t Avtp_CanXl_GetVcid(const Avtp_CanXl_t* const pdu) {
  * @param pdu Pointer to an ACF_CANXL message.
  * @returns The value of the sdt field.
  */
-OPEN1722_INLINE uint8_t Avtp_CanXl_GetSdt(const Avtp_CanXl_t* const pdu) {
-    return (uint8_t) GET_CANXL_FIELD(AVTP_CANXL_FIELD_SDT);
+OPEN1722_INLINE uint8_t Avtp_CanXl_GetSdt(const Avtp_CanXl_t *const pdu)
+{
+    return (uint8_t)GET_CANXL_FIELD(AVTP_CANXL_FIELD_SDT);
 }
 
 /**
@@ -248,8 +259,9 @@ OPEN1722_INLINE uint8_t Avtp_CanXl_GetSdt(const Avtp_CanXl_t* const pdu) {
  * @param pdu Pointer to an ACF_CANXL message.
  * @returns The value of the rrs flag.
  */
-OPEN1722_INLINE bool Avtp_CanXl_IsRrs(const Avtp_CanXl_t* const pdu) {
-    return (bool) GET_CANXL_FIELD(AVTP_CANXL_FIELD_RRS);
+OPEN1722_INLINE bool Avtp_CanXl_IsRrs(const Avtp_CanXl_t *const pdu)
+{
+    return (bool)GET_CANXL_FIELD(AVTP_CANXL_FIELD_RRS);
 }
 
 /**
@@ -258,8 +270,9 @@ OPEN1722_INLINE bool Avtp_CanXl_IsRrs(const Avtp_CanXl_t* const pdu) {
  * @param pdu Pointer to an ACF_CANXL message.
  * @returns The value of the sec flag.
  */
-OPEN1722_INLINE bool Avtp_CanXl_IsSec(const Avtp_CanXl_t* const pdu) {
-    return (bool) GET_CANXL_FIELD(AVTP_CANXL_FIELD_SEC);
+OPEN1722_INLINE bool Avtp_CanXl_IsSec(const Avtp_CanXl_t *const pdu)
+{
+    return (bool)GET_CANXL_FIELD(AVTP_CANXL_FIELD_SEC);
 }
 
 /**
@@ -268,8 +281,9 @@ OPEN1722_INLINE bool Avtp_CanXl_IsSec(const Avtp_CanXl_t* const pdu) {
  * @param pdu Pointer to an ACF_CANXL message.
  * @returns The value of the priority_id field.
  */
-OPEN1722_INLINE uint16_t Avtp_CanXl_GetPriorityId(const Avtp_CanXl_t* const pdu) {
-    return (uint16_t) GET_CANXL_FIELD(AVTP_CANXL_FIELD_PRIORITY_ID);
+OPEN1722_INLINE uint16_t Avtp_CanXl_GetPriorityId(const Avtp_CanXl_t *const pdu)
+{
+    return (uint16_t)GET_CANXL_FIELD(AVTP_CANXL_FIELD_PRIORITY_ID);
 }
 
 /**
@@ -278,8 +292,9 @@ OPEN1722_INLINE uint16_t Avtp_CanXl_GetPriorityId(const Avtp_CanXl_t* const pdu)
  * @param pdu Pointer to an ACF_CANXL message.
  * @returns The value of the acceptance_field.
  */
-OPEN1722_INLINE uint32_t Avtp_CanXl_GetAcceptanceField(const Avtp_CanXl_t* const pdu) {
-    return (uint32_t) GET_CANXL_FIELD(AVTP_CANXL_FIELD_ACCEPTANCE_FIELD);
+OPEN1722_INLINE uint32_t Avtp_CanXl_GetAcceptanceField(const Avtp_CanXl_t *const pdu)
+{
+    return (uint32_t)GET_CANXL_FIELD(AVTP_CANXL_FIELD_ACCEPTANCE_FIELD);
 }
 
 /**
@@ -288,8 +303,9 @@ OPEN1722_INLINE uint32_t Avtp_CanXl_GetAcceptanceField(const Avtp_CanXl_t* const
  * @param pdu Pointer to an ACF_CANXL message.
  * @returns The value of the transaction_num field.
  */
-OPEN1722_INLINE uint8_t Avtp_CanXl_GetTransactionNum(const Avtp_CanXl_t* const pdu) {
-    return (uint8_t) GET_CANXL_FIELD(AVTP_CANXL_FIELD_TRANSACTION_NUM);
+OPEN1722_INLINE uint8_t Avtp_CanXl_GetTransactionNum(const Avtp_CanXl_t *const pdu)
+{
+    return (uint8_t)GET_CANXL_FIELD(AVTP_CANXL_FIELD_TRANSACTION_NUM);
 }
 
 /**
@@ -298,8 +314,9 @@ OPEN1722_INLINE uint8_t Avtp_CanXl_GetTransactionNum(const Avtp_CanXl_t* const p
  * @param pdu Pointer to an ACF_CANXL message.
  * @returns The value of the ms flag.
  */
-OPEN1722_INLINE bool Avtp_CanXl_IsMs(const Avtp_CanXl_t* const pdu) {
-    return (bool) GET_CANXL_FIELD(AVTP_CANXL_FIELD_MS);
+OPEN1722_INLINE bool Avtp_CanXl_IsMs(const Avtp_CanXl_t *const pdu)
+{
+    return (bool)GET_CANXL_FIELD(AVTP_CANXL_FIELD_MS);
 }
 
 /**
@@ -308,8 +325,9 @@ OPEN1722_INLINE bool Avtp_CanXl_IsMs(const Avtp_CanXl_t* const pdu) {
  * @param pdu Pointer to an ACF_CANXL message.
  * @returns The value of the segment_num field.
  */
-OPEN1722_INLINE uint16_t Avtp_CanXl_GetSegmentNum(const Avtp_CanXl_t* const pdu) {
-    return (uint16_t) GET_CANXL_FIELD(AVTP_CANXL_FIELD_SEGMENT_NUM);
+OPEN1722_INLINE uint16_t Avtp_CanXl_GetSegmentNum(const Avtp_CanXl_t *const pdu)
+{
+    return (uint16_t)GET_CANXL_FIELD(AVTP_CANXL_FIELD_SEGMENT_NUM);
 }
 
 /**
@@ -318,7 +336,8 @@ OPEN1722_INLINE uint16_t Avtp_CanXl_GetSegmentNum(const Avtp_CanXl_t* const pdu)
  * @param pdu Pointer to an ACF_CANXL message.
  * @param mtv The value to set.
  */
-OPEN1722_INLINE void Avtp_CanXl_SetMtv(Avtp_CanXl_t* pdu, bool mtv) {
+OPEN1722_INLINE void Avtp_CanXl_SetMtv(Avtp_CanXl_t *pdu, bool mtv)
+{
     SET_CANXL_FIELD(AVTP_CANXL_FIELD_MTV, mtv);
 }
 
@@ -328,7 +347,8 @@ OPEN1722_INLINE void Avtp_CanXl_SetMtv(Avtp_CanXl_t* pdu, bool mtv) {
  * @param pdu Pointer to an ACF_CANXL message.
  * @param canBusId The value to set.
  */
-OPEN1722_INLINE void Avtp_CanXl_SetCanBusId(Avtp_CanXl_t* pdu, uint16_t canBusId) {
+OPEN1722_INLINE void Avtp_CanXl_SetCanBusId(Avtp_CanXl_t *pdu, uint16_t canBusId)
+{
     SET_CANXL_FIELD(AVTP_CANXL_FIELD_CAN_BUS_ID, canBusId);
 }
 
@@ -338,7 +358,8 @@ OPEN1722_INLINE void Avtp_CanXl_SetCanBusId(Avtp_CanXl_t* pdu, uint16_t canBusId
  * @param pdu Pointer to an ACF_CANXL message.
  * @param messageTimestamp The value to set.
  */
-OPEN1722_INLINE void Avtp_CanXl_SetMessageTimestamp(Avtp_CanXl_t* pdu, uint64_t messageTimestamp) {
+OPEN1722_INLINE void Avtp_CanXl_SetMessageTimestamp(Avtp_CanXl_t *pdu, uint64_t messageTimestamp)
+{
     SET_CANXL_FIELD(AVTP_CANXL_FIELD_MESSAGE_TIMESTAMP, messageTimestamp);
 }
 
@@ -348,7 +369,8 @@ OPEN1722_INLINE void Avtp_CanXl_SetMessageTimestamp(Avtp_CanXl_t* pdu, uint64_t 
  * @param pdu Pointer to an ACF_CANXL message.
  * @param vcid The value to set.
  */
-OPEN1722_INLINE void Avtp_CanXl_SetVcid(Avtp_CanXl_t* pdu, uint8_t vcid) {
+OPEN1722_INLINE void Avtp_CanXl_SetVcid(Avtp_CanXl_t *pdu, uint8_t vcid)
+{
     SET_CANXL_FIELD(AVTP_CANXL_FIELD_VCID, vcid);
 }
 
@@ -358,7 +380,8 @@ OPEN1722_INLINE void Avtp_CanXl_SetVcid(Avtp_CanXl_t* pdu, uint8_t vcid) {
  * @param pdu Pointer to an ACF_CANXL message.
  * @param sdt The value to set.
  */
-OPEN1722_INLINE void Avtp_CanXl_SetSdt(Avtp_CanXl_t* pdu, uint8_t sdt) {
+OPEN1722_INLINE void Avtp_CanXl_SetSdt(Avtp_CanXl_t *pdu, uint8_t sdt)
+{
     SET_CANXL_FIELD(AVTP_CANXL_FIELD_SDT, sdt);
 }
 
@@ -368,7 +391,8 @@ OPEN1722_INLINE void Avtp_CanXl_SetSdt(Avtp_CanXl_t* pdu, uint8_t sdt) {
  * @param pdu Pointer to an ACF_CANXL message.
  * @param rrs The value to set.
  */
-OPEN1722_INLINE void Avtp_CanXl_SetRrs(Avtp_CanXl_t* pdu, bool rrs) {
+OPEN1722_INLINE void Avtp_CanXl_SetRrs(Avtp_CanXl_t *pdu, bool rrs)
+{
     SET_CANXL_FIELD(AVTP_CANXL_FIELD_RRS, rrs);
 }
 
@@ -378,7 +402,8 @@ OPEN1722_INLINE void Avtp_CanXl_SetRrs(Avtp_CanXl_t* pdu, bool rrs) {
  * @param pdu Pointer to an ACF_CANXL message.
  * @param sec The value to set.
  */
-OPEN1722_INLINE void Avtp_CanXl_SetSec(Avtp_CanXl_t* pdu, bool sec) {
+OPEN1722_INLINE void Avtp_CanXl_SetSec(Avtp_CanXl_t *pdu, bool sec)
+{
     SET_CANXL_FIELD(AVTP_CANXL_FIELD_SEC, sec);
 }
 
@@ -388,7 +413,8 @@ OPEN1722_INLINE void Avtp_CanXl_SetSec(Avtp_CanXl_t* pdu, bool sec) {
  * @param pdu Pointer to an ACF_CANXL message.
  * @param priorityId The value to set.
  */
-OPEN1722_INLINE void Avtp_CanXl_SetPriorityId(Avtp_CanXl_t* pdu, uint16_t priorityId) {
+OPEN1722_INLINE void Avtp_CanXl_SetPriorityId(Avtp_CanXl_t *pdu, uint16_t priorityId)
+{
     SET_CANXL_FIELD(AVTP_CANXL_FIELD_PRIORITY_ID, priorityId);
 }
 
@@ -398,7 +424,8 @@ OPEN1722_INLINE void Avtp_CanXl_SetPriorityId(Avtp_CanXl_t* pdu, uint16_t priori
  * @param pdu Pointer to an ACF_CANXL message.
  * @param acceptanceField The value to set.
  */
-OPEN1722_INLINE void Avtp_CanXl_SetAcceptanceField(Avtp_CanXl_t* pdu, uint32_t acceptanceField) {
+OPEN1722_INLINE void Avtp_CanXl_SetAcceptanceField(Avtp_CanXl_t *pdu, uint32_t acceptanceField)
+{
     SET_CANXL_FIELD(AVTP_CANXL_FIELD_ACCEPTANCE_FIELD, acceptanceField);
 }
 
@@ -408,7 +435,8 @@ OPEN1722_INLINE void Avtp_CanXl_SetAcceptanceField(Avtp_CanXl_t* pdu, uint32_t a
  * @param pdu Pointer to an ACF_CANXL message.
  * @param transactionNum The value to set.
  */
-OPEN1722_INLINE void Avtp_CanXl_SetTransactionNum(Avtp_CanXl_t* pdu, uint8_t transactionNum) {
+OPEN1722_INLINE void Avtp_CanXl_SetTransactionNum(Avtp_CanXl_t *pdu, uint8_t transactionNum)
+{
     SET_CANXL_FIELD(AVTP_CANXL_FIELD_TRANSACTION_NUM, transactionNum);
 }
 
@@ -418,7 +446,8 @@ OPEN1722_INLINE void Avtp_CanXl_SetTransactionNum(Avtp_CanXl_t* pdu, uint8_t tra
  * @param pdu Pointer to an ACF_CANXL message.
  * @param ms The value to set.
  */
-OPEN1722_INLINE void Avtp_CanXl_SetMs(Avtp_CanXl_t* pdu, bool ms) {
+OPEN1722_INLINE void Avtp_CanXl_SetMs(Avtp_CanXl_t *pdu, bool ms)
+{
     SET_CANXL_FIELD(AVTP_CANXL_FIELD_MS, ms);
 }
 
@@ -428,7 +457,8 @@ OPEN1722_INLINE void Avtp_CanXl_SetMs(Avtp_CanXl_t* pdu, bool ms) {
  * @param pdu Pointer to an ACF_CANXL message.
  * @param segmentNum The value to set.
  */
-OPEN1722_INLINE void Avtp_CanXl_SetSegmentNum(Avtp_CanXl_t* pdu, uint16_t segmentNum) {
+OPEN1722_INLINE void Avtp_CanXl_SetSegmentNum(Avtp_CanXl_t *pdu, uint16_t segmentNum)
+{
     SET_CANXL_FIELD(AVTP_CANXL_FIELD_SEGMENT_NUM, segmentNum);
 }
 
@@ -438,7 +468,7 @@ OPEN1722_INLINE void Avtp_CanXl_SetSegmentNum(Avtp_CanXl_t* pdu, uint16_t segmen
  * @param pdu Pointer to the first bit of a 1722 ACF CANXL PDU.
  * @return Pointer to ACF CAN XL frame payload
  */
-OPEN1722_INLINE const uint8_t *Avtp_CanXl_GetPayload(const Avtp_CanXl_t* const pdu)
+OPEN1722_INLINE const uint8_t *Avtp_CanXl_GetPayload(const Avtp_CanXl_t *const pdu)
 {
     return pdu->payload;
 }
@@ -488,7 +518,7 @@ OPEN1722_INLINE void Avtp_CanXl_SetPayloadLength(Avtp_CanXl_t *pdu, uint16_t pay
  * @param pdu Pointer to the first bit of a 1722 ACF CANXL PDU.
  * @return  Length of CAN payload in bytes
  */
-OPEN1722_INLINE uint8_t Avtp_CanXl_GetPayloadLength(const Avtp_CanXl_t* const pdu)
+OPEN1722_INLINE uint8_t Avtp_CanXl_GetPayloadLength(const Avtp_CanXl_t *const pdu)
 {
     uint8_t pad_length = Avtp_CanXl_GetPad(pdu);
     uint16_t acf_length_bytes = Avtp_CanXl_GetAcfMsgLengthInBytes(pdu);
@@ -500,7 +530,7 @@ OPEN1722_INLINE uint8_t Avtp_CanXl_GetPayloadLength(const Avtp_CanXl_t* const pd
  *
  * @param pdu Pointer to the first bit of a 1722 ACF CANXL PDU.
  */
-OPEN1722_INLINE void Avtp_CanXl_Init(Avtp_CanXl_t* pdu)
+OPEN1722_INLINE void Avtp_CanXl_Init(Avtp_CanXl_t *pdu)
 {
     if (pdu != NULL) {
         memset(pdu, 0, sizeof(Avtp_CanXl_t));
@@ -546,7 +576,7 @@ OPEN1722_INLINE void Avtp_CanXl_CreateAcfMessage(Avtp_CanXl_t *pdu, uint16_t pri
  * @param bufferSize Size of the buffer containing the ACF CAN XL frame.
  * @return true if the ACF CAN XL frame is valid, false otherwise.
  */
-OPEN1722_INLINE bool Avtp_CanXl_IsValid(const Avtp_CanXl_t* const pdu, size_t bufferSize)
+OPEN1722_INLINE bool Avtp_CanXl_IsValid(const Avtp_CanXl_t *const pdu, size_t bufferSize)
 {
     if (pdu == NULL) {
         return false;

--- a/include/avtp/acf/CanXlBrief.h
+++ b/include/avtp/acf/CanXlBrief.h
@@ -44,9 +44,15 @@ extern "C" {
 #include <stdbool.h>
 #include <string.h>
 
+#include "avtp/Utils.h"
 #include "avtp/Defines.h"
 #include "avtp/acf/AcfCommon.h"
-#include "avtp/Utils.h"
+
+#define GET_CANXL_BRIEF_FIELD(field)                                                               \
+    (Avtp_GetField(Avtp_CanXlBriefFieldDesc, AVTP_CANXL_BRIEF_FIELD_MAX, (uint8_t *)pdu, field))
+#define SET_CANXL_BRIEF_FIELD(field, value)                                                        \
+    (Avtp_SetField(Avtp_CanXlBriefFieldDesc, AVTP_CANXL_BRIEF_FIELD_MAX, (uint8_t *)pdu, field,   \
+                   value))
 
 /**
  * Length of ACF_CAN_XL_BRIEF message header in bytes.
@@ -60,7 +66,7 @@ extern "C" {
 typedef struct {
     uint8_t header[AVTP_CANXL_BRIEF_HEADER_LEN];
     uint8_t payload[0];
-} Avtp_CanXlBrief_t;
+} __attribute__((packed)) Avtp_CanXlBrief_t;
 
 /**
  * Fields encoded in the ACF_CAN_XL_BRIEF header.
@@ -84,12 +90,12 @@ typedef enum {
     AVTP_CANXL_BRIEF_FIELD_SEGMENT_NUM,
     /* Count number of fields for bound checks */
     AVTP_CANXL_BRIEF_FIELD_MAX
-} Avtp_CanXlBriefField_t;
+} Avtp_CanXlBriefFields_t;
 
 /**
  * This table describes all the offsets of the ACF_CAN_XL_BRIEF header fields.
  */
-static const Avtp_FieldDescriptor_t __AVTP_CANXL_BRIEF_FIELDS[AVTP_CANXL_BRIEF_FIELD_MAX] =
+static const Avtp_FieldDescriptor_t Avtp_CanXlBriefFieldDesc[AVTP_CANXL_BRIEF_FIELD_MAX] =
 {
     /* ACF common header fields */
     [AVTP_CANXL_BRIEF_FIELD_ACF_MSG_TYPE]           = { .quadlet = 0, .offset =  0, .bits = 7 },
@@ -110,308 +116,447 @@ static const Avtp_FieldDescriptor_t __AVTP_CANXL_BRIEF_FIELDS[AVTP_CANXL_BRIEF_F
 };
 
 /**
- * Macro to get the value of a field from an ACF_CAN_XL_BRIEF message header.
- * 
- * @note This macro should not be used directly, instead use the field specific
- * getter functions defined below.
- */
-#define __Avtp_CanXlBrief_GetField(field) \
-        (Avtp_GetField(__AVTP_CANXL_BRIEF_FIELDS, AVTP_CANXL_BRIEF_FIELD_MAX, (uint8_t*)msg, field))
-
-/**
- * Macro to set the value of a field in an ACF_CAN_XL_BRIEF message header.
- * 
- * @note This macro should not be used directly, instead use the field specific
- * setter functions defined below.
- */
-#define __Avtp_CanXlBrief_SetField(field, value) \
-        (Avtp_SetField(__AVTP_CANXL_BRIEF_FIELDS, AVTP_CANXL_BRIEF_FIELD_MAX, (uint8_t*)msg, field, value))
-
-/**
- * Initializes an ACF_CAN_XL_BRIEF message with default values for the header fields
- * including acf_msg_type and acf_msg_length.
+ * Return the value of the ACF message type field as specified in the IEEE 1722 Specification.
  *
- * @param msg Pointer to the ACF_CAN_XL_BRIEF message to initialize.
+ * @param pdu Pointer to the first bit of a 1722 ACF CAN XL Brief PDU.
+ * @returns Value of the ACF message type field.
  */
-OPEN1722_INLINE void Avtp_CanXlBrief_Init(Avtp_CanXlBrief_t* msg) {
-    memset(msg, 0, sizeof(Avtp_CanXlBrief_t));
-    __Avtp_CanXlBrief_SetField(AVTP_CANXL_BRIEF_FIELD_ACF_MSG_TYPE, AVTP_ACF_TYPE_CAN_XL_BRIEF);
-    __Avtp_CanXlBrief_SetField(AVTP_CANXL_BRIEF_FIELD_ACF_MSG_LENGTH, AVTP_CANXL_BRIEF_HEADER_LEN / AVTP_QUADLET_SIZE);
+OPEN1722_INLINE uint8_t Avtp_CanXlBrief_GetAcfMsgType(const Avtp_CanXlBrief_t* const pdu) {
+    return (uint8_t) GET_CANXL_BRIEF_FIELD(AVTP_CANXL_BRIEF_FIELD_ACF_MSG_TYPE);
+}
+
+/**
+ * Return the value of the ACF message length field as specified in the IEEE 1722 Specification.
+ * This returns the length in Quadlets as specified in the IEEE 1722 Specification.
+ *
+ * You can use Avtp_CanXlBrief_GetPayloadLength to get the length in bytes without padding.
+ *
+ * @param pdu Pointer to the first bit of a 1722 ACF CAN XL Brief PDU.
+ * @returns Value of the ACF message length field.
+ */
+OPEN1722_INLINE uint16_t Avtp_CanXlBrief_GetAcfMsgLength(const Avtp_CanXlBrief_t* const pdu) {
+    return (uint16_t) GET_CANXL_BRIEF_FIELD(AVTP_CANXL_BRIEF_FIELD_ACF_MSG_LENGTH);
+}
+
+/**
+ * Return the ACF message length in bytes.
+ *
+ * @param pdu Pointer to the first bit of a 1722 ACF CAN XL Brief PDU.
+ * @returns Length of the ACF message in bytes.
+ */
+OPEN1722_INLINE uint16_t Avtp_CanXlBrief_GetAcfMsgLengthInBytes(const Avtp_CanXlBrief_t* const pdu) {
+    return (uint16_t) GET_CANXL_BRIEF_FIELD(AVTP_CANXL_BRIEF_FIELD_ACF_MSG_LENGTH) * 4;
+}
+
+/**
+ * Set the value of the ACF message type field as specified in the IEEE 1722 Specification.
+ *
+ * @param pdu Pointer to the first bit of a 1722 ACF CAN XL Brief PDU.
+ * @param value Value to set the ACF message type field to.
+ */
+OPEN1722_INLINE void Avtp_CanXlBrief_SetAcfMsgType(Avtp_CanXlBrief_t* pdu, uint8_t value) {
+    SET_CANXL_BRIEF_FIELD(AVTP_CANXL_BRIEF_FIELD_ACF_MSG_TYPE, value);
+}
+
+/**
+ * Set the value of the ACF message length field as specified in the IEEE 1722 Specification.
+ * Note: the size is in Quadlets as specified in the IEEE 1722 Specification.
+ * You can use Avtp_CanXlBrief_SetPayloadLength to set length in bytes and automatically set the
+ * correct padding.
+ *
+ * @param pdu Pointer to the first bit of a 1722 ACF CAN XL Brief PDU.
+ * @param value Value to set the ACF message length field to.
+ */
+OPEN1722_INLINE void Avtp_CanXlBrief_SetAcfMsgLength(Avtp_CanXlBrief_t* pdu, uint16_t value) {
+    SET_CANXL_BRIEF_FIELD(AVTP_CANXL_BRIEF_FIELD_ACF_MSG_LENGTH, value);
 }
 
 /**
  * Returns the pad field from an ACF_CAN_XL_BRIEF message header.
- * 
- * @param msg Pointer to an ACF_CAN_XL_BRIEF message.
+ *
+ * @param pdu Pointer to an ACF_CAN_XL_BRIEF message.
  * @returns The value of the pad field.
  */
-OPEN1722_INLINE uint8_t Avtp_CanXlBrief_GetPad(const Avtp_CanXlBrief_t* msg) {
-    return (uint8_t) __Avtp_CanXlBrief_GetField(AVTP_CANXL_BRIEF_FIELD_PAD);
+OPEN1722_INLINE uint8_t Avtp_CanXlBrief_GetPad(const Avtp_CanXlBrief_t* const pdu) {
+    return (uint8_t) GET_CANXL_BRIEF_FIELD(AVTP_CANXL_BRIEF_FIELD_PAD);
 }
 
 /**
- * Returns the message timestamp valid flag (mtv) from an ACF_CAN_XL_BRIEF message
- * header.
- * 
- * @param msg Pointer to an ACF_CAN_XL_BRIEF message.
+ * Sets the pad field in an ACF_CAN_XL_BRIEF message header.
+ *
+ * @param pdu Pointer to an ACF_CAN_XL_BRIEF message.
+ * @param pad The value to set.
+ */
+OPEN1722_INLINE void Avtp_CanXlBrief_SetPad(Avtp_CanXlBrief_t* pdu, uint8_t pad) {
+    SET_CANXL_BRIEF_FIELD(AVTP_CANXL_BRIEF_FIELD_PAD, pad);
+}
+
+/**
+ * Returns the message timestamp valid flag (mtv) from an ACF_CAN_XL_BRIEF message header.
+ *
+ * @param pdu Pointer to an ACF_CAN_XL_BRIEF message.
  * @returns The value of the mtv flag.
  */
-OPEN1722_INLINE bool Avtp_CanXlBrief_IsMtv(const Avtp_CanXlBrief_t* msg) {
-    return (bool) __Avtp_CanXlBrief_GetField(AVTP_CANXL_BRIEF_FIELD_MTV);
+OPEN1722_INLINE bool Avtp_CanXlBrief_IsMtv(const Avtp_CanXlBrief_t* const pdu) {
+    return (bool) GET_CANXL_BRIEF_FIELD(AVTP_CANXL_BRIEF_FIELD_MTV);
 }
 
 /**
  * Returns the value of the can_bus_id field from an ACF_CAN_XL_BRIEF message header.
- * 
- * @param msg Pointer to an ACF_CAN_XL_BRIEF message.
+ *
+ * @param pdu Pointer to an ACF_CAN_XL_BRIEF message.
  * @returns The value of the can_bus_id field.
  */
-OPEN1722_INLINE uint16_t Avtp_CanXlBrief_GetCanBusId(const Avtp_CanXlBrief_t* msg) {
-    return (uint16_t) __Avtp_CanXlBrief_GetField(AVTP_CANXL_BRIEF_FIELD_CAN_BUS_ID);
+OPEN1722_INLINE uint16_t Avtp_CanXlBrief_GetCanBusId(const Avtp_CanXlBrief_t* const pdu) {
+    return (uint16_t) GET_CANXL_BRIEF_FIELD(AVTP_CANXL_BRIEF_FIELD_CAN_BUS_ID);
 }
 
 /**
  * Returns the value of the vcid field from an ACF_CAN_XL_BRIEF message header.
- * 
- * @param msg Pointer to an ACF_CAN_XL_BRIEF message.
+ *
+ * @param pdu Pointer to an ACF_CAN_XL_BRIEF message.
  * @returns The value of the vcid field.
  */
-OPEN1722_INLINE uint8_t Avtp_CanXlBrief_GetVcid(const Avtp_CanXlBrief_t* msg) {
-    return (uint8_t) __Avtp_CanXlBrief_GetField(AVTP_CANXL_BRIEF_FIELD_VCID);
+OPEN1722_INLINE uint8_t Avtp_CanXlBrief_GetVcid(const Avtp_CanXlBrief_t* const pdu) {
+    return (uint8_t) GET_CANXL_BRIEF_FIELD(AVTP_CANXL_BRIEF_FIELD_VCID);
 }
 
 /**
  * Returns the value of the sdt field from an ACF_CAN_XL_BRIEF message header.
- * 
- * @param msg Pointer to an ACF_CAN_XL_BRIEF message.
+ *
+ * @param pdu Pointer to an ACF_CAN_XL_BRIEF message.
  * @returns The value of the sdt field.
  */
-OPEN1722_INLINE uint8_t Avtp_CanXlBrief_GetSdt(const Avtp_CanXlBrief_t* msg) {
-    return (uint8_t) __Avtp_CanXlBrief_GetField(AVTP_CANXL_BRIEF_FIELD_SDT);
+OPEN1722_INLINE uint8_t Avtp_CanXlBrief_GetSdt(const Avtp_CanXlBrief_t* const pdu) {
+    return (uint8_t) GET_CANXL_BRIEF_FIELD(AVTP_CANXL_BRIEF_FIELD_SDT);
 }
 
 /**
  * Returns the value of the rrs flag from an ACF_CAN_XL_BRIEF message header.
- * 
- * @param msg Pointer to an ACF_CAN_XL_BRIEF message.
+ *
+ * @param pdu Pointer to an ACF_CAN_XL_BRIEF message.
  * @returns The value of the rrs flag.
  */
-OPEN1722_INLINE bool Avtp_CanXlBrief_IsRrs(const Avtp_CanXlBrief_t* msg) {
-    return (bool) __Avtp_CanXlBrief_GetField(AVTP_CANXL_BRIEF_FIELD_RRS);
+OPEN1722_INLINE bool Avtp_CanXlBrief_IsRrs(const Avtp_CanXlBrief_t* const pdu) {
+    return (bool) GET_CANXL_BRIEF_FIELD(AVTP_CANXL_BRIEF_FIELD_RRS);
 }
 
 /**
  * Returns the value of the sec flag from an ACF_CAN_XL_BRIEF message header.
- * 
- * @param msg Pointer to an ACF_CAN_XL_BRIEF message.
+ *
+ * @param pdu Pointer to an ACF_CAN_XL_BRIEF message.
  * @returns The value of the sec flag.
  */
-OPEN1722_INLINE bool Avtp_CanXlBrief_IsSec(const Avtp_CanXlBrief_t* msg) {
-    return (bool) __Avtp_CanXlBrief_GetField(AVTP_CANXL_BRIEF_FIELD_SEC);
+OPEN1722_INLINE bool Avtp_CanXlBrief_IsSec(const Avtp_CanXlBrief_t* const pdu) {
+    return (bool) GET_CANXL_BRIEF_FIELD(AVTP_CANXL_BRIEF_FIELD_SEC);
 }
 
 /**
- * Returns the value of the priority_id field from an ACF_CAN_XL_BRIEF message
- * header.
- * 
- * @param msg Pointer to an ACF_CAN_XL_BRIEF message.
+ * Returns the value of the priority_id field from an ACF_CAN_XL_BRIEF message header.
+ *
+ * @param pdu Pointer to an ACF_CAN_XL_BRIEF message.
  * @returns The value of the priority_id field.
  */
-OPEN1722_INLINE uint16_t Avtp_CanXlBrief_GetPriorityId(const Avtp_CanXlBrief_t* msg) {
-    return (uint16_t) __Avtp_CanXlBrief_GetField(AVTP_CANXL_BRIEF_FIELD_PRIORITY_ID);
+OPEN1722_INLINE uint16_t Avtp_CanXlBrief_GetPriorityId(const Avtp_CanXlBrief_t* const pdu) {
+    return (uint16_t) GET_CANXL_BRIEF_FIELD(AVTP_CANXL_BRIEF_FIELD_PRIORITY_ID);
 }
 
 /**
  * Returns the value of the acceptance_field from an ACF_CAN_XL_BRIEF message header.
- * 
- * @param msg Pointer to an ACF_CAN_XL_BRIEF message.
+ *
+ * @param pdu Pointer to an ACF_CAN_XL_BRIEF message.
  * @returns The value of the acceptance_field.
  */
-OPEN1722_INLINE uint32_t Avtp_CanXlBrief_GetAcceptanceField(const Avtp_CanXlBrief_t* msg) {
-    return (uint32_t) __Avtp_CanXlBrief_GetField(AVTP_CANXL_BRIEF_FIELD_ACCEPTANCE_FIELD);
+OPEN1722_INLINE uint32_t Avtp_CanXlBrief_GetAcceptanceField(const Avtp_CanXlBrief_t* const pdu) {
+    return (uint32_t) GET_CANXL_BRIEF_FIELD(AVTP_CANXL_BRIEF_FIELD_ACCEPTANCE_FIELD);
 }
 
 /**
- * Returns the value of the transaction_num field from an ACF_CAN_XL_BRIEF message
- * header.
- * 
- * @param msg Pointer to an ACF_CAN_XL_BRIEF message.
+ * Returns the value of the transaction_num field from an ACF_CAN_XL_BRIEF message header.
+ *
+ * @param pdu Pointer to an ACF_CAN_XL_BRIEF message.
  * @returns The value of the transaction_num field.
  */
-OPEN1722_INLINE uint8_t Avtp_CanXlBrief_GetTransactionNum(const Avtp_CanXlBrief_t* msg) {
-    return (uint8_t) __Avtp_CanXlBrief_GetField(AVTP_CANXL_BRIEF_FIELD_TRANSACTION_NUM);
+OPEN1722_INLINE uint8_t Avtp_CanXlBrief_GetTransactionNum(const Avtp_CanXlBrief_t* const pdu) {
+    return (uint8_t) GET_CANXL_BRIEF_FIELD(AVTP_CANXL_BRIEF_FIELD_TRANSACTION_NUM);
 }
 
 /**
  * Returns the value of the ms flag from an ACF_CAN_XL_BRIEF message header.
- * 
- * @param msg Pointer to an ACF_CAN_XL_BRIEF message.
+ *
+ * @param pdu Pointer to an ACF_CAN_XL_BRIEF message.
  * @returns The value of the ms flag.
  */
-OPEN1722_INLINE bool Avtp_CanXlBrief_IsMs(const Avtp_CanXlBrief_t* msg) {
-    return (bool) __Avtp_CanXlBrief_GetField(AVTP_CANXL_BRIEF_FIELD_MS);
+OPEN1722_INLINE bool Avtp_CanXlBrief_IsMs(const Avtp_CanXlBrief_t* const pdu) {
+    return (bool) GET_CANXL_BRIEF_FIELD(AVTP_CANXL_BRIEF_FIELD_MS);
 }
 
 /**
- * Returns the value of the segment_num field from an ACF_CAN_XL_BRIEF message
- * header.
- * 
- * @param msg Pointer to an ACF_CAN_XL_BRIEF message.
+ * Returns the value of the segment_num field from an ACF_CAN_XL_BRIEF message header.
+ *
+ * @param pdu Pointer to an ACF_CAN_XL_BRIEF message.
  * @returns The value of the segment_num field.
  */
-OPEN1722_INLINE uint16_t Avtp_CanXlBrief_GetSegmentNum(const Avtp_CanXlBrief_t* msg) {
-    return (uint16_t) __Avtp_CanXlBrief_GetField(AVTP_CANXL_BRIEF_FIELD_SEGMENT_NUM);
-}
-
-/**
- * Returns the payload length from an ACF_CAN_XL_BRIEF message (in bytes). This is
- * calculated based on the value of the acf_msg_length field in the header
- * as well as the value of the pad field.
- * 
- * @param msg Pointer to an ACF_CAN_XL_BRIEF message.
- * @returns The payload length in bytes.
- */
-OPEN1722_INLINE uint16_t Avtp_CanXlBrief_GetPayloadLen(const Avtp_CanXlBrief_t* msg) {
-    return (uint16_t) (__Avtp_CanXlBrief_GetField(AVTP_CANXL_BRIEF_FIELD_ACF_MSG_LENGTH) * AVTP_QUADLET_SIZE
-           - AVTP_CANXL_BRIEF_HEADER_LEN
-           - __Avtp_CanXlBrief_GetField(AVTP_CANXL_BRIEF_FIELD_PAD));
-}
-
-/**
- * Returns the total message length from an ACF_CAN_XL_BRIEF message (in bytes)
- * including header and payload section.
- * 
- * @param msg Pointer to an ACF_CAN_XL_BRIEF message.
- * @returns The total message length in bytes.
- */
-OPEN1722_INLINE uint16_t Avtp_CanXlBrief_GetLen(const Avtp_CanXlBrief_t* msg) {
-    return (uint16_t) (__Avtp_CanXlBrief_GetField(AVTP_CANXL_BRIEF_FIELD_ACF_MSG_LENGTH) * AVTP_QUADLET_SIZE);
+OPEN1722_INLINE uint16_t Avtp_CanXlBrief_GetSegmentNum(const Avtp_CanXlBrief_t* const pdu) {
+    return (uint16_t) GET_CANXL_BRIEF_FIELD(AVTP_CANXL_BRIEF_FIELD_SEGMENT_NUM);
 }
 
 /**
  * Sets the value of the mtv flag in an ACF_CAN_XL_BRIEF message header.
- * 
- * @param msg Pointer to an ACF_CAN_XL_BRIEF message.
+ *
+ * @param pdu Pointer to an ACF_CAN_XL_BRIEF message.
  * @param mtv The value to set.
  */
-OPEN1722_INLINE void Avtp_CanXlBrief_SetMtv(Avtp_CanXlBrief_t* msg, bool mtv) {
-    __Avtp_CanXlBrief_SetField(AVTP_CANXL_BRIEF_FIELD_MTV, mtv);
+OPEN1722_INLINE void Avtp_CanXlBrief_SetMtv(Avtp_CanXlBrief_t* pdu, bool mtv) {
+    SET_CANXL_BRIEF_FIELD(AVTP_CANXL_BRIEF_FIELD_MTV, mtv);
 }
 
 /**
  * Sets the value of the can_bus_id field in an ACF_CAN_XL_BRIEF message header.
- * 
- * @param msg Pointer to an ACF_CAN_XL_BRIEF message.
+ *
+ * @param pdu Pointer to an ACF_CAN_XL_BRIEF message.
  * @param canBusId The value to set.
  */
-OPEN1722_INLINE void Avtp_CanXlBrief_SetCanBusId(Avtp_CanXlBrief_t* msg, uint16_t canBusId) {
-    __Avtp_CanXlBrief_SetField(AVTP_CANXL_BRIEF_FIELD_CAN_BUS_ID, canBusId);
+OPEN1722_INLINE void Avtp_CanXlBrief_SetCanBusId(Avtp_CanXlBrief_t* pdu, uint16_t canBusId) {
+    SET_CANXL_BRIEF_FIELD(AVTP_CANXL_BRIEF_FIELD_CAN_BUS_ID, canBusId);
 }
 
 /**
  * Sets the value of the vcid field in an ACF_CAN_XL_BRIEF message header.
- * 
- * @param msg Pointer to an ACF_CAN_XL_BRIEF message.
+ *
+ * @param pdu Pointer to an ACF_CAN_XL_BRIEF message.
  * @param vcid The value to set.
  */
-OPEN1722_INLINE void Avtp_CanXlBrief_SetVcid(Avtp_CanXlBrief_t* msg, uint8_t vcid) {
-    __Avtp_CanXlBrief_SetField(AVTP_CANXL_BRIEF_FIELD_VCID, vcid);
+OPEN1722_INLINE void Avtp_CanXlBrief_SetVcid(Avtp_CanXlBrief_t* pdu, uint8_t vcid) {
+    SET_CANXL_BRIEF_FIELD(AVTP_CANXL_BRIEF_FIELD_VCID, vcid);
 }
 
 /**
  * Sets the value of the sdt field in an ACF_CAN_XL_BRIEF message header.
- * 
- * @param msg Pointer to an ACF_CAN_XL_BRIEF message.
+ *
+ * @param pdu Pointer to an ACF_CAN_XL_BRIEF message.
  * @param sdt The value to set.
  */
-OPEN1722_INLINE void Avtp_CanXlBrief_SetSdt(Avtp_CanXlBrief_t* msg, uint8_t sdt) {
-    __Avtp_CanXlBrief_SetField(AVTP_CANXL_BRIEF_FIELD_SDT, sdt);
+OPEN1722_INLINE void Avtp_CanXlBrief_SetSdt(Avtp_CanXlBrief_t* pdu, uint8_t sdt) {
+    SET_CANXL_BRIEF_FIELD(AVTP_CANXL_BRIEF_FIELD_SDT, sdt);
 }
 
 /**
  * Sets the value of the rrs flag in an ACF_CAN_XL_BRIEF message header.
- * 
- * @param msg Pointer to an ACF_CAN_XL_BRIEF message.
+ *
+ * @param pdu Pointer to an ACF_CAN_XL_BRIEF message.
  * @param rrs The value to set.
  */
-OPEN1722_INLINE void Avtp_CanXlBrief_SetRrs(Avtp_CanXlBrief_t* msg, bool rrs) {
-    __Avtp_CanXlBrief_SetField(AVTP_CANXL_BRIEF_FIELD_RRS, rrs);
+OPEN1722_INLINE void Avtp_CanXlBrief_SetRrs(Avtp_CanXlBrief_t* pdu, bool rrs) {
+    SET_CANXL_BRIEF_FIELD(AVTP_CANXL_BRIEF_FIELD_RRS, rrs);
 }
 
 /**
  * Sets the value of the sec flag in an ACF_CAN_XL_BRIEF message header.
- * 
- * @param msg Pointer to an ACF_CAN_XL_BRIEF message.
+ *
+ * @param pdu Pointer to an ACF_CAN_XL_BRIEF message.
  * @param sec The value to set.
  */
-OPEN1722_INLINE void Avtp_CanXlBrief_SetSec(Avtp_CanXlBrief_t* msg, bool sec) {
-    __Avtp_CanXlBrief_SetField(AVTP_CANXL_BRIEF_FIELD_SEC, sec);
+OPEN1722_INLINE void Avtp_CanXlBrief_SetSec(Avtp_CanXlBrief_t* pdu, bool sec) {
+    SET_CANXL_BRIEF_FIELD(AVTP_CANXL_BRIEF_FIELD_SEC, sec);
 }
 
 /**
  * Sets the value of the priority_id field in an ACF_CAN_XL_BRIEF message header.
- * 
- * @param msg Pointer to an ACF_CAN_XL_BRIEF message.
+ *
+ * @param pdu Pointer to an ACF_CAN_XL_BRIEF message.
  * @param priorityId The value to set.
  */
-OPEN1722_INLINE void Avtp_CanXlBrief_SetPriorityId(Avtp_CanXlBrief_t* msg, uint16_t priorityId) {
-    __Avtp_CanXlBrief_SetField(AVTP_CANXL_BRIEF_FIELD_PRIORITY_ID, priorityId);
+OPEN1722_INLINE void Avtp_CanXlBrief_SetPriorityId(Avtp_CanXlBrief_t* pdu, uint16_t priorityId) {
+    SET_CANXL_BRIEF_FIELD(AVTP_CANXL_BRIEF_FIELD_PRIORITY_ID, priorityId);
 }
 
 /**
  * Sets the value of the acceptance_field in an ACF_CAN_XL_BRIEF message header.
- * 
- * @param msg Pointer to an ACF_CAN_XL_BRIEF message.
+ *
+ * @param pdu Pointer to an ACF_CAN_XL_BRIEF message.
  * @param acceptanceField The value to set.
  */
-OPEN1722_INLINE void Avtp_CanXlBrief_SetAcceptanceField(Avtp_CanXlBrief_t* msg, uint32_t acceptanceField) {
-    __Avtp_CanXlBrief_SetField(AVTP_CANXL_BRIEF_FIELD_ACCEPTANCE_FIELD, acceptanceField);
+OPEN1722_INLINE void Avtp_CanXlBrief_SetAcceptanceField(Avtp_CanXlBrief_t* pdu,
+                                                        uint32_t acceptanceField) {
+    SET_CANXL_BRIEF_FIELD(AVTP_CANXL_BRIEF_FIELD_ACCEPTANCE_FIELD, acceptanceField);
 }
 
 /**
  * Sets the value of the transaction_num field in an ACF_CAN_XL_BRIEF message header.
- * 
- * @param msg Pointer to an ACF_CAN_XL_BRIEF message.
+ *
+ * @param pdu Pointer to an ACF_CAN_XL_BRIEF message.
  * @param transactionNum The value to set.
  */
-OPEN1722_INLINE void Avtp_CanXlBrief_SetTransactionNum(Avtp_CanXlBrief_t* msg, uint8_t transactionNum) {
-    __Avtp_CanXlBrief_SetField(AVTP_CANXL_BRIEF_FIELD_TRANSACTION_NUM, transactionNum);
+OPEN1722_INLINE void Avtp_CanXlBrief_SetTransactionNum(Avtp_CanXlBrief_t* pdu,
+                                                       uint8_t transactionNum) {
+    SET_CANXL_BRIEF_FIELD(AVTP_CANXL_BRIEF_FIELD_TRANSACTION_NUM, transactionNum);
 }
 
 /**
  * Sets the value of the ms flag in an ACF_CAN_XL_BRIEF message header.
- * 
- * @param msg Pointer to an ACF_CAN_XL_BRIEF message.
+ *
+ * @param pdu Pointer to an ACF_CAN_XL_BRIEF message.
  * @param ms The value to set.
  */
-OPEN1722_INLINE void Avtp_CanXlBrief_SetMs(Avtp_CanXlBrief_t* msg, bool ms) {
-    __Avtp_CanXlBrief_SetField(AVTP_CANXL_BRIEF_FIELD_MS, ms);
+OPEN1722_INLINE void Avtp_CanXlBrief_SetMs(Avtp_CanXlBrief_t* pdu, bool ms) {
+    SET_CANXL_BRIEF_FIELD(AVTP_CANXL_BRIEF_FIELD_MS, ms);
 }
 
 /**
  * Sets the value of the segment_num field in an ACF_CAN_XL_BRIEF message header.
- * 
- * @param msg Pointer to an ACF_CAN_XL_BRIEF message.
+ *
+ * @param pdu Pointer to an ACF_CAN_XL_BRIEF message.
  * @param segmentNum The value to set.
  */
-OPEN1722_INLINE void Avtp_CanXlBrief_SetSegmentNum(Avtp_CanXlBrief_t* msg, uint16_t segmentNum) {
-    __Avtp_CanXlBrief_SetField(AVTP_CANXL_BRIEF_FIELD_SEGMENT_NUM, segmentNum);
+OPEN1722_INLINE void Avtp_CanXlBrief_SetSegmentNum(Avtp_CanXlBrief_t* pdu, uint16_t segmentNum) {
+    SET_CANXL_BRIEF_FIELD(AVTP_CANXL_BRIEF_FIELD_SEGMENT_NUM, segmentNum);
 }
 
 /**
- * Sets the value of the acf_msg_length field in an ACF_CAN_XL_BRIEF message header
- * based on the given payload length. This function also calculates the
- * required padding and sets the value of the pad field accordingly.
- * 
- * @param msg Pointer to an ACF_CAN_XL_BRIEF message.
- * @param payloadLen The length of the payload in bytes.
+ * Returns pointer to payload of an ACF CAN XL Brief frame.
+ *
+ * @param pdu Pointer to the first bit of a 1722 ACF CAN XL Brief PDU.
+ * @return Pointer to ACF CAN XL Brief frame payload
  */
-OPEN1722_INLINE void Avtp_CanXlBrief_SetPayloadLen(Avtp_CanXlBrief_t* msg, uint16_t payloadLen) {
-    uint16_t msgLenBytes = AVTP_CANXL_BRIEF_HEADER_LEN + payloadLen;
-    uint8_t pad = (uint8_t) (4 - (msgLenBytes % 4)) % 4;
-    uint16_t msgLenQuadlets = (uint16_t) ((msgLenBytes + pad) / 4);
-    __Avtp_CanXlBrief_SetField(AVTP_CANXL_BRIEF_FIELD_ACF_MSG_LENGTH, msgLenQuadlets);
-    __Avtp_CanXlBrief_SetField(AVTP_CANXL_BRIEF_FIELD_PAD, pad);
+OPEN1722_INLINE const uint8_t *Avtp_CanXlBrief_GetPayload(const Avtp_CanXlBrief_t* const pdu)
+{
+    return pdu->payload;
+}
+
+/**
+ * Sets the CAN payload in an ACF CAN XL Brief frame.
+ *
+ * @param pdu Pointer to the first bit of a 1722 ACF CAN XL Brief PDU.
+ * @param payload Pointer to the payload byte array
+ * @param payload_length Length of the payload
+ */
+OPEN1722_INLINE void Avtp_CanXlBrief_SetPayload(Avtp_CanXlBrief_t *pdu, uint8_t *payload,
+                                                uint16_t payload_length)
+{
+    memcpy(pdu->payload, payload, payload_length);
+}
+
+/**
+ * Finalizes the ACF CAN XL Brief frame. This function will set the
+ * length and pad fields while inserting the padded bytes. This will also
+ * set padding bytes to zero if the payload length is not a multiple of 4.
+ * to avoid leaking information
+ *
+ * @param pdu Pointer to the first bit of a 1722 ACF CAN XL Brief PDU.
+ * @param payload_length Length of the CAN frame payload.
+ */
+OPEN1722_INLINE void Avtp_CanXlBrief_SetPayloadLength(Avtp_CanXlBrief_t *pdu,
+                                                      uint16_t payload_length)
+{
+    uint16_t msgLenBytes = AVTP_CANXL_BRIEF_HEADER_LEN + payload_length;
+    uint8_t pad = (uint8_t)(4 - (msgLenBytes % 4)) % 4;
+    if (pad > 0) {
+        memset(pdu->payload + payload_length, 0, pad);
+    }
+    uint16_t msgLenQuadlets = (uint16_t)((msgLenBytes + pad) / 4);
+    Avtp_CanXlBrief_SetPad(pdu, pad);
+    Avtp_CanXlBrief_SetAcfMsgLength(pdu, msgLenQuadlets);
+}
+
+/**
+ * Returns the length of the CAN payload without the padding bytes and the
+ * header length of the encapsulating ACF Frame.
+ *
+ * Precondition: the caller must have validated the PDU with
+ * Avtp_CanXlBrief_IsValid(). This function performs no further bounds
+ * checking and assumes those invariants already hold.
+ *
+ * @param pdu Pointer to the first bit of a 1722 ACF CAN XL Brief PDU.
+ * @return  Length of CAN payload in bytes
+ */
+OPEN1722_INLINE uint8_t Avtp_CanXlBrief_GetPayloadLength(const Avtp_CanXlBrief_t* const pdu)
+{
+    uint8_t pad_length = Avtp_CanXlBrief_GetPad(pdu);
+    uint16_t acf_length_bytes = Avtp_CanXlBrief_GetAcfMsgLengthInBytes(pdu);
+    return (uint8_t)(acf_length_bytes - AVTP_CANXL_BRIEF_HEADER_LEN - pad_length);
+}
+
+/**
+ * Initializes an ACF_CAN_XL_BRIEF message header as specified in the IEEE 1722 Specification.
+ *
+ * @param pdu Pointer to the first bit of a 1722 ACF CAN XL Brief PDU.
+ */
+OPEN1722_INLINE void Avtp_CanXlBrief_Init(Avtp_CanXlBrief_t* pdu)
+{
+    if (pdu != NULL) {
+        memset(pdu, 0, sizeof(Avtp_CanXlBrief_t));
+        Avtp_CanXlBrief_SetAcfMsgType(pdu, AVTP_ACF_TYPE_CAN_XL_BRIEF);
+    }
+}
+
+/**
+ * Copies the payload data, priority ID, acceptance field and SDT into the ACF CAN XL Brief frame.
+ * This function will also set the length and pad fields while inserting the padded bytes.
+ *
+ * @param pdu Pointer to the first bit of a 1722 ACF CAN XL Brief PDU.
+ * @param priority_id Priority ID
+ * @param acceptance_field Acceptance field
+ * @param sdt SDT value
+ * @param payload Pointer to the payload byte array
+ * @param payload_length Length of the payload.
+ */
+OPEN1722_INLINE void Avtp_CanXlBrief_CreateAcfMessage(Avtp_CanXlBrief_t *pdu, uint16_t priority_id,
+                                                      uint32_t acceptance_field, uint8_t sdt,
+                                                      uint8_t *payload, uint16_t payload_length)
+{
+    // Initialize the ACF CAN XL Brief header
+    Avtp_CanXlBrief_Init(pdu);
+
+    // Set the priority ID, acceptance field and SDT
+    Avtp_CanXlBrief_SetPriorityId(pdu, priority_id);
+    Avtp_CanXlBrief_SetAcceptanceField(pdu, acceptance_field);
+    Avtp_CanXlBrief_SetSdt(pdu, sdt);
+
+    // Copy the payload into the CAN PDU
+    Avtp_CanXlBrief_SetPayload(pdu, payload, payload_length);
+
+    // Finalize the AVTP CAN XL Brief Frame
+    Avtp_CanXlBrief_SetPayloadLength(pdu, payload_length);
+}
+
+/**
+ * Checks if the ACF CAN XL Brief frame is valid by checking:
+ *     1) if the length field of AVTP/ACF messages contains a value larger than the actual size of
+ * the buffer that contains the AVTP message. 2) if other format specific invariants are not upheld
+ * @param pdu Pointer to the first bit of a 1722 ACF CAN XL Brief PDU.
+ * @param bufferSize Size of the buffer containing the ACF CAN XL Brief frame.
+ * @return true if the ACF CAN XL Brief frame is valid, false otherwise.
+ */
+OPEN1722_INLINE bool Avtp_CanXlBrief_IsValid(const Avtp_CanXlBrief_t* const pdu, size_t bufferSize)
+{
+    if (pdu == NULL) {
+        return false;
+    }
+
+    if (bufferSize < AVTP_CANXL_BRIEF_HEADER_LEN) {
+        return false;
+    }
+
+    if (Avtp_CanXlBrief_GetAcfMsgType(pdu) != AVTP_ACF_TYPE_CAN_XL_BRIEF) {
+        return false;
+    }
+
+    // Avtp_CanXlBrief_GetAcfMsgLength returns quadlets. Convert the length field to octets.
+    uint16_t msg_length_bytes = (uint16_t)Avtp_CanXlBrief_GetAcfMsgLength(pdu) * 4;
+    if (msg_length_bytes > bufferSize) {
+        return false;
+    }
+
+    /* The encoded message length must accommodate header + declared padding
+     * so the payload computation in Avtp_CanXlBrief_GetPayloadLength()
+     * doesn't underflow. */
+    uint8_t pad_length = Avtp_CanXlBrief_GetPad(pdu);
+    uint16_t header_and_pad = (uint16_t)AVTP_CANXL_BRIEF_HEADER_LEN + pad_length;
+    if (msg_length_bytes < header_and_pad) {
+        return false;
+    }
+    return true;
 }
 
 #ifdef __cplusplus

--- a/include/avtp/acf/CanXlBrief.h
+++ b/include/avtp/acf/CanXlBrief.h
@@ -51,7 +51,7 @@ extern "C" {
 #define GET_CANXL_BRIEF_FIELD(field)                                                               \
     (Avtp_GetField(Avtp_CanXlBriefFieldDesc, AVTP_CANXL_BRIEF_FIELD_MAX, (uint8_t *)pdu, field))
 #define SET_CANXL_BRIEF_FIELD(field, value)                                                        \
-    (Avtp_SetField(Avtp_CanXlBriefFieldDesc, AVTP_CANXL_BRIEF_FIELD_MAX, (uint8_t *)pdu, field,   \
+    (Avtp_SetField(Avtp_CanXlBriefFieldDesc, AVTP_CANXL_BRIEF_FIELD_MAX, (uint8_t *)pdu, field,    \
                    value))
 
 /**
@@ -95,24 +95,23 @@ typedef enum {
 /**
  * This table describes all the offsets of the ACF_CAN_XL_BRIEF header fields.
  */
-static const Avtp_FieldDescriptor_t Avtp_CanXlBriefFieldDesc[AVTP_CANXL_BRIEF_FIELD_MAX] =
-{
+static const Avtp_FieldDescriptor_t Avtp_CanXlBriefFieldDesc[AVTP_CANXL_BRIEF_FIELD_MAX] = {
     /* ACF common header fields */
-    [AVTP_CANXL_BRIEF_FIELD_ACF_MSG_TYPE]           = { .quadlet = 0, .offset =  0, .bits = 7 },
-    [AVTP_CANXL_BRIEF_FIELD_ACF_MSG_LENGTH]         = { .quadlet = 0, .offset =  7, .bits = 9 },
+    [AVTP_CANXL_BRIEF_FIELD_ACF_MSG_TYPE] = {.quadlet = 0, .offset = 0, .bits = 7},
+    [AVTP_CANXL_BRIEF_FIELD_ACF_MSG_LENGTH] = {.quadlet = 0, .offset = 7, .bits = 9},
     /* ACF CAN_XL_BRIEF header fields */
-    [AVTP_CANXL_BRIEF_FIELD_PAD]                    = { .quadlet = 0, .offset = 16, .bits =   2 },
-    [AVTP_CANXL_BRIEF_FIELD_MTV]                    = { .quadlet = 0, .offset = 18, .bits =   1 },
-    [AVTP_CANXL_BRIEF_FIELD_CAN_BUS_ID]             = { .quadlet = 0, .offset = 21, .bits =  11 },
-    [AVTP_CANXL_BRIEF_FIELD_VCID]                   = { .quadlet = 1, .offset =  0, .bits =   8 },
-    [AVTP_CANXL_BRIEF_FIELD_SDT]                    = { .quadlet = 1, .offset =  8, .bits =   8 },
-    [AVTP_CANXL_BRIEF_FIELD_RRS]                    = { .quadlet = 1, .offset = 19, .bits =   1 },
-    [AVTP_CANXL_BRIEF_FIELD_SEC]                    = { .quadlet = 1, .offset = 20, .bits =   1 },
-    [AVTP_CANXL_BRIEF_FIELD_PRIORITY_ID]            = { .quadlet = 1, .offset = 21, .bits =  11 },
-    [AVTP_CANXL_BRIEF_FIELD_ACCEPTANCE_FIELD]       = { .quadlet = 2, .offset =  0, .bits =  32 },
-    [AVTP_CANXL_BRIEF_FIELD_TRANSACTION_NUM]        = { .quadlet = 3, .offset =  8, .bits =   8 },
-    [AVTP_CANXL_BRIEF_FIELD_MS]                     = { .quadlet = 3, .offset = 19, .bits =   1 },
-    [AVTP_CANXL_BRIEF_FIELD_SEGMENT_NUM]            = { .quadlet = 3, .offset = 20, .bits =  12 },
+    [AVTP_CANXL_BRIEF_FIELD_PAD] = {.quadlet = 0, .offset = 16, .bits = 2},
+    [AVTP_CANXL_BRIEF_FIELD_MTV] = {.quadlet = 0, .offset = 18, .bits = 1},
+    [AVTP_CANXL_BRIEF_FIELD_CAN_BUS_ID] = {.quadlet = 0, .offset = 21, .bits = 11},
+    [AVTP_CANXL_BRIEF_FIELD_VCID] = {.quadlet = 1, .offset = 0, .bits = 8},
+    [AVTP_CANXL_BRIEF_FIELD_SDT] = {.quadlet = 1, .offset = 8, .bits = 8},
+    [AVTP_CANXL_BRIEF_FIELD_RRS] = {.quadlet = 1, .offset = 19, .bits = 1},
+    [AVTP_CANXL_BRIEF_FIELD_SEC] = {.quadlet = 1, .offset = 20, .bits = 1},
+    [AVTP_CANXL_BRIEF_FIELD_PRIORITY_ID] = {.quadlet = 1, .offset = 21, .bits = 11},
+    [AVTP_CANXL_BRIEF_FIELD_ACCEPTANCE_FIELD] = {.quadlet = 2, .offset = 0, .bits = 32},
+    [AVTP_CANXL_BRIEF_FIELD_TRANSACTION_NUM] = {.quadlet = 3, .offset = 8, .bits = 8},
+    [AVTP_CANXL_BRIEF_FIELD_MS] = {.quadlet = 3, .offset = 19, .bits = 1},
+    [AVTP_CANXL_BRIEF_FIELD_SEGMENT_NUM] = {.quadlet = 3, .offset = 20, .bits = 12},
 };
 
 /**
@@ -121,8 +120,9 @@ static const Avtp_FieldDescriptor_t Avtp_CanXlBriefFieldDesc[AVTP_CANXL_BRIEF_FI
  * @param pdu Pointer to the first bit of a 1722 ACF CAN XL Brief PDU.
  * @returns Value of the ACF message type field.
  */
-OPEN1722_INLINE uint8_t Avtp_CanXlBrief_GetAcfMsgType(const Avtp_CanXlBrief_t* const pdu) {
-    return (uint8_t) GET_CANXL_BRIEF_FIELD(AVTP_CANXL_BRIEF_FIELD_ACF_MSG_TYPE);
+OPEN1722_INLINE uint8_t Avtp_CanXlBrief_GetAcfMsgType(const Avtp_CanXlBrief_t *const pdu)
+{
+    return (uint8_t)GET_CANXL_BRIEF_FIELD(AVTP_CANXL_BRIEF_FIELD_ACF_MSG_TYPE);
 }
 
 /**
@@ -134,8 +134,9 @@ OPEN1722_INLINE uint8_t Avtp_CanXlBrief_GetAcfMsgType(const Avtp_CanXlBrief_t* c
  * @param pdu Pointer to the first bit of a 1722 ACF CAN XL Brief PDU.
  * @returns Value of the ACF message length field.
  */
-OPEN1722_INLINE uint16_t Avtp_CanXlBrief_GetAcfMsgLength(const Avtp_CanXlBrief_t* const pdu) {
-    return (uint16_t) GET_CANXL_BRIEF_FIELD(AVTP_CANXL_BRIEF_FIELD_ACF_MSG_LENGTH);
+OPEN1722_INLINE uint16_t Avtp_CanXlBrief_GetAcfMsgLength(const Avtp_CanXlBrief_t *const pdu)
+{
+    return (uint16_t)GET_CANXL_BRIEF_FIELD(AVTP_CANXL_BRIEF_FIELD_ACF_MSG_LENGTH);
 }
 
 /**
@@ -144,8 +145,9 @@ OPEN1722_INLINE uint16_t Avtp_CanXlBrief_GetAcfMsgLength(const Avtp_CanXlBrief_t
  * @param pdu Pointer to the first bit of a 1722 ACF CAN XL Brief PDU.
  * @returns Length of the ACF message in bytes.
  */
-OPEN1722_INLINE uint16_t Avtp_CanXlBrief_GetAcfMsgLengthInBytes(const Avtp_CanXlBrief_t* const pdu) {
-    return (uint16_t) GET_CANXL_BRIEF_FIELD(AVTP_CANXL_BRIEF_FIELD_ACF_MSG_LENGTH) * 4;
+OPEN1722_INLINE uint16_t Avtp_CanXlBrief_GetAcfMsgLengthInBytes(const Avtp_CanXlBrief_t *const pdu)
+{
+    return (uint16_t)GET_CANXL_BRIEF_FIELD(AVTP_CANXL_BRIEF_FIELD_ACF_MSG_LENGTH) * 4;
 }
 
 /**
@@ -154,7 +156,8 @@ OPEN1722_INLINE uint16_t Avtp_CanXlBrief_GetAcfMsgLengthInBytes(const Avtp_CanXl
  * @param pdu Pointer to the first bit of a 1722 ACF CAN XL Brief PDU.
  * @param value Value to set the ACF message type field to.
  */
-OPEN1722_INLINE void Avtp_CanXlBrief_SetAcfMsgType(Avtp_CanXlBrief_t* pdu, uint8_t value) {
+OPEN1722_INLINE void Avtp_CanXlBrief_SetAcfMsgType(Avtp_CanXlBrief_t *pdu, uint8_t value)
+{
     SET_CANXL_BRIEF_FIELD(AVTP_CANXL_BRIEF_FIELD_ACF_MSG_TYPE, value);
 }
 
@@ -167,7 +170,8 @@ OPEN1722_INLINE void Avtp_CanXlBrief_SetAcfMsgType(Avtp_CanXlBrief_t* pdu, uint8
  * @param pdu Pointer to the first bit of a 1722 ACF CAN XL Brief PDU.
  * @param value Value to set the ACF message length field to.
  */
-OPEN1722_INLINE void Avtp_CanXlBrief_SetAcfMsgLength(Avtp_CanXlBrief_t* pdu, uint16_t value) {
+OPEN1722_INLINE void Avtp_CanXlBrief_SetAcfMsgLength(Avtp_CanXlBrief_t *pdu, uint16_t value)
+{
     SET_CANXL_BRIEF_FIELD(AVTP_CANXL_BRIEF_FIELD_ACF_MSG_LENGTH, value);
 }
 
@@ -177,8 +181,9 @@ OPEN1722_INLINE void Avtp_CanXlBrief_SetAcfMsgLength(Avtp_CanXlBrief_t* pdu, uin
  * @param pdu Pointer to an ACF_CAN_XL_BRIEF message.
  * @returns The value of the pad field.
  */
-OPEN1722_INLINE uint8_t Avtp_CanXlBrief_GetPad(const Avtp_CanXlBrief_t* const pdu) {
-    return (uint8_t) GET_CANXL_BRIEF_FIELD(AVTP_CANXL_BRIEF_FIELD_PAD);
+OPEN1722_INLINE uint8_t Avtp_CanXlBrief_GetPad(const Avtp_CanXlBrief_t *const pdu)
+{
+    return (uint8_t)GET_CANXL_BRIEF_FIELD(AVTP_CANXL_BRIEF_FIELD_PAD);
 }
 
 /**
@@ -187,7 +192,8 @@ OPEN1722_INLINE uint8_t Avtp_CanXlBrief_GetPad(const Avtp_CanXlBrief_t* const pd
  * @param pdu Pointer to an ACF_CAN_XL_BRIEF message.
  * @param pad The value to set.
  */
-OPEN1722_INLINE void Avtp_CanXlBrief_SetPad(Avtp_CanXlBrief_t* pdu, uint8_t pad) {
+OPEN1722_INLINE void Avtp_CanXlBrief_SetPad(Avtp_CanXlBrief_t *pdu, uint8_t pad)
+{
     SET_CANXL_BRIEF_FIELD(AVTP_CANXL_BRIEF_FIELD_PAD, pad);
 }
 
@@ -197,8 +203,9 @@ OPEN1722_INLINE void Avtp_CanXlBrief_SetPad(Avtp_CanXlBrief_t* pdu, uint8_t pad)
  * @param pdu Pointer to an ACF_CAN_XL_BRIEF message.
  * @returns The value of the mtv flag.
  */
-OPEN1722_INLINE bool Avtp_CanXlBrief_IsMtv(const Avtp_CanXlBrief_t* const pdu) {
-    return (bool) GET_CANXL_BRIEF_FIELD(AVTP_CANXL_BRIEF_FIELD_MTV);
+OPEN1722_INLINE bool Avtp_CanXlBrief_IsMtv(const Avtp_CanXlBrief_t *const pdu)
+{
+    return (bool)GET_CANXL_BRIEF_FIELD(AVTP_CANXL_BRIEF_FIELD_MTV);
 }
 
 /**
@@ -207,8 +214,9 @@ OPEN1722_INLINE bool Avtp_CanXlBrief_IsMtv(const Avtp_CanXlBrief_t* const pdu) {
  * @param pdu Pointer to an ACF_CAN_XL_BRIEF message.
  * @returns The value of the can_bus_id field.
  */
-OPEN1722_INLINE uint16_t Avtp_CanXlBrief_GetCanBusId(const Avtp_CanXlBrief_t* const pdu) {
-    return (uint16_t) GET_CANXL_BRIEF_FIELD(AVTP_CANXL_BRIEF_FIELD_CAN_BUS_ID);
+OPEN1722_INLINE uint16_t Avtp_CanXlBrief_GetCanBusId(const Avtp_CanXlBrief_t *const pdu)
+{
+    return (uint16_t)GET_CANXL_BRIEF_FIELD(AVTP_CANXL_BRIEF_FIELD_CAN_BUS_ID);
 }
 
 /**
@@ -217,8 +225,9 @@ OPEN1722_INLINE uint16_t Avtp_CanXlBrief_GetCanBusId(const Avtp_CanXlBrief_t* co
  * @param pdu Pointer to an ACF_CAN_XL_BRIEF message.
  * @returns The value of the vcid field.
  */
-OPEN1722_INLINE uint8_t Avtp_CanXlBrief_GetVcid(const Avtp_CanXlBrief_t* const pdu) {
-    return (uint8_t) GET_CANXL_BRIEF_FIELD(AVTP_CANXL_BRIEF_FIELD_VCID);
+OPEN1722_INLINE uint8_t Avtp_CanXlBrief_GetVcid(const Avtp_CanXlBrief_t *const pdu)
+{
+    return (uint8_t)GET_CANXL_BRIEF_FIELD(AVTP_CANXL_BRIEF_FIELD_VCID);
 }
 
 /**
@@ -227,8 +236,9 @@ OPEN1722_INLINE uint8_t Avtp_CanXlBrief_GetVcid(const Avtp_CanXlBrief_t* const p
  * @param pdu Pointer to an ACF_CAN_XL_BRIEF message.
  * @returns The value of the sdt field.
  */
-OPEN1722_INLINE uint8_t Avtp_CanXlBrief_GetSdt(const Avtp_CanXlBrief_t* const pdu) {
-    return (uint8_t) GET_CANXL_BRIEF_FIELD(AVTP_CANXL_BRIEF_FIELD_SDT);
+OPEN1722_INLINE uint8_t Avtp_CanXlBrief_GetSdt(const Avtp_CanXlBrief_t *const pdu)
+{
+    return (uint8_t)GET_CANXL_BRIEF_FIELD(AVTP_CANXL_BRIEF_FIELD_SDT);
 }
 
 /**
@@ -237,8 +247,9 @@ OPEN1722_INLINE uint8_t Avtp_CanXlBrief_GetSdt(const Avtp_CanXlBrief_t* const pd
  * @param pdu Pointer to an ACF_CAN_XL_BRIEF message.
  * @returns The value of the rrs flag.
  */
-OPEN1722_INLINE bool Avtp_CanXlBrief_IsRrs(const Avtp_CanXlBrief_t* const pdu) {
-    return (bool) GET_CANXL_BRIEF_FIELD(AVTP_CANXL_BRIEF_FIELD_RRS);
+OPEN1722_INLINE bool Avtp_CanXlBrief_IsRrs(const Avtp_CanXlBrief_t *const pdu)
+{
+    return (bool)GET_CANXL_BRIEF_FIELD(AVTP_CANXL_BRIEF_FIELD_RRS);
 }
 
 /**
@@ -247,8 +258,9 @@ OPEN1722_INLINE bool Avtp_CanXlBrief_IsRrs(const Avtp_CanXlBrief_t* const pdu) {
  * @param pdu Pointer to an ACF_CAN_XL_BRIEF message.
  * @returns The value of the sec flag.
  */
-OPEN1722_INLINE bool Avtp_CanXlBrief_IsSec(const Avtp_CanXlBrief_t* const pdu) {
-    return (bool) GET_CANXL_BRIEF_FIELD(AVTP_CANXL_BRIEF_FIELD_SEC);
+OPEN1722_INLINE bool Avtp_CanXlBrief_IsSec(const Avtp_CanXlBrief_t *const pdu)
+{
+    return (bool)GET_CANXL_BRIEF_FIELD(AVTP_CANXL_BRIEF_FIELD_SEC);
 }
 
 /**
@@ -257,8 +269,9 @@ OPEN1722_INLINE bool Avtp_CanXlBrief_IsSec(const Avtp_CanXlBrief_t* const pdu) {
  * @param pdu Pointer to an ACF_CAN_XL_BRIEF message.
  * @returns The value of the priority_id field.
  */
-OPEN1722_INLINE uint16_t Avtp_CanXlBrief_GetPriorityId(const Avtp_CanXlBrief_t* const pdu) {
-    return (uint16_t) GET_CANXL_BRIEF_FIELD(AVTP_CANXL_BRIEF_FIELD_PRIORITY_ID);
+OPEN1722_INLINE uint16_t Avtp_CanXlBrief_GetPriorityId(const Avtp_CanXlBrief_t *const pdu)
+{
+    return (uint16_t)GET_CANXL_BRIEF_FIELD(AVTP_CANXL_BRIEF_FIELD_PRIORITY_ID);
 }
 
 /**
@@ -267,8 +280,9 @@ OPEN1722_INLINE uint16_t Avtp_CanXlBrief_GetPriorityId(const Avtp_CanXlBrief_t* 
  * @param pdu Pointer to an ACF_CAN_XL_BRIEF message.
  * @returns The value of the acceptance_field.
  */
-OPEN1722_INLINE uint32_t Avtp_CanXlBrief_GetAcceptanceField(const Avtp_CanXlBrief_t* const pdu) {
-    return (uint32_t) GET_CANXL_BRIEF_FIELD(AVTP_CANXL_BRIEF_FIELD_ACCEPTANCE_FIELD);
+OPEN1722_INLINE uint32_t Avtp_CanXlBrief_GetAcceptanceField(const Avtp_CanXlBrief_t *const pdu)
+{
+    return (uint32_t)GET_CANXL_BRIEF_FIELD(AVTP_CANXL_BRIEF_FIELD_ACCEPTANCE_FIELD);
 }
 
 /**
@@ -277,8 +291,9 @@ OPEN1722_INLINE uint32_t Avtp_CanXlBrief_GetAcceptanceField(const Avtp_CanXlBrie
  * @param pdu Pointer to an ACF_CAN_XL_BRIEF message.
  * @returns The value of the transaction_num field.
  */
-OPEN1722_INLINE uint8_t Avtp_CanXlBrief_GetTransactionNum(const Avtp_CanXlBrief_t* const pdu) {
-    return (uint8_t) GET_CANXL_BRIEF_FIELD(AVTP_CANXL_BRIEF_FIELD_TRANSACTION_NUM);
+OPEN1722_INLINE uint8_t Avtp_CanXlBrief_GetTransactionNum(const Avtp_CanXlBrief_t *const pdu)
+{
+    return (uint8_t)GET_CANXL_BRIEF_FIELD(AVTP_CANXL_BRIEF_FIELD_TRANSACTION_NUM);
 }
 
 /**
@@ -287,8 +302,9 @@ OPEN1722_INLINE uint8_t Avtp_CanXlBrief_GetTransactionNum(const Avtp_CanXlBrief_
  * @param pdu Pointer to an ACF_CAN_XL_BRIEF message.
  * @returns The value of the ms flag.
  */
-OPEN1722_INLINE bool Avtp_CanXlBrief_IsMs(const Avtp_CanXlBrief_t* const pdu) {
-    return (bool) GET_CANXL_BRIEF_FIELD(AVTP_CANXL_BRIEF_FIELD_MS);
+OPEN1722_INLINE bool Avtp_CanXlBrief_IsMs(const Avtp_CanXlBrief_t *const pdu)
+{
+    return (bool)GET_CANXL_BRIEF_FIELD(AVTP_CANXL_BRIEF_FIELD_MS);
 }
 
 /**
@@ -297,8 +313,9 @@ OPEN1722_INLINE bool Avtp_CanXlBrief_IsMs(const Avtp_CanXlBrief_t* const pdu) {
  * @param pdu Pointer to an ACF_CAN_XL_BRIEF message.
  * @returns The value of the segment_num field.
  */
-OPEN1722_INLINE uint16_t Avtp_CanXlBrief_GetSegmentNum(const Avtp_CanXlBrief_t* const pdu) {
-    return (uint16_t) GET_CANXL_BRIEF_FIELD(AVTP_CANXL_BRIEF_FIELD_SEGMENT_NUM);
+OPEN1722_INLINE uint16_t Avtp_CanXlBrief_GetSegmentNum(const Avtp_CanXlBrief_t *const pdu)
+{
+    return (uint16_t)GET_CANXL_BRIEF_FIELD(AVTP_CANXL_BRIEF_FIELD_SEGMENT_NUM);
 }
 
 /**
@@ -307,7 +324,8 @@ OPEN1722_INLINE uint16_t Avtp_CanXlBrief_GetSegmentNum(const Avtp_CanXlBrief_t* 
  * @param pdu Pointer to an ACF_CAN_XL_BRIEF message.
  * @param mtv The value to set.
  */
-OPEN1722_INLINE void Avtp_CanXlBrief_SetMtv(Avtp_CanXlBrief_t* pdu, bool mtv) {
+OPEN1722_INLINE void Avtp_CanXlBrief_SetMtv(Avtp_CanXlBrief_t *pdu, bool mtv)
+{
     SET_CANXL_BRIEF_FIELD(AVTP_CANXL_BRIEF_FIELD_MTV, mtv);
 }
 
@@ -317,7 +335,8 @@ OPEN1722_INLINE void Avtp_CanXlBrief_SetMtv(Avtp_CanXlBrief_t* pdu, bool mtv) {
  * @param pdu Pointer to an ACF_CAN_XL_BRIEF message.
  * @param canBusId The value to set.
  */
-OPEN1722_INLINE void Avtp_CanXlBrief_SetCanBusId(Avtp_CanXlBrief_t* pdu, uint16_t canBusId) {
+OPEN1722_INLINE void Avtp_CanXlBrief_SetCanBusId(Avtp_CanXlBrief_t *pdu, uint16_t canBusId)
+{
     SET_CANXL_BRIEF_FIELD(AVTP_CANXL_BRIEF_FIELD_CAN_BUS_ID, canBusId);
 }
 
@@ -327,7 +346,8 @@ OPEN1722_INLINE void Avtp_CanXlBrief_SetCanBusId(Avtp_CanXlBrief_t* pdu, uint16_
  * @param pdu Pointer to an ACF_CAN_XL_BRIEF message.
  * @param vcid The value to set.
  */
-OPEN1722_INLINE void Avtp_CanXlBrief_SetVcid(Avtp_CanXlBrief_t* pdu, uint8_t vcid) {
+OPEN1722_INLINE void Avtp_CanXlBrief_SetVcid(Avtp_CanXlBrief_t *pdu, uint8_t vcid)
+{
     SET_CANXL_BRIEF_FIELD(AVTP_CANXL_BRIEF_FIELD_VCID, vcid);
 }
 
@@ -337,7 +357,8 @@ OPEN1722_INLINE void Avtp_CanXlBrief_SetVcid(Avtp_CanXlBrief_t* pdu, uint8_t vci
  * @param pdu Pointer to an ACF_CAN_XL_BRIEF message.
  * @param sdt The value to set.
  */
-OPEN1722_INLINE void Avtp_CanXlBrief_SetSdt(Avtp_CanXlBrief_t* pdu, uint8_t sdt) {
+OPEN1722_INLINE void Avtp_CanXlBrief_SetSdt(Avtp_CanXlBrief_t *pdu, uint8_t sdt)
+{
     SET_CANXL_BRIEF_FIELD(AVTP_CANXL_BRIEF_FIELD_SDT, sdt);
 }
 
@@ -347,7 +368,8 @@ OPEN1722_INLINE void Avtp_CanXlBrief_SetSdt(Avtp_CanXlBrief_t* pdu, uint8_t sdt)
  * @param pdu Pointer to an ACF_CAN_XL_BRIEF message.
  * @param rrs The value to set.
  */
-OPEN1722_INLINE void Avtp_CanXlBrief_SetRrs(Avtp_CanXlBrief_t* pdu, bool rrs) {
+OPEN1722_INLINE void Avtp_CanXlBrief_SetRrs(Avtp_CanXlBrief_t *pdu, bool rrs)
+{
     SET_CANXL_BRIEF_FIELD(AVTP_CANXL_BRIEF_FIELD_RRS, rrs);
 }
 
@@ -357,7 +379,8 @@ OPEN1722_INLINE void Avtp_CanXlBrief_SetRrs(Avtp_CanXlBrief_t* pdu, bool rrs) {
  * @param pdu Pointer to an ACF_CAN_XL_BRIEF message.
  * @param sec The value to set.
  */
-OPEN1722_INLINE void Avtp_CanXlBrief_SetSec(Avtp_CanXlBrief_t* pdu, bool sec) {
+OPEN1722_INLINE void Avtp_CanXlBrief_SetSec(Avtp_CanXlBrief_t *pdu, bool sec)
+{
     SET_CANXL_BRIEF_FIELD(AVTP_CANXL_BRIEF_FIELD_SEC, sec);
 }
 
@@ -367,7 +390,8 @@ OPEN1722_INLINE void Avtp_CanXlBrief_SetSec(Avtp_CanXlBrief_t* pdu, bool sec) {
  * @param pdu Pointer to an ACF_CAN_XL_BRIEF message.
  * @param priorityId The value to set.
  */
-OPEN1722_INLINE void Avtp_CanXlBrief_SetPriorityId(Avtp_CanXlBrief_t* pdu, uint16_t priorityId) {
+OPEN1722_INLINE void Avtp_CanXlBrief_SetPriorityId(Avtp_CanXlBrief_t *pdu, uint16_t priorityId)
+{
     SET_CANXL_BRIEF_FIELD(AVTP_CANXL_BRIEF_FIELD_PRIORITY_ID, priorityId);
 }
 
@@ -377,8 +401,9 @@ OPEN1722_INLINE void Avtp_CanXlBrief_SetPriorityId(Avtp_CanXlBrief_t* pdu, uint1
  * @param pdu Pointer to an ACF_CAN_XL_BRIEF message.
  * @param acceptanceField The value to set.
  */
-OPEN1722_INLINE void Avtp_CanXlBrief_SetAcceptanceField(Avtp_CanXlBrief_t* pdu,
-                                                        uint32_t acceptanceField) {
+OPEN1722_INLINE void Avtp_CanXlBrief_SetAcceptanceField(Avtp_CanXlBrief_t *pdu,
+                                                        uint32_t acceptanceField)
+{
     SET_CANXL_BRIEF_FIELD(AVTP_CANXL_BRIEF_FIELD_ACCEPTANCE_FIELD, acceptanceField);
 }
 
@@ -388,8 +413,9 @@ OPEN1722_INLINE void Avtp_CanXlBrief_SetAcceptanceField(Avtp_CanXlBrief_t* pdu,
  * @param pdu Pointer to an ACF_CAN_XL_BRIEF message.
  * @param transactionNum The value to set.
  */
-OPEN1722_INLINE void Avtp_CanXlBrief_SetTransactionNum(Avtp_CanXlBrief_t* pdu,
-                                                       uint8_t transactionNum) {
+OPEN1722_INLINE void Avtp_CanXlBrief_SetTransactionNum(Avtp_CanXlBrief_t *pdu,
+                                                       uint8_t transactionNum)
+{
     SET_CANXL_BRIEF_FIELD(AVTP_CANXL_BRIEF_FIELD_TRANSACTION_NUM, transactionNum);
 }
 
@@ -399,7 +425,8 @@ OPEN1722_INLINE void Avtp_CanXlBrief_SetTransactionNum(Avtp_CanXlBrief_t* pdu,
  * @param pdu Pointer to an ACF_CAN_XL_BRIEF message.
  * @param ms The value to set.
  */
-OPEN1722_INLINE void Avtp_CanXlBrief_SetMs(Avtp_CanXlBrief_t* pdu, bool ms) {
+OPEN1722_INLINE void Avtp_CanXlBrief_SetMs(Avtp_CanXlBrief_t *pdu, bool ms)
+{
     SET_CANXL_BRIEF_FIELD(AVTP_CANXL_BRIEF_FIELD_MS, ms);
 }
 
@@ -409,7 +436,8 @@ OPEN1722_INLINE void Avtp_CanXlBrief_SetMs(Avtp_CanXlBrief_t* pdu, bool ms) {
  * @param pdu Pointer to an ACF_CAN_XL_BRIEF message.
  * @param segmentNum The value to set.
  */
-OPEN1722_INLINE void Avtp_CanXlBrief_SetSegmentNum(Avtp_CanXlBrief_t* pdu, uint16_t segmentNum) {
+OPEN1722_INLINE void Avtp_CanXlBrief_SetSegmentNum(Avtp_CanXlBrief_t *pdu, uint16_t segmentNum)
+{
     SET_CANXL_BRIEF_FIELD(AVTP_CANXL_BRIEF_FIELD_SEGMENT_NUM, segmentNum);
 }
 
@@ -419,7 +447,7 @@ OPEN1722_INLINE void Avtp_CanXlBrief_SetSegmentNum(Avtp_CanXlBrief_t* pdu, uint1
  * @param pdu Pointer to the first bit of a 1722 ACF CAN XL Brief PDU.
  * @return Pointer to ACF CAN XL Brief frame payload
  */
-OPEN1722_INLINE const uint8_t *Avtp_CanXlBrief_GetPayload(const Avtp_CanXlBrief_t* const pdu)
+OPEN1722_INLINE const uint8_t *Avtp_CanXlBrief_GetPayload(const Avtp_CanXlBrief_t *const pdu)
 {
     return pdu->payload;
 }
@@ -470,7 +498,7 @@ OPEN1722_INLINE void Avtp_CanXlBrief_SetPayloadLength(Avtp_CanXlBrief_t *pdu,
  * @param pdu Pointer to the first bit of a 1722 ACF CAN XL Brief PDU.
  * @return  Length of CAN payload in bytes
  */
-OPEN1722_INLINE uint8_t Avtp_CanXlBrief_GetPayloadLength(const Avtp_CanXlBrief_t* const pdu)
+OPEN1722_INLINE uint8_t Avtp_CanXlBrief_GetPayloadLength(const Avtp_CanXlBrief_t *const pdu)
 {
     uint8_t pad_length = Avtp_CanXlBrief_GetPad(pdu);
     uint16_t acf_length_bytes = Avtp_CanXlBrief_GetAcfMsgLengthInBytes(pdu);
@@ -482,7 +510,7 @@ OPEN1722_INLINE uint8_t Avtp_CanXlBrief_GetPayloadLength(const Avtp_CanXlBrief_t
  *
  * @param pdu Pointer to the first bit of a 1722 ACF CAN XL Brief PDU.
  */
-OPEN1722_INLINE void Avtp_CanXlBrief_Init(Avtp_CanXlBrief_t* pdu)
+OPEN1722_INLINE void Avtp_CanXlBrief_Init(Avtp_CanXlBrief_t *pdu)
 {
     if (pdu != NULL) {
         memset(pdu, 0, sizeof(Avtp_CanXlBrief_t));
@@ -528,7 +556,7 @@ OPEN1722_INLINE void Avtp_CanXlBrief_CreateAcfMessage(Avtp_CanXlBrief_t *pdu, ui
  * @param bufferSize Size of the buffer containing the ACF CAN XL Brief frame.
  * @return true if the ACF CAN XL Brief frame is valid, false otherwise.
  */
-OPEN1722_INLINE bool Avtp_CanXlBrief_IsValid(const Avtp_CanXlBrief_t* const pdu, size_t bufferSize)
+OPEN1722_INLINE bool Avtp_CanXlBrief_IsValid(const Avtp_CanXlBrief_t *const pdu, size_t bufferSize)
 {
     if (pdu == NULL) {
         return false;

--- a/unit/test-canxl-brief.c
+++ b/unit/test-canxl-brief.c
@@ -44,10 +44,14 @@ static void Test_CanXlBrief_Init(void** state)
     const size_t msg_len = AVTP_CANXL_BRIEF_HEADER_LEN + 4;
     uint8_t msg[msg_len] = {0};
     Avtp_CanXlBrief_t* canxl = (Avtp_CanXlBrief_t*)msg;
+
+    // Check init function while passing in a null pointer
+    Avtp_CanXlBrief_Init(NULL);
+
     Avtp_CanXlBrief_Init(canxl);
 
     uint8_t expected_msg[msg_len] = {
-        0x24, 0x04, 0x0,  0x0,
+        0x24, 0x00, 0x0,  0x0,
         0x0,  0x0,  0x0,  0x0,
         0x0,  0x0,  0x0,  0x0,
         0x0,  0x0,  0x0,  0x0,
@@ -55,6 +59,34 @@ static void Test_CanXlBrief_Init(void** state)
     };
 
     assert_memory_equal(msg, expected_msg, msg_len);
+}
+
+static void Test_CanXlBrief_GetAcfMsgType(void** state)
+{
+    const size_t msg_len = AVTP_CANXL_BRIEF_HEADER_LEN + 4;
+    uint8_t msg[msg_len] = {
+        0x24, 0x04, 0x0,  0x0,
+        0x0,  0x0,  0x0,  0x0,
+        0x0,  0x0,  0x0,  0x0,
+        0x0,  0x0,  0x0,  0x0,
+        0x0,  0x0,  0x0,  0x0
+    };
+    Avtp_CanXlBrief_t* canxl = (Avtp_CanXlBrief_t*)msg;
+    assert_int_equal(Avtp_CanXlBrief_GetAcfMsgType(canxl), AVTP_ACF_TYPE_CAN_XL_BRIEF);
+}
+
+static void Test_CanXlBrief_GetAcfMsgLength(void** state)
+{
+    const size_t msg_len = AVTP_CANXL_BRIEF_HEADER_LEN + 4;
+    uint8_t msg[msg_len] = {
+        0x24, 0x04, 0x0,  0x0,
+        0x0,  0x0,  0x0,  0x0,
+        0x0,  0x0,  0x0,  0x0,
+        0x0,  0x0,  0x0,  0x0,
+        0x0,  0x0,  0x0,  0x0
+    };
+    Avtp_CanXlBrief_t* canxl = (Avtp_CanXlBrief_t*)msg;
+    assert_int_equal(Avtp_CanXlBrief_GetAcfMsgLength(canxl), 4);
 }
 
 static void Test_CanXlBrief_GetPad(void** state)
@@ -225,21 +257,21 @@ static void Test_CanXlBrief_GetSegmentNum(void** state)
     assert_int_equal(Avtp_CanXlBrief_GetSegmentNum(canxl), 0xBFF);
 }
 
-static void Test_CanXlBrief_GetPayloadLen(void** state)
+static void Test_CanXlBrief_GetPayloadLength(void** state)
 {
     const size_t msg_len = AVTP_CANXL_BRIEF_HEADER_LEN + 4;
     uint8_t msg[msg_len] = {
         0x24, 0x05, 0xC0, 0x0,
         0x0,  0x0,  0x0,  0x0,
         0x0,  0x0,  0x0,  0x0,
-        0x0,  0x0, 0x0,  0x0,
+        0x0,  0x0,  0x0,  0x0,
         0x0,  0x0,  0x0,  0x0
     };
     Avtp_CanXlBrief_t* canxl = (Avtp_CanXlBrief_t*)msg;
-    assert_int_equal(Avtp_CanXlBrief_GetPayloadLen(canxl), 1);
+    assert_int_equal(Avtp_CanXlBrief_GetPayloadLength(canxl), 1);
 }
 
-static void Test_CanXlBrief_GetPayloadLen_NoPadding(void** state)
+static void Test_CanXlBrief_GetPayloadLength_NoPadding(void** state)
 {
     const size_t msg_len = AVTP_CANXL_BRIEF_HEADER_LEN + 4;
     uint8_t msg[msg_len] = {
@@ -250,10 +282,10 @@ static void Test_CanXlBrief_GetPayloadLen_NoPadding(void** state)
         0x0,  0x0,  0x0,  0x0
     };
     Avtp_CanXlBrief_t* canxl = (Avtp_CanXlBrief_t*)msg;
-    assert_int_equal(Avtp_CanXlBrief_GetPayloadLen(canxl), 4);
+    assert_int_equal(Avtp_CanXlBrief_GetPayloadLength(canxl), 4);
 }
 
-static void Test_CanXlBrief_GetLen(void** state)
+static void Test_CanXlBrief_GetAcfMsgLengthInBytes(void** state)
 {
     const size_t msg_len = AVTP_CANXL_BRIEF_HEADER_LEN + 4;
     uint8_t msg[msg_len] = {
@@ -264,7 +296,28 @@ static void Test_CanXlBrief_GetLen(void** state)
         0x0,  0x0,  0x0,  0x0
     };
     Avtp_CanXlBrief_t* canxl = (Avtp_CanXlBrief_t*)msg;
-    assert_int_equal(Avtp_CanXlBrief_GetLen(canxl), 5 * 4);
+    assert_int_equal(Avtp_CanXlBrief_GetAcfMsgLengthInBytes(canxl), 5 * 4);
+}
+
+static void Test_CanXlBrief_SetAcfMsgType(void** state)
+{
+    const size_t msg_len = AVTP_CANXL_BRIEF_HEADER_LEN + 4;
+    uint8_t msg[msg_len] = {0};
+    Avtp_CanXlBrief_t* canxl = (Avtp_CanXlBrief_t*)msg;
+    Avtp_CanXlBrief_Init(canxl);
+    Avtp_CanXlBrief_SetAcfMsgType(canxl, AVTP_ACF_TYPE_CAN_XL_BRIEF);
+    assert_int_equal(Avtp_CanXlBrief_GetAcfMsgType(canxl), AVTP_ACF_TYPE_CAN_XL_BRIEF);
+}
+
+static void Test_CanXlBrief_SetAcfMsgLength(void** state)
+{
+    const size_t msg_len = AVTP_CANXL_BRIEF_HEADER_LEN + 4;
+    uint8_t msg[msg_len] = {0};
+    Avtp_CanXlBrief_t* canxl = (Avtp_CanXlBrief_t*)msg;
+    Avtp_CanXlBrief_Init(canxl);
+    Avtp_CanXlBrief_SetAcfMsgLength(canxl, 5);
+    assert_int_equal(Avtp_CanXlBrief_GetAcfMsgLength(canxl), 5);
+    assert_int_equal(Avtp_CanXlBrief_GetAcfMsgLengthInBytes(canxl), 20);
 }
 
 static void Test_CanXlBrief_SetMtv(void** state)
@@ -276,7 +329,7 @@ static void Test_CanXlBrief_SetMtv(void** state)
     Avtp_CanXlBrief_SetMtv(canxl, true);
 
     uint8_t expected_msg[msg_len] = {
-        0x24, 0x04, 0x20, 0x0,
+        0x24, 0x00, 0x20, 0x0,
         0x0,  0x0,  0x0,  0x0,
         0x0,  0x0,  0x0,  0x0,
         0x0,  0x0,  0x0,  0x0,
@@ -294,7 +347,7 @@ static void Test_CanXlBrief_SetCanBusId(void** state)
     Avtp_CanXlBrief_SetCanBusId(canxl, 0x5FF);
 
     uint8_t expected_msg[msg_len] = {
-        0x24, 0x04, 0x05, 0xFF,
+        0x24, 0x00, 0x05, 0xFF,
         0x0,  0x0,  0x0,  0x0,
         0x0,  0x0,  0x0,  0x0,
         0x0,  0x0,  0x0,  0x0,
@@ -312,7 +365,7 @@ static void Test_CanXlBrief_SetVcid(void** state)
     Avtp_CanXlBrief_SetVcid(canxl, 0xBF);
 
     uint8_t expected_msg[msg_len] = {
-        0x24, 0x04, 0x0,  0x0,
+        0x24, 0x00, 0x0,  0x0,
         0xBF, 0x0,  0x0,  0x0,
         0x0,  0x0,  0x0,  0x0,
         0x0,  0x0,  0x0,  0x0,
@@ -330,7 +383,7 @@ static void Test_CanXlBrief_SetSdt(void** state)
     Avtp_CanXlBrief_SetSdt(canxl, 0xBF);
 
     uint8_t expected_msg[msg_len] = {
-        0x24, 0x04, 0x0,  0x0,
+        0x24, 0x00, 0x0,  0x0,
         0x0,  0xBF, 0x0,  0x0,
         0x0,  0x0,  0x0,  0x0,
         0x0,  0x0,  0x0,  0x0,
@@ -348,7 +401,7 @@ static void Test_CanXlBrief_SetRrs(void** state)
     Avtp_CanXlBrief_SetRrs(canxl, true);
 
     uint8_t expected_msg[msg_len] = {
-        0x24, 0x04, 0x0,  0x0,
+        0x24, 0x00, 0x0,  0x0,
         0x0,  0x0,  0x10, 0x0,
         0x0,  0x0,  0x0,  0x0,
         0x0,  0x0,  0x0,  0x0,
@@ -366,7 +419,7 @@ static void Test_CanXlBrief_SetSec(void** state)
     Avtp_CanXlBrief_SetSec(canxl, true);
 
     uint8_t expected_msg[msg_len] = {
-        0x24, 0x04, 0x0,  0x0,
+        0x24, 0x00, 0x0,  0x0,
         0x0,  0x0,  0x8,  0x0,
         0x0,  0x0,  0x0,  0x0,
         0x0,  0x0,  0x0,  0x0,
@@ -384,7 +437,7 @@ static void Test_CanXlBrief_SetPriorityId(void** state)
     Avtp_CanXlBrief_SetPriorityId(canxl, 0x5FF);
 
     uint8_t expected_msg[msg_len] = {
-        0x24, 0x04, 0x0,  0x0,
+        0x24, 0x00, 0x0,  0x0,
         0x0,  0x0,  0x05, 0xFF,
         0x0,  0x0,  0x0,  0x0,
         0x0,  0x0,  0x0,  0x0,
@@ -402,7 +455,7 @@ static void Test_CanXlBrief_SetAcceptanceField(void** state)
     Avtp_CanXlBrief_SetAcceptanceField(canxl, 0xBFFFFFFFul);
 
     uint8_t expected_msg[msg_len] = {
-        0x24, 0x04, 0x0,  0x0,
+        0x24, 0x00, 0x0,  0x0,
         0x0,  0x0,  0x0,  0x0,
         0xBF, 0xFF, 0xFF, 0xFF,
         0x0,  0x0,  0x0,  0x0,
@@ -420,7 +473,7 @@ static void Test_CanXlBrief_SetTransactionNum(void** state)
     Avtp_CanXlBrief_SetTransactionNum(canxl, 0xBF);
 
     uint8_t expected_msg[msg_len] = {
-        0x24, 0x04, 0x0,  0x0,
+        0x24, 0x00, 0x0,  0x0,
         0x0,  0x0,  0x0,  0x0,
         0x0,  0x0,  0x0,  0x0,
         0x0,  0xBF, 0x0,  0x0,
@@ -438,7 +491,7 @@ static void Test_CanXlBrief_SetMs(void** state)
     Avtp_CanXlBrief_SetMs(canxl, true);
 
     uint8_t expected_msg[msg_len] = {
-        0x24, 0x04, 0x0,  0x0,
+        0x24, 0x00, 0x0,  0x0,
         0x0,  0x0,  0x0,  0x0,
         0x0,  0x0,  0x0,  0x0,
         0x0,  0x0,  0x10, 0x0,
@@ -456,7 +509,7 @@ static void Test_CanXlBrief_SetSegmentNum(void** state)
     Avtp_CanXlBrief_SetSegmentNum(canxl, 0xBFF);
 
     uint8_t expected_msg[msg_len] = {
-        0x24, 0x04, 0x0,  0x0,
+        0x24, 0x00, 0x0,  0x0,
         0x0,  0x0,  0x0,  0x0,
         0x0,  0x0,  0x0,  0x0,
         0x0,  0x0,  0x0B, 0xFF,
@@ -465,13 +518,13 @@ static void Test_CanXlBrief_SetSegmentNum(void** state)
     assert_memory_equal(msg, expected_msg, msg_len);
 }
 
-static void Test_CanXlBrief_SetPayloadLen(void** state)
+static void Test_CanXlBrief_SetPayloadLength(void** state)
 {
     const size_t msg_len = AVTP_CANXL_BRIEF_HEADER_LEN + 4;
     uint8_t msg[msg_len] = {0};
     Avtp_CanXlBrief_t* canxl = (Avtp_CanXlBrief_t*)msg;
     Avtp_CanXlBrief_Init(canxl);
-    Avtp_CanXlBrief_SetPayloadLen(canxl, 3);
+    Avtp_CanXlBrief_SetPayloadLength(canxl, 3);
 
     uint8_t expected_msg[msg_len] = {
         0x24, 0x05, 0x40, 0x0,
@@ -483,13 +536,13 @@ static void Test_CanXlBrief_SetPayloadLen(void** state)
     assert_memory_equal(msg, expected_msg, msg_len);
 }
 
-static void Test_CanXlBrief_SetPayloadLen_NoPadding(void** state)
+static void Test_CanXlBrief_SetPayloadLength_NoPadding(void** state)
 {
     const size_t msg_len = AVTP_CANXL_BRIEF_HEADER_LEN + 4;
     uint8_t msg[msg_len] = {0};
     Avtp_CanXlBrief_t* canxl = (Avtp_CanXlBrief_t*)msg;
     Avtp_CanXlBrief_Init(canxl);
-    Avtp_CanXlBrief_SetPayloadLen(canxl, 4);
+    Avtp_CanXlBrief_SetPayloadLength(canxl, 4);
 
     uint8_t expected_msg[msg_len] = {
         0x24, 0x05, 0x0,  0x0,
@@ -501,10 +554,94 @@ static void Test_CanXlBrief_SetPayloadLen_NoPadding(void** state)
     assert_memory_equal(msg, expected_msg, msg_len);
 }
 
+static void Test_CanXlBrief_Payload(void** state)
+{
+    const size_t msg_len = AVTP_CANXL_BRIEF_HEADER_LEN + 8;
+    uint8_t msg[msg_len] = {0};
+    Avtp_CanXlBrief_t* canxl = (Avtp_CanXlBrief_t*)msg;
+    uint8_t payload[8] = {0,1,2,3,4,5,6,7};
+
+    Avtp_CanXlBrief_Init(canxl);
+    Avtp_CanXlBrief_SetPayload(canxl, payload, sizeof(payload));
+
+    assert_ptr_equal(Avtp_CanXlBrief_GetPayload(canxl), msg + AVTP_CANXL_BRIEF_HEADER_LEN);
+    assert_memory_equal(payload, Avtp_CanXlBrief_GetPayload(canxl), sizeof(payload));
+}
+
+static void Test_CanXlBrief_CreateAcfMessage(void** state)
+{
+    const size_t msg_len = AVTP_CANXL_BRIEF_HEADER_LEN + 8;
+    uint8_t msg[msg_len] = {0};
+    Avtp_CanXlBrief_t* canxl = (Avtp_CanXlBrief_t*)msg;
+    uint8_t payload[8] = {0,1,2,3,4,5,6,7};
+
+    Avtp_CanXlBrief_CreateAcfMessage(canxl, 0x5FF, 0xBFFFFFFFul, 0xBF, payload, sizeof(payload));
+
+    assert_int_equal(Avtp_CanXlBrief_GetAcfMsgType(canxl), AVTP_ACF_TYPE_CAN_XL_BRIEF);
+    assert_int_equal(Avtp_CanXlBrief_GetPriorityId(canxl), 0x5FF);
+    assert_int_equal(Avtp_CanXlBrief_GetAcceptanceField(canxl), 0xBFFFFFFFul);
+    assert_int_equal(Avtp_CanXlBrief_GetSdt(canxl), 0xBF);
+    assert_memory_equal(payload, msg + AVTP_CANXL_BRIEF_HEADER_LEN, sizeof(payload));
+    assert_int_equal(Avtp_CanXlBrief_GetPayloadLength(canxl), 8);
+
+    // can_bus_id and vcid are set by the caller afterwards
+    Avtp_CanXlBrief_SetCanBusId(canxl, 0x5FF);
+    Avtp_CanXlBrief_SetVcid(canxl, 0xBF);
+    assert_int_equal(Avtp_CanXlBrief_GetCanBusId(canxl), 0x5FF);
+    assert_int_equal(Avtp_CanXlBrief_GetVcid(canxl), 0xBF);
+}
+
+static void Test_CanXlBrief_CreateFromGarbage(void** state)
+{
+    const size_t msg_len = AVTP_CANXL_BRIEF_HEADER_LEN + 8;
+    uint8_t msg[msg_len];
+    Avtp_CanXlBrief_t* canxl = (Avtp_CanXlBrief_t*)msg;
+    uint8_t payload[8] = {0,1,2,3,4,5,6,7};
+
+    // CreateAcfMessage must fully initialize the header even on garbage input.
+    memset(msg, 0xAA, msg_len);
+    Avtp_CanXlBrief_CreateAcfMessage(canxl, 0x5FF, 0x0, 0x0, payload, sizeof(payload));
+
+    assert_int_equal(Avtp_CanXlBrief_GetAcfMsgType(canxl), AVTP_ACF_TYPE_CAN_XL_BRIEF);
+    assert_int_equal(Avtp_CanXlBrief_IsMtv(canxl), false);
+    assert_int_equal(Avtp_CanXlBrief_IsRrs(canxl), false);
+    assert_int_equal(Avtp_CanXlBrief_IsSec(canxl), false);
+    assert_int_equal(Avtp_CanXlBrief_IsMs(canxl), false);
+    assert_int_equal(Avtp_CanXlBrief_GetCanBusId(canxl), 0);
+    assert_memory_equal(payload, msg + AVTP_CANXL_BRIEF_HEADER_LEN, sizeof(payload));
+    assert_int_equal(Avtp_CanXlBrief_IsValid(canxl, msg_len), 1);
+}
+
+static void Test_CanXlBrief_IsValid(void** state)
+{
+    const size_t msg_len = AVTP_CANXL_BRIEF_HEADER_LEN + 32;
+    uint8_t msg[msg_len] = {0};
+    Avtp_CanXlBrief_t* canxl = (Avtp_CanXlBrief_t*)msg;
+    uint8_t payload[8] = {0,1,2,3,4,5,6,7};
+
+    // An Init-only PDU has AcfMsgLength == 0, so IsValid must reject it.
+    Avtp_CanXlBrief_Init(canxl);
+    assert_int_equal(Avtp_CanXlBrief_IsValid(canxl, msg_len), 0);
+
+    // A properly-formed frame with an 8-byte payload is valid.
+    Avtp_CanXlBrief_CreateAcfMessage(canxl, 0x5FF, 0x0, 0x0, payload, sizeof(payload));
+    assert_int_equal(Avtp_CanXlBrief_IsValid(canxl, msg_len), 1);
+
+    // Not a CAN XL Brief message (zero buffer, AcfMsgType != CAN_XL_BRIEF).
+    memset(msg, 0, msg_len);
+    assert_int_equal(Avtp_CanXlBrief_IsValid(canxl, msg_len), 0);
+
+    // Declared length larger than the buffer is invalid.
+    Avtp_CanXlBrief_CreateAcfMessage(canxl, 0x5FF, 0x0, 0x0, payload, sizeof(payload));
+    assert_int_equal(Avtp_CanXlBrief_IsValid(canxl, AVTP_CANXL_BRIEF_HEADER_LEN + 1), 0);
+}
+
 int main(void)
 {
     const struct CMUnitTest tests[] = {
         cmocka_unit_test(Test_CanXlBrief_Init),
+        cmocka_unit_test(Test_CanXlBrief_GetAcfMsgType),
+        cmocka_unit_test(Test_CanXlBrief_GetAcfMsgLength),
         cmocka_unit_test(Test_CanXlBrief_GetPad),
         cmocka_unit_test(Test_CanXlBrief_IsMtv),
         cmocka_unit_test(Test_CanXlBrief_GetCanBusId),
@@ -517,9 +654,11 @@ int main(void)
         cmocka_unit_test(Test_CanXlBrief_GetTransactionNum),
         cmocka_unit_test(Test_CanXlBrief_IsMs),
         cmocka_unit_test(Test_CanXlBrief_GetSegmentNum),
-        cmocka_unit_test(Test_CanXlBrief_GetPayloadLen),
-        cmocka_unit_test(Test_CanXlBrief_GetPayloadLen_NoPadding),
-        cmocka_unit_test(Test_CanXlBrief_GetLen),
+        cmocka_unit_test(Test_CanXlBrief_GetPayloadLength),
+        cmocka_unit_test(Test_CanXlBrief_GetPayloadLength_NoPadding),
+        cmocka_unit_test(Test_CanXlBrief_GetAcfMsgLengthInBytes),
+        cmocka_unit_test(Test_CanXlBrief_SetAcfMsgType),
+        cmocka_unit_test(Test_CanXlBrief_SetAcfMsgLength),
         cmocka_unit_test(Test_CanXlBrief_SetMtv),
         cmocka_unit_test(Test_CanXlBrief_SetCanBusId),
         cmocka_unit_test(Test_CanXlBrief_SetVcid),
@@ -531,8 +670,12 @@ int main(void)
         cmocka_unit_test(Test_CanXlBrief_SetTransactionNum),
         cmocka_unit_test(Test_CanXlBrief_SetMs),
         cmocka_unit_test(Test_CanXlBrief_SetSegmentNum),
-        cmocka_unit_test(Test_CanXlBrief_SetPayloadLen),
-        cmocka_unit_test(Test_CanXlBrief_SetPayloadLen_NoPadding)
+        cmocka_unit_test(Test_CanXlBrief_SetPayloadLength),
+        cmocka_unit_test(Test_CanXlBrief_SetPayloadLength_NoPadding),
+        cmocka_unit_test(Test_CanXlBrief_Payload),
+        cmocka_unit_test(Test_CanXlBrief_CreateAcfMessage),
+        cmocka_unit_test(Test_CanXlBrief_CreateFromGarbage),
+        cmocka_unit_test(Test_CanXlBrief_IsValid)
     };
 
     return cmocka_run_group_tests(tests, NULL, NULL);

--- a/unit/test-canxl-brief.c
+++ b/unit/test-canxl-brief.c
@@ -39,527 +39,372 @@ extern "C" {
 #include <cmocka.h>
 #include <stdio.h>
 
-static void Test_CanXlBrief_Init(void** state)
+static void Test_CanXlBrief_Init(void **state)
 {
     const size_t msg_len = AVTP_CANXL_BRIEF_HEADER_LEN + 4;
     uint8_t msg[msg_len] = {0};
-    Avtp_CanXlBrief_t* canxl = (Avtp_CanXlBrief_t*)msg;
+    Avtp_CanXlBrief_t *canxl = (Avtp_CanXlBrief_t *)msg;
 
     // Check init function while passing in a null pointer
     Avtp_CanXlBrief_Init(NULL);
 
     Avtp_CanXlBrief_Init(canxl);
 
-    uint8_t expected_msg[msg_len] = {
-        0x24, 0x00, 0x0,  0x0,
-        0x0,  0x0,  0x0,  0x0,
-        0x0,  0x0,  0x0,  0x0,
-        0x0,  0x0,  0x0,  0x0,
-        0x0,  0x0,  0x0,  0x0
-    };
+    uint8_t expected_msg[msg_len] = {0x24, 0x00, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0,
+                                     0x0,  0x0,  0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0};
 
     assert_memory_equal(msg, expected_msg, msg_len);
 }
 
-static void Test_CanXlBrief_GetAcfMsgType(void** state)
+static void Test_CanXlBrief_GetAcfMsgType(void **state)
 {
     const size_t msg_len = AVTP_CANXL_BRIEF_HEADER_LEN + 4;
-    uint8_t msg[msg_len] = {
-        0x24, 0x04, 0x0,  0x0,
-        0x0,  0x0,  0x0,  0x0,
-        0x0,  0x0,  0x0,  0x0,
-        0x0,  0x0,  0x0,  0x0,
-        0x0,  0x0,  0x0,  0x0
-    };
-    Avtp_CanXlBrief_t* canxl = (Avtp_CanXlBrief_t*)msg;
+    uint8_t msg[msg_len] = {0x24, 0x04, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0,
+                            0x0,  0x0,  0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0};
+    Avtp_CanXlBrief_t *canxl = (Avtp_CanXlBrief_t *)msg;
     assert_int_equal(Avtp_CanXlBrief_GetAcfMsgType(canxl), AVTP_ACF_TYPE_CAN_XL_BRIEF);
 }
 
-static void Test_CanXlBrief_GetAcfMsgLength(void** state)
+static void Test_CanXlBrief_GetAcfMsgLength(void **state)
 {
     const size_t msg_len = AVTP_CANXL_BRIEF_HEADER_LEN + 4;
-    uint8_t msg[msg_len] = {
-        0x24, 0x04, 0x0,  0x0,
-        0x0,  0x0,  0x0,  0x0,
-        0x0,  0x0,  0x0,  0x0,
-        0x0,  0x0,  0x0,  0x0,
-        0x0,  0x0,  0x0,  0x0
-    };
-    Avtp_CanXlBrief_t* canxl = (Avtp_CanXlBrief_t*)msg;
+    uint8_t msg[msg_len] = {0x24, 0x04, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0,
+                            0x0,  0x0,  0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0};
+    Avtp_CanXlBrief_t *canxl = (Avtp_CanXlBrief_t *)msg;
     assert_int_equal(Avtp_CanXlBrief_GetAcfMsgLength(canxl), 4);
 }
 
-static void Test_CanXlBrief_GetPad(void** state)
+static void Test_CanXlBrief_GetPad(void **state)
 {
     const size_t msg_len = AVTP_CANXL_BRIEF_HEADER_LEN + 4;
-    uint8_t msg[msg_len] = {
-        0x24, 0x04, 0xC0, 0x0,
-        0x0,  0x0,  0x0,  0x0,
-        0x0,  0x0,  0x0,  0x0,
-        0x0,  0x0,  0x0,  0x0,
-        0x0,  0x0,  0x0,  0x0
-    };
-    Avtp_CanXlBrief_t* canxl = (Avtp_CanXlBrief_t*)msg;
+    uint8_t msg[msg_len] = {0x24, 0x04, 0xC0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0,
+                            0x0,  0x0,  0x0,  0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0};
+    Avtp_CanXlBrief_t *canxl = (Avtp_CanXlBrief_t *)msg;
     assert_int_equal(Avtp_CanXlBrief_GetPad(canxl), 3);
 }
 
-static void Test_CanXlBrief_IsMtv(void** state)
+static void Test_CanXlBrief_IsMtv(void **state)
 {
     const size_t msg_len = AVTP_CANXL_BRIEF_HEADER_LEN + 4;
-    uint8_t msg[msg_len] = {
-        0x24, 0x04, 0x20, 0x0,
-        0x0,  0x0,  0x0,  0x0,
-        0x0,  0x0,  0x0,  0x0,
-        0x0,  0x0,  0x0,  0x0,
-        0x0,  0x0,  0x0,  0x0
-    };
-    Avtp_CanXlBrief_t* canxl = (Avtp_CanXlBrief_t*)msg;
+    uint8_t msg[msg_len] = {0x24, 0x04, 0x20, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0,
+                            0x0,  0x0,  0x0,  0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0};
+    Avtp_CanXlBrief_t *canxl = (Avtp_CanXlBrief_t *)msg;
     assert_int_equal(Avtp_CanXlBrief_IsMtv(canxl), true);
 }
 
-static void Test_CanXlBrief_GetCanBusId(void** state)
+static void Test_CanXlBrief_GetCanBusId(void **state)
 {
     const size_t msg_len = AVTP_CANXL_BRIEF_HEADER_LEN + 4;
-    uint8_t msg[msg_len] = {
-        0x24, 0x04, 0x05, 0xFF,
-        0x0,  0x0,  0x0,  0x0,
-        0x0,  0x0,  0x0,  0x0,
-        0x0,  0x0,  0x0,  0x0,
-        0x0,  0x0,  0x0,  0x0
-    };
-    Avtp_CanXlBrief_t* canxl = (Avtp_CanXlBrief_t*)msg;
+    uint8_t msg[msg_len] = {0x24, 0x04, 0x05, 0xFF, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0,
+                            0x0,  0x0,  0x0,  0x0,  0x0, 0x0, 0x0, 0x0, 0x0, 0x0};
+    Avtp_CanXlBrief_t *canxl = (Avtp_CanXlBrief_t *)msg;
     assert_int_equal(Avtp_CanXlBrief_GetCanBusId(canxl), 0x5FF);
 }
 
-static void Test_CanXlBrief_GetVcid(void** state)
+static void Test_CanXlBrief_GetVcid(void **state)
 {
     const size_t msg_len = AVTP_CANXL_BRIEF_HEADER_LEN + 4;
-    uint8_t msg[msg_len] = {
-        0x24, 0x04, 0x0,  0x0,
-        0xBF, 0x0,  0x0,  0x0,
-        0x0,  0x0,  0x0,  0x0,
-        0x0,  0x0,  0x0,  0x0,
-        0x0,  0x0,  0x0,  0x0
-    };
-    Avtp_CanXlBrief_t* canxl = (Avtp_CanXlBrief_t*)msg;
+    uint8_t msg[msg_len] = {0x24, 0x04, 0x0, 0x0, 0xBF, 0x0, 0x0, 0x0, 0x0, 0x0,
+                            0x0,  0x0,  0x0, 0x0, 0x0,  0x0, 0x0, 0x0, 0x0, 0x0};
+    Avtp_CanXlBrief_t *canxl = (Avtp_CanXlBrief_t *)msg;
     assert_int_equal(Avtp_CanXlBrief_GetVcid(canxl), 0xBF);
 }
 
-static void Test_CanXlBrief_GetSdt(void** state)
+static void Test_CanXlBrief_GetSdt(void **state)
 {
     const size_t msg_len = AVTP_CANXL_BRIEF_HEADER_LEN + 4;
-    uint8_t msg[msg_len] = {
-        0x24, 0x04, 0x0,  0x0,
-        0x0,  0xBF, 0x0,  0x0,
-        0x0,  0x0,  0x0,  0x0,
-        0x0,  0x0,  0x0,  0x0,
-        0x0,  0x0,  0x0,  0x0
-    };
-    Avtp_CanXlBrief_t* canxl = (Avtp_CanXlBrief_t*)msg;
+    uint8_t msg[msg_len] = {0x24, 0x04, 0x0, 0x0, 0x0, 0xBF, 0x0, 0x0, 0x0, 0x0,
+                            0x0,  0x0,  0x0, 0x0, 0x0, 0x0,  0x0, 0x0, 0x0, 0x0};
+    Avtp_CanXlBrief_t *canxl = (Avtp_CanXlBrief_t *)msg;
     assert_int_equal(Avtp_CanXlBrief_GetSdt(canxl), 0xBF);
 }
 
-static void Test_CanXlBrief_IsRrs(void** state)
+static void Test_CanXlBrief_IsRrs(void **state)
 {
     const size_t msg_len = AVTP_CANXL_BRIEF_HEADER_LEN + 4;
-    uint8_t msg[msg_len] = {
-        0x24, 0x04, 0x0,  0x0,
-        0x0,  0x0,  0x10, 0x0,
-        0x0,  0x0,  0x0,  0x0,
-        0x0,  0x0,  0x0,  0x0,
-        0x0,  0x0,  0x0,  0x0
-    };
-    Avtp_CanXlBrief_t* canxl = (Avtp_CanXlBrief_t*)msg;
+    uint8_t msg[msg_len] = {0x24, 0x04, 0x0, 0x0, 0x0, 0x0, 0x10, 0x0, 0x0, 0x0,
+                            0x0,  0x0,  0x0, 0x0, 0x0, 0x0, 0x0,  0x0, 0x0, 0x0};
+    Avtp_CanXlBrief_t *canxl = (Avtp_CanXlBrief_t *)msg;
     assert_int_equal(Avtp_CanXlBrief_IsRrs(canxl), true);
 }
 
-static void Test_CanXlBrief_IsSec(void** state)
+static void Test_CanXlBrief_IsSec(void **state)
 {
     const size_t msg_len = AVTP_CANXL_BRIEF_HEADER_LEN + 4;
-    uint8_t msg[msg_len] = {
-        0x24, 0x04, 0x0,  0x0,
-        0x0,  0x0,  0x08, 0x0,
-        0x0,  0x0,  0x0,  0x0,
-        0x0,  0x0,  0x0,  0x0,
-        0x0,  0x0,  0x0,  0x0
-    };
-    Avtp_CanXlBrief_t* canxl = (Avtp_CanXlBrief_t*)msg;
+    uint8_t msg[msg_len] = {0x24, 0x04, 0x0, 0x0, 0x0, 0x0, 0x08, 0x0, 0x0, 0x0,
+                            0x0,  0x0,  0x0, 0x0, 0x0, 0x0, 0x0,  0x0, 0x0, 0x0};
+    Avtp_CanXlBrief_t *canxl = (Avtp_CanXlBrief_t *)msg;
     assert_int_equal(Avtp_CanXlBrief_IsSec(canxl), true);
 }
 
-static void Test_CanXlBrief_GetPriorityId(void** state)
+static void Test_CanXlBrief_GetPriorityId(void **state)
 {
     const size_t msg_len = AVTP_CANXL_BRIEF_HEADER_LEN + 4;
-    uint8_t msg[msg_len] = {
-        0x24, 0x04, 0x0,  0x0,
-        0x0,  0x0,  0x05, 0xFF,
-        0x0,  0x0,  0x0,  0x0,
-        0x0,  0x0,  0x0,  0x0,
-        0x0,  0x0,  0x0,  0x0
-    };
-    Avtp_CanXlBrief_t* canxl = (Avtp_CanXlBrief_t*)msg;
+    uint8_t msg[msg_len] = {0x24, 0x04, 0x0, 0x0, 0x0, 0x0, 0x05, 0xFF, 0x0, 0x0,
+                            0x0,  0x0,  0x0, 0x0, 0x0, 0x0, 0x0,  0x0,  0x0, 0x0};
+    Avtp_CanXlBrief_t *canxl = (Avtp_CanXlBrief_t *)msg;
     assert_int_equal(Avtp_CanXlBrief_GetPriorityId(canxl), 0x5FF);
 }
 
-static void Test_CanXlBrief_GetAcceptanceField(void** state)
+static void Test_CanXlBrief_GetAcceptanceField(void **state)
 {
     const size_t msg_len = AVTP_CANXL_BRIEF_HEADER_LEN + 4;
-    uint8_t msg[msg_len] = {
-        0x24, 0x04, 0x0,  0x0,
-        0x0,  0x0,  0x0,  0x0,
-        0xBF, 0xFF, 0xFF, 0xFF,
-        0x0,  0x0,  0x0,  0x0,
-        0x0,  0x0,  0x0,  0x0
-    };
-    Avtp_CanXlBrief_t* canxl = (Avtp_CanXlBrief_t*)msg;
+    uint8_t msg[msg_len] = {0x24, 0x04, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0xBF, 0xFF,
+                            0xFF, 0xFF, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0,  0x0};
+    Avtp_CanXlBrief_t *canxl = (Avtp_CanXlBrief_t *)msg;
     assert_int_equal(Avtp_CanXlBrief_GetAcceptanceField(canxl), 0xBFFFFFFFul);
 }
 
-static void Test_CanXlBrief_GetTransactionNum(void** state)
+static void Test_CanXlBrief_GetTransactionNum(void **state)
 {
     const size_t msg_len = AVTP_CANXL_BRIEF_HEADER_LEN + 4;
-    uint8_t msg[msg_len] = {
-        0x24, 0x04, 0x0,  0x0,
-        0x0,  0x0,  0x0,  0x0,
-        0x0,  0x0,  0x0,  0x0,
-        0x0,  0xBF, 0x0,  0x0,
-        0x0,  0x0,  0x0,  0x0
-    };
-    Avtp_CanXlBrief_t* canxl = (Avtp_CanXlBrief_t*)msg;
+    uint8_t msg[msg_len] = {0x24, 0x04, 0x0, 0x0,  0x0, 0x0, 0x0, 0x0, 0x0, 0x0,
+                            0x0,  0x0,  0x0, 0xBF, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0};
+    Avtp_CanXlBrief_t *canxl = (Avtp_CanXlBrief_t *)msg;
     assert_int_equal(Avtp_CanXlBrief_GetTransactionNum(canxl), 0xBF);
 }
 
-static void Test_CanXlBrief_IsMs(void** state)
+static void Test_CanXlBrief_IsMs(void **state)
 {
     const size_t msg_len = AVTP_CANXL_BRIEF_HEADER_LEN + 4;
-    uint8_t msg[msg_len] = {
-        0x24, 0x04, 0x0,  0x0,
-        0x0,  0x0,  0x0,  0x0,
-        0x0,  0x0,  0x0,  0x0,
-        0x0,  0x0,  0x10, 0x0,
-        0x0,  0x0,  0x0,  0x0
-    };
-    Avtp_CanXlBrief_t* canxl = (Avtp_CanXlBrief_t*)msg;
+    uint8_t msg[msg_len] = {0x24, 0x04, 0x0, 0x0, 0x0,  0x0, 0x0, 0x0, 0x0, 0x0,
+                            0x0,  0x0,  0x0, 0x0, 0x10, 0x0, 0x0, 0x0, 0x0, 0x0};
+    Avtp_CanXlBrief_t *canxl = (Avtp_CanXlBrief_t *)msg;
     assert_int_equal(Avtp_CanXlBrief_IsMs(canxl), true);
 }
 
-static void Test_CanXlBrief_GetSegmentNum(void** state)
+static void Test_CanXlBrief_GetSegmentNum(void **state)
 {
     const size_t msg_len = AVTP_CANXL_BRIEF_HEADER_LEN + 4;
-    uint8_t msg[msg_len] = {
-        0x24, 0x04, 0x0,  0x0,
-        0x0,  0x0,  0x0,  0x0,
-        0x0,  0x0,  0x0,  0x0,
-        0x0,  0x0,  0xB,  0xFF,
-        0x0,  0x0,  0x0,  0x0
-    };
-    Avtp_CanXlBrief_t* canxl = (Avtp_CanXlBrief_t*)msg;
+    uint8_t msg[msg_len] = {0x24, 0x04, 0x0, 0x0, 0x0, 0x0,  0x0, 0x0, 0x0, 0x0,
+                            0x0,  0x0,  0x0, 0x0, 0xB, 0xFF, 0x0, 0x0, 0x0, 0x0};
+    Avtp_CanXlBrief_t *canxl = (Avtp_CanXlBrief_t *)msg;
     assert_int_equal(Avtp_CanXlBrief_GetSegmentNum(canxl), 0xBFF);
 }
 
-static void Test_CanXlBrief_GetPayloadLength(void** state)
+static void Test_CanXlBrief_GetPayloadLength(void **state)
 {
     const size_t msg_len = AVTP_CANXL_BRIEF_HEADER_LEN + 4;
-    uint8_t msg[msg_len] = {
-        0x24, 0x05, 0xC0, 0x0,
-        0x0,  0x0,  0x0,  0x0,
-        0x0,  0x0,  0x0,  0x0,
-        0x0,  0x0,  0x0,  0x0,
-        0x0,  0x0,  0x0,  0x0
-    };
-    Avtp_CanXlBrief_t* canxl = (Avtp_CanXlBrief_t*)msg;
+    uint8_t msg[msg_len] = {0x24, 0x05, 0xC0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0,
+                            0x0,  0x0,  0x0,  0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0};
+    Avtp_CanXlBrief_t *canxl = (Avtp_CanXlBrief_t *)msg;
     assert_int_equal(Avtp_CanXlBrief_GetPayloadLength(canxl), 1);
 }
 
-static void Test_CanXlBrief_GetPayloadLength_NoPadding(void** state)
+static void Test_CanXlBrief_GetPayloadLength_NoPadding(void **state)
 {
     const size_t msg_len = AVTP_CANXL_BRIEF_HEADER_LEN + 4;
-    uint8_t msg[msg_len] = {
-        0x24, 0x05, 0x0,  0x0,
-        0x0,  0x0,  0x0,  0x0,
-        0x0,  0x0,  0x0,  0x0,
-        0x0,  0x0,  0x0,  0x0,
-        0x0,  0x0,  0x0,  0x0
-    };
-    Avtp_CanXlBrief_t* canxl = (Avtp_CanXlBrief_t*)msg;
+    uint8_t msg[msg_len] = {0x24, 0x05, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0,
+                            0x0,  0x0,  0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0};
+    Avtp_CanXlBrief_t *canxl = (Avtp_CanXlBrief_t *)msg;
     assert_int_equal(Avtp_CanXlBrief_GetPayloadLength(canxl), 4);
 }
 
-static void Test_CanXlBrief_GetAcfMsgLengthInBytes(void** state)
+static void Test_CanXlBrief_GetAcfMsgLengthInBytes(void **state)
 {
     const size_t msg_len = AVTP_CANXL_BRIEF_HEADER_LEN + 4;
-    uint8_t msg[msg_len] = {
-        0x24, 0x05, 0x0,  0x0,
-        0x0,  0x0,  0x0,  0x0,
-        0x0,  0x0,  0x0,  0x0,
-        0x0,  0x0,  0x0,  0x0,
-        0x0,  0x0,  0x0,  0x0
-    };
-    Avtp_CanXlBrief_t* canxl = (Avtp_CanXlBrief_t*)msg;
+    uint8_t msg[msg_len] = {0x24, 0x05, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0,
+                            0x0,  0x0,  0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0};
+    Avtp_CanXlBrief_t *canxl = (Avtp_CanXlBrief_t *)msg;
     assert_int_equal(Avtp_CanXlBrief_GetAcfMsgLengthInBytes(canxl), 5 * 4);
 }
 
-static void Test_CanXlBrief_SetAcfMsgType(void** state)
+static void Test_CanXlBrief_SetAcfMsgType(void **state)
 {
     const size_t msg_len = AVTP_CANXL_BRIEF_HEADER_LEN + 4;
     uint8_t msg[msg_len] = {0};
-    Avtp_CanXlBrief_t* canxl = (Avtp_CanXlBrief_t*)msg;
+    Avtp_CanXlBrief_t *canxl = (Avtp_CanXlBrief_t *)msg;
     Avtp_CanXlBrief_Init(canxl);
     Avtp_CanXlBrief_SetAcfMsgType(canxl, AVTP_ACF_TYPE_CAN_XL_BRIEF);
     assert_int_equal(Avtp_CanXlBrief_GetAcfMsgType(canxl), AVTP_ACF_TYPE_CAN_XL_BRIEF);
 }
 
-static void Test_CanXlBrief_SetAcfMsgLength(void** state)
+static void Test_CanXlBrief_SetAcfMsgLength(void **state)
 {
     const size_t msg_len = AVTP_CANXL_BRIEF_HEADER_LEN + 4;
     uint8_t msg[msg_len] = {0};
-    Avtp_CanXlBrief_t* canxl = (Avtp_CanXlBrief_t*)msg;
+    Avtp_CanXlBrief_t *canxl = (Avtp_CanXlBrief_t *)msg;
     Avtp_CanXlBrief_Init(canxl);
     Avtp_CanXlBrief_SetAcfMsgLength(canxl, 5);
     assert_int_equal(Avtp_CanXlBrief_GetAcfMsgLength(canxl), 5);
     assert_int_equal(Avtp_CanXlBrief_GetAcfMsgLengthInBytes(canxl), 20);
 }
 
-static void Test_CanXlBrief_SetMtv(void** state)
+static void Test_CanXlBrief_SetMtv(void **state)
 {
     const size_t msg_len = AVTP_CANXL_BRIEF_HEADER_LEN + 4;
     uint8_t msg[msg_len] = {0};
-    Avtp_CanXlBrief_t* canxl = (Avtp_CanXlBrief_t*)msg;
+    Avtp_CanXlBrief_t *canxl = (Avtp_CanXlBrief_t *)msg;
     Avtp_CanXlBrief_Init(canxl);
     Avtp_CanXlBrief_SetMtv(canxl, true);
 
-    uint8_t expected_msg[msg_len] = {
-        0x24, 0x00, 0x20, 0x0,
-        0x0,  0x0,  0x0,  0x0,
-        0x0,  0x0,  0x0,  0x0,
-        0x0,  0x0,  0x0,  0x0,
-        0x0,  0x0,  0x0,  0x0
-    };
+    uint8_t expected_msg[msg_len] = {0x24, 0x00, 0x20, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0,
+                                     0x0,  0x0,  0x0,  0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0};
     assert_memory_equal(msg, expected_msg, msg_len);
 }
 
-static void Test_CanXlBrief_SetCanBusId(void** state)
+static void Test_CanXlBrief_SetCanBusId(void **state)
 {
     const size_t msg_len = AVTP_CANXL_BRIEF_HEADER_LEN + 4;
     uint8_t msg[msg_len] = {0};
-    Avtp_CanXlBrief_t* canxl = (Avtp_CanXlBrief_t*)msg;
+    Avtp_CanXlBrief_t *canxl = (Avtp_CanXlBrief_t *)msg;
     Avtp_CanXlBrief_Init(canxl);
     Avtp_CanXlBrief_SetCanBusId(canxl, 0x5FF);
 
-    uint8_t expected_msg[msg_len] = {
-        0x24, 0x00, 0x05, 0xFF,
-        0x0,  0x0,  0x0,  0x0,
-        0x0,  0x0,  0x0,  0x0,
-        0x0,  0x0,  0x0,  0x0,
-        0x0,  0x0,  0x0,  0x0
-    };
+    uint8_t expected_msg[msg_len] = {0x24, 0x00, 0x05, 0xFF, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0,
+                                     0x0,  0x0,  0x0,  0x0,  0x0, 0x0, 0x0, 0x0, 0x0, 0x0};
     assert_memory_equal(msg, expected_msg, msg_len);
 }
 
-static void Test_CanXlBrief_SetVcid(void** state)
+static void Test_CanXlBrief_SetVcid(void **state)
 {
     const size_t msg_len = AVTP_CANXL_BRIEF_HEADER_LEN + 4;
     uint8_t msg[msg_len] = {0};
-    Avtp_CanXlBrief_t* canxl = (Avtp_CanXlBrief_t*)msg;
+    Avtp_CanXlBrief_t *canxl = (Avtp_CanXlBrief_t *)msg;
     Avtp_CanXlBrief_Init(canxl);
     Avtp_CanXlBrief_SetVcid(canxl, 0xBF);
 
-    uint8_t expected_msg[msg_len] = {
-        0x24, 0x00, 0x0,  0x0,
-        0xBF, 0x0,  0x0,  0x0,
-        0x0,  0x0,  0x0,  0x0,
-        0x0,  0x0,  0x0,  0x0,
-        0x0,  0x0,  0x0,  0x0
-    };
+    uint8_t expected_msg[msg_len] = {0x24, 0x00, 0x0, 0x0, 0xBF, 0x0, 0x0, 0x0, 0x0, 0x0,
+                                     0x0,  0x0,  0x0, 0x0, 0x0,  0x0, 0x0, 0x0, 0x0, 0x0};
     assert_memory_equal(msg, expected_msg, msg_len);
 }
 
-static void Test_CanXlBrief_SetSdt(void** state)
+static void Test_CanXlBrief_SetSdt(void **state)
 {
     const size_t msg_len = AVTP_CANXL_BRIEF_HEADER_LEN + 4;
     uint8_t msg[msg_len] = {0};
-    Avtp_CanXlBrief_t* canxl = (Avtp_CanXlBrief_t*)msg;
+    Avtp_CanXlBrief_t *canxl = (Avtp_CanXlBrief_t *)msg;
     Avtp_CanXlBrief_Init(canxl);
     Avtp_CanXlBrief_SetSdt(canxl, 0xBF);
 
-    uint8_t expected_msg[msg_len] = {
-        0x24, 0x00, 0x0,  0x0,
-        0x0,  0xBF, 0x0,  0x0,
-        0x0,  0x0,  0x0,  0x0,
-        0x0,  0x0,  0x0,  0x0,
-        0x0,  0x0,  0x0,  0x0
-    };
+    uint8_t expected_msg[msg_len] = {0x24, 0x00, 0x0, 0x0, 0x0, 0xBF, 0x0, 0x0, 0x0, 0x0,
+                                     0x0,  0x0,  0x0, 0x0, 0x0, 0x0,  0x0, 0x0, 0x0, 0x0};
     assert_memory_equal(msg, expected_msg, msg_len);
 }
 
-static void Test_CanXlBrief_SetRrs(void** state)
+static void Test_CanXlBrief_SetRrs(void **state)
 {
     const size_t msg_len = AVTP_CANXL_BRIEF_HEADER_LEN + 4;
     uint8_t msg[msg_len] = {0};
-    Avtp_CanXlBrief_t* canxl = (Avtp_CanXlBrief_t*)msg;
+    Avtp_CanXlBrief_t *canxl = (Avtp_CanXlBrief_t *)msg;
     Avtp_CanXlBrief_Init(canxl);
     Avtp_CanXlBrief_SetRrs(canxl, true);
 
-    uint8_t expected_msg[msg_len] = {
-        0x24, 0x00, 0x0,  0x0,
-        0x0,  0x0,  0x10, 0x0,
-        0x0,  0x0,  0x0,  0x0,
-        0x0,  0x0,  0x0,  0x0,
-        0x0,  0x0,  0x0,  0x0
-    };
+    uint8_t expected_msg[msg_len] = {0x24, 0x00, 0x0, 0x0, 0x0, 0x0, 0x10, 0x0, 0x0, 0x0,
+                                     0x0,  0x0,  0x0, 0x0, 0x0, 0x0, 0x0,  0x0, 0x0, 0x0};
     assert_memory_equal(msg, expected_msg, msg_len);
 }
 
-static void Test_CanXlBrief_SetSec(void** state)
+static void Test_CanXlBrief_SetSec(void **state)
 {
     const size_t msg_len = AVTP_CANXL_BRIEF_HEADER_LEN + 4;
     uint8_t msg[msg_len] = {0};
-    Avtp_CanXlBrief_t* canxl = (Avtp_CanXlBrief_t*)msg;
+    Avtp_CanXlBrief_t *canxl = (Avtp_CanXlBrief_t *)msg;
     Avtp_CanXlBrief_Init(canxl);
     Avtp_CanXlBrief_SetSec(canxl, true);
 
-    uint8_t expected_msg[msg_len] = {
-        0x24, 0x00, 0x0,  0x0,
-        0x0,  0x0,  0x8,  0x0,
-        0x0,  0x0,  0x0,  0x0,
-        0x0,  0x0,  0x0,  0x0,
-        0x0,  0x0,  0x0,  0x0
-    };
+    uint8_t expected_msg[msg_len] = {0x24, 0x00, 0x0, 0x0, 0x0, 0x0, 0x8, 0x0, 0x0, 0x0,
+                                     0x0,  0x0,  0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0};
     assert_memory_equal(msg, expected_msg, msg_len);
 }
 
-static void Test_CanXlBrief_SetPriorityId(void** state)
+static void Test_CanXlBrief_SetPriorityId(void **state)
 {
     const size_t msg_len = AVTP_CANXL_BRIEF_HEADER_LEN + 4;
     uint8_t msg[msg_len] = {0};
-    Avtp_CanXlBrief_t* canxl = (Avtp_CanXlBrief_t*)msg;
+    Avtp_CanXlBrief_t *canxl = (Avtp_CanXlBrief_t *)msg;
     Avtp_CanXlBrief_Init(canxl);
     Avtp_CanXlBrief_SetPriorityId(canxl, 0x5FF);
 
-    uint8_t expected_msg[msg_len] = {
-        0x24, 0x00, 0x0,  0x0,
-        0x0,  0x0,  0x05, 0xFF,
-        0x0,  0x0,  0x0,  0x0,
-        0x0,  0x0,  0x0,  0x0,
-        0x0,  0x0,  0x0,  0x0
-    };
+    uint8_t expected_msg[msg_len] = {0x24, 0x00, 0x0, 0x0, 0x0, 0x0, 0x05, 0xFF, 0x0, 0x0,
+                                     0x0,  0x0,  0x0, 0x0, 0x0, 0x0, 0x0,  0x0,  0x0, 0x0};
     assert_memory_equal(msg, expected_msg, msg_len);
 }
 
-static void Test_CanXlBrief_SetAcceptanceField(void** state)
+static void Test_CanXlBrief_SetAcceptanceField(void **state)
 {
     const size_t msg_len = AVTP_CANXL_BRIEF_HEADER_LEN + 4;
     uint8_t msg[msg_len] = {0};
-    Avtp_CanXlBrief_t* canxl = (Avtp_CanXlBrief_t*)msg;
+    Avtp_CanXlBrief_t *canxl = (Avtp_CanXlBrief_t *)msg;
     Avtp_CanXlBrief_Init(canxl);
     Avtp_CanXlBrief_SetAcceptanceField(canxl, 0xBFFFFFFFul);
 
-    uint8_t expected_msg[msg_len] = {
-        0x24, 0x00, 0x0,  0x0,
-        0x0,  0x0,  0x0,  0x0,
-        0xBF, 0xFF, 0xFF, 0xFF,
-        0x0,  0x0,  0x0,  0x0,
-        0x0,  0x0,  0x0,  0x0
-    };
+    uint8_t expected_msg[msg_len] = {0x24, 0x00, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0xBF, 0xFF,
+                                     0xFF, 0xFF, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0,  0x0};
     assert_memory_equal(msg, expected_msg, msg_len);
 }
 
-static void Test_CanXlBrief_SetTransactionNum(void** state)
+static void Test_CanXlBrief_SetTransactionNum(void **state)
 {
     const size_t msg_len = AVTP_CANXL_BRIEF_HEADER_LEN + 4;
     uint8_t msg[msg_len] = {0};
-    Avtp_CanXlBrief_t* canxl = (Avtp_CanXlBrief_t*)msg;
+    Avtp_CanXlBrief_t *canxl = (Avtp_CanXlBrief_t *)msg;
     Avtp_CanXlBrief_Init(canxl);
     Avtp_CanXlBrief_SetTransactionNum(canxl, 0xBF);
 
-    uint8_t expected_msg[msg_len] = {
-        0x24, 0x00, 0x0,  0x0,
-        0x0,  0x0,  0x0,  0x0,
-        0x0,  0x0,  0x0,  0x0,
-        0x0,  0xBF, 0x0,  0x0,
-        0x0,  0x0,  0x0,  0x0
-    };
+    uint8_t expected_msg[msg_len] = {0x24, 0x00, 0x0, 0x0,  0x0, 0x0, 0x0, 0x0, 0x0, 0x0,
+                                     0x0,  0x0,  0x0, 0xBF, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0};
     assert_memory_equal(msg, expected_msg, msg_len);
 }
 
-static void Test_CanXlBrief_SetMs(void** state)
+static void Test_CanXlBrief_SetMs(void **state)
 {
     const size_t msg_len = AVTP_CANXL_BRIEF_HEADER_LEN + 4;
     uint8_t msg[msg_len] = {0};
-    Avtp_CanXlBrief_t* canxl = (Avtp_CanXlBrief_t*)msg;
+    Avtp_CanXlBrief_t *canxl = (Avtp_CanXlBrief_t *)msg;
     Avtp_CanXlBrief_Init(canxl);
     Avtp_CanXlBrief_SetMs(canxl, true);
 
-    uint8_t expected_msg[msg_len] = {
-        0x24, 0x00, 0x0,  0x0,
-        0x0,  0x0,  0x0,  0x0,
-        0x0,  0x0,  0x0,  0x0,
-        0x0,  0x0,  0x10, 0x0,
-        0x0,  0x0,  0x0,  0x0
-    };
+    uint8_t expected_msg[msg_len] = {0x24, 0x00, 0x0, 0x0, 0x0,  0x0, 0x0, 0x0, 0x0, 0x0,
+                                     0x0,  0x0,  0x0, 0x0, 0x10, 0x0, 0x0, 0x0, 0x0, 0x0};
     assert_memory_equal(msg, expected_msg, msg_len);
 }
 
-static void Test_CanXlBrief_SetSegmentNum(void** state)
+static void Test_CanXlBrief_SetSegmentNum(void **state)
 {
     const size_t msg_len = AVTP_CANXL_BRIEF_HEADER_LEN + 4;
     uint8_t msg[msg_len] = {0};
-    Avtp_CanXlBrief_t* canxl = (Avtp_CanXlBrief_t*)msg;
+    Avtp_CanXlBrief_t *canxl = (Avtp_CanXlBrief_t *)msg;
     Avtp_CanXlBrief_Init(canxl);
     Avtp_CanXlBrief_SetSegmentNum(canxl, 0xBFF);
 
-    uint8_t expected_msg[msg_len] = {
-        0x24, 0x00, 0x0,  0x0,
-        0x0,  0x0,  0x0,  0x0,
-        0x0,  0x0,  0x0,  0x0,
-        0x0,  0x0,  0x0B, 0xFF,
-        0x0,  0x0,  0x0,  0x0
-    };
+    uint8_t expected_msg[msg_len] = {0x24, 0x00, 0x0, 0x0, 0x0,  0x0,  0x0, 0x0, 0x0, 0x0,
+                                     0x0,  0x0,  0x0, 0x0, 0x0B, 0xFF, 0x0, 0x0, 0x0, 0x0};
     assert_memory_equal(msg, expected_msg, msg_len);
 }
 
-static void Test_CanXlBrief_SetPayloadLength(void** state)
+static void Test_CanXlBrief_SetPayloadLength(void **state)
 {
     const size_t msg_len = AVTP_CANXL_BRIEF_HEADER_LEN + 4;
     uint8_t msg[msg_len] = {0};
-    Avtp_CanXlBrief_t* canxl = (Avtp_CanXlBrief_t*)msg;
+    Avtp_CanXlBrief_t *canxl = (Avtp_CanXlBrief_t *)msg;
     Avtp_CanXlBrief_Init(canxl);
     Avtp_CanXlBrief_SetPayloadLength(canxl, 3);
 
-    uint8_t expected_msg[msg_len] = {
-        0x24, 0x05, 0x40, 0x0,
-        0x0,  0x0,  0x0,  0x0,
-        0x0,  0x0,  0x0,  0x0,
-        0x0,  0x0,  0x0,  0x0,
-        0x0,  0x0,  0x0,  0x0
-    };
+    uint8_t expected_msg[msg_len] = {0x24, 0x05, 0x40, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0,
+                                     0x0,  0x0,  0x0,  0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0};
     assert_memory_equal(msg, expected_msg, msg_len);
 }
 
-static void Test_CanXlBrief_SetPayloadLength_NoPadding(void** state)
+static void Test_CanXlBrief_SetPayloadLength_NoPadding(void **state)
 {
     const size_t msg_len = AVTP_CANXL_BRIEF_HEADER_LEN + 4;
     uint8_t msg[msg_len] = {0};
-    Avtp_CanXlBrief_t* canxl = (Avtp_CanXlBrief_t*)msg;
+    Avtp_CanXlBrief_t *canxl = (Avtp_CanXlBrief_t *)msg;
     Avtp_CanXlBrief_Init(canxl);
     Avtp_CanXlBrief_SetPayloadLength(canxl, 4);
 
-    uint8_t expected_msg[msg_len] = {
-        0x24, 0x05, 0x0,  0x0,
-        0x0,  0x0,  0x0,  0x0,
-        0x0,  0x0,  0x0,  0x0,
-        0x0,  0x0,  0x0,  0x0,
-        0x0,  0x0,  0x0,  0x0
-    };
+    uint8_t expected_msg[msg_len] = {0x24, 0x05, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0,
+                                     0x0,  0x0,  0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0};
     assert_memory_equal(msg, expected_msg, msg_len);
 }
 
-static void Test_CanXlBrief_Payload(void** state)
+static void Test_CanXlBrief_Payload(void **state)
 {
     const size_t msg_len = AVTP_CANXL_BRIEF_HEADER_LEN + 8;
     uint8_t msg[msg_len] = {0};
-    Avtp_CanXlBrief_t* canxl = (Avtp_CanXlBrief_t*)msg;
-    uint8_t payload[8] = {0,1,2,3,4,5,6,7};
+    Avtp_CanXlBrief_t *canxl = (Avtp_CanXlBrief_t *)msg;
+    uint8_t payload[8] = {0, 1, 2, 3, 4, 5, 6, 7};
 
     Avtp_CanXlBrief_Init(canxl);
     Avtp_CanXlBrief_SetPayload(canxl, payload, sizeof(payload));
@@ -568,12 +413,12 @@ static void Test_CanXlBrief_Payload(void** state)
     assert_memory_equal(payload, Avtp_CanXlBrief_GetPayload(canxl), sizeof(payload));
 }
 
-static void Test_CanXlBrief_CreateAcfMessage(void** state)
+static void Test_CanXlBrief_CreateAcfMessage(void **state)
 {
     const size_t msg_len = AVTP_CANXL_BRIEF_HEADER_LEN + 8;
     uint8_t msg[msg_len] = {0};
-    Avtp_CanXlBrief_t* canxl = (Avtp_CanXlBrief_t*)msg;
-    uint8_t payload[8] = {0,1,2,3,4,5,6,7};
+    Avtp_CanXlBrief_t *canxl = (Avtp_CanXlBrief_t *)msg;
+    uint8_t payload[8] = {0, 1, 2, 3, 4, 5, 6, 7};
 
     Avtp_CanXlBrief_CreateAcfMessage(canxl, 0x5FF, 0xBFFFFFFFul, 0xBF, payload, sizeof(payload));
 
@@ -591,12 +436,12 @@ static void Test_CanXlBrief_CreateAcfMessage(void** state)
     assert_int_equal(Avtp_CanXlBrief_GetVcid(canxl), 0xBF);
 }
 
-static void Test_CanXlBrief_CreateFromGarbage(void** state)
+static void Test_CanXlBrief_CreateFromGarbage(void **state)
 {
     const size_t msg_len = AVTP_CANXL_BRIEF_HEADER_LEN + 8;
     uint8_t msg[msg_len];
-    Avtp_CanXlBrief_t* canxl = (Avtp_CanXlBrief_t*)msg;
-    uint8_t payload[8] = {0,1,2,3,4,5,6,7};
+    Avtp_CanXlBrief_t *canxl = (Avtp_CanXlBrief_t *)msg;
+    uint8_t payload[8] = {0, 1, 2, 3, 4, 5, 6, 7};
 
     // CreateAcfMessage must fully initialize the header even on garbage input.
     memset(msg, 0xAA, msg_len);
@@ -612,12 +457,12 @@ static void Test_CanXlBrief_CreateFromGarbage(void** state)
     assert_int_equal(Avtp_CanXlBrief_IsValid(canxl, msg_len), 1);
 }
 
-static void Test_CanXlBrief_IsValid(void** state)
+static void Test_CanXlBrief_IsValid(void **state)
 {
     const size_t msg_len = AVTP_CANXL_BRIEF_HEADER_LEN + 32;
     uint8_t msg[msg_len] = {0};
-    Avtp_CanXlBrief_t* canxl = (Avtp_CanXlBrief_t*)msg;
-    uint8_t payload[8] = {0,1,2,3,4,5,6,7};
+    Avtp_CanXlBrief_t *canxl = (Avtp_CanXlBrief_t *)msg;
+    uint8_t payload[8] = {0, 1, 2, 3, 4, 5, 6, 7};
 
     // An Init-only PDU has AcfMsgLength == 0, so IsValid must reject it.
     Avtp_CanXlBrief_Init(canxl);
@@ -638,45 +483,43 @@ static void Test_CanXlBrief_IsValid(void** state)
 
 int main(void)
 {
-    const struct CMUnitTest tests[] = {
-        cmocka_unit_test(Test_CanXlBrief_Init),
-        cmocka_unit_test(Test_CanXlBrief_GetAcfMsgType),
-        cmocka_unit_test(Test_CanXlBrief_GetAcfMsgLength),
-        cmocka_unit_test(Test_CanXlBrief_GetPad),
-        cmocka_unit_test(Test_CanXlBrief_IsMtv),
-        cmocka_unit_test(Test_CanXlBrief_GetCanBusId),
-        cmocka_unit_test(Test_CanXlBrief_GetVcid),
-        cmocka_unit_test(Test_CanXlBrief_GetSdt),
-        cmocka_unit_test(Test_CanXlBrief_IsRrs),
-        cmocka_unit_test(Test_CanXlBrief_IsSec),
-        cmocka_unit_test(Test_CanXlBrief_GetPriorityId),
-        cmocka_unit_test(Test_CanXlBrief_GetAcceptanceField),
-        cmocka_unit_test(Test_CanXlBrief_GetTransactionNum),
-        cmocka_unit_test(Test_CanXlBrief_IsMs),
-        cmocka_unit_test(Test_CanXlBrief_GetSegmentNum),
-        cmocka_unit_test(Test_CanXlBrief_GetPayloadLength),
-        cmocka_unit_test(Test_CanXlBrief_GetPayloadLength_NoPadding),
-        cmocka_unit_test(Test_CanXlBrief_GetAcfMsgLengthInBytes),
-        cmocka_unit_test(Test_CanXlBrief_SetAcfMsgType),
-        cmocka_unit_test(Test_CanXlBrief_SetAcfMsgLength),
-        cmocka_unit_test(Test_CanXlBrief_SetMtv),
-        cmocka_unit_test(Test_CanXlBrief_SetCanBusId),
-        cmocka_unit_test(Test_CanXlBrief_SetVcid),
-        cmocka_unit_test(Test_CanXlBrief_SetSdt),
-        cmocka_unit_test(Test_CanXlBrief_SetRrs),
-        cmocka_unit_test(Test_CanXlBrief_SetSec),
-        cmocka_unit_test(Test_CanXlBrief_SetPriorityId),
-        cmocka_unit_test(Test_CanXlBrief_SetAcceptanceField),
-        cmocka_unit_test(Test_CanXlBrief_SetTransactionNum),
-        cmocka_unit_test(Test_CanXlBrief_SetMs),
-        cmocka_unit_test(Test_CanXlBrief_SetSegmentNum),
-        cmocka_unit_test(Test_CanXlBrief_SetPayloadLength),
-        cmocka_unit_test(Test_CanXlBrief_SetPayloadLength_NoPadding),
-        cmocka_unit_test(Test_CanXlBrief_Payload),
-        cmocka_unit_test(Test_CanXlBrief_CreateAcfMessage),
-        cmocka_unit_test(Test_CanXlBrief_CreateFromGarbage),
-        cmocka_unit_test(Test_CanXlBrief_IsValid)
-    };
+    const struct CMUnitTest tests[] = {cmocka_unit_test(Test_CanXlBrief_Init),
+                                       cmocka_unit_test(Test_CanXlBrief_GetAcfMsgType),
+                                       cmocka_unit_test(Test_CanXlBrief_GetAcfMsgLength),
+                                       cmocka_unit_test(Test_CanXlBrief_GetPad),
+                                       cmocka_unit_test(Test_CanXlBrief_IsMtv),
+                                       cmocka_unit_test(Test_CanXlBrief_GetCanBusId),
+                                       cmocka_unit_test(Test_CanXlBrief_GetVcid),
+                                       cmocka_unit_test(Test_CanXlBrief_GetSdt),
+                                       cmocka_unit_test(Test_CanXlBrief_IsRrs),
+                                       cmocka_unit_test(Test_CanXlBrief_IsSec),
+                                       cmocka_unit_test(Test_CanXlBrief_GetPriorityId),
+                                       cmocka_unit_test(Test_CanXlBrief_GetAcceptanceField),
+                                       cmocka_unit_test(Test_CanXlBrief_GetTransactionNum),
+                                       cmocka_unit_test(Test_CanXlBrief_IsMs),
+                                       cmocka_unit_test(Test_CanXlBrief_GetSegmentNum),
+                                       cmocka_unit_test(Test_CanXlBrief_GetPayloadLength),
+                                       cmocka_unit_test(Test_CanXlBrief_GetPayloadLength_NoPadding),
+                                       cmocka_unit_test(Test_CanXlBrief_GetAcfMsgLengthInBytes),
+                                       cmocka_unit_test(Test_CanXlBrief_SetAcfMsgType),
+                                       cmocka_unit_test(Test_CanXlBrief_SetAcfMsgLength),
+                                       cmocka_unit_test(Test_CanXlBrief_SetMtv),
+                                       cmocka_unit_test(Test_CanXlBrief_SetCanBusId),
+                                       cmocka_unit_test(Test_CanXlBrief_SetVcid),
+                                       cmocka_unit_test(Test_CanXlBrief_SetSdt),
+                                       cmocka_unit_test(Test_CanXlBrief_SetRrs),
+                                       cmocka_unit_test(Test_CanXlBrief_SetSec),
+                                       cmocka_unit_test(Test_CanXlBrief_SetPriorityId),
+                                       cmocka_unit_test(Test_CanXlBrief_SetAcceptanceField),
+                                       cmocka_unit_test(Test_CanXlBrief_SetTransactionNum),
+                                       cmocka_unit_test(Test_CanXlBrief_SetMs),
+                                       cmocka_unit_test(Test_CanXlBrief_SetSegmentNum),
+                                       cmocka_unit_test(Test_CanXlBrief_SetPayloadLength),
+                                       cmocka_unit_test(Test_CanXlBrief_SetPayloadLength_NoPadding),
+                                       cmocka_unit_test(Test_CanXlBrief_Payload),
+                                       cmocka_unit_test(Test_CanXlBrief_CreateAcfMessage),
+                                       cmocka_unit_test(Test_CanXlBrief_CreateFromGarbage),
+                                       cmocka_unit_test(Test_CanXlBrief_IsValid)};
 
     return cmocka_run_group_tests(tests, NULL, NULL);
 }

--- a/unit/test-canxl.c
+++ b/unit/test-canxl.c
@@ -44,10 +44,14 @@ static void Test_CanXl_Init(void** state)
     const size_t msg_len = AVTP_CANXL_HEADER_LEN + 4;
     uint8_t msg[msg_len] = {0};
     Avtp_CanXl_t* canxl = (Avtp_CanXl_t*)msg;
+
+    // Check init function while passing in a null pointer
+    Avtp_CanXl_Init(NULL);
+
     Avtp_CanXl_Init(canxl);
 
     uint8_t expected_msg[msg_len] = {
-        0x22, 0x06, 0x0,  0x0,
+        0x22, 0x00, 0x0,  0x0,
         0x0,  0x0,  0x0,  0x0,
         0x0,  0x0,  0x0,  0x0,
         0x0,  0x0,  0x0,  0x0,
@@ -57,6 +61,38 @@ static void Test_CanXl_Init(void** state)
     };
 
     assert_memory_equal(msg, expected_msg, msg_len);
+}
+
+static void Test_CanXl_GetAcfMsgType(void** state)
+{
+    const size_t msg_len = AVTP_CANXL_HEADER_LEN + 4;
+    uint8_t msg[msg_len] = {
+        0x22, 0x06, 0x0,  0x0,
+        0x0,  0x0,  0x0,  0x0,
+        0x0,  0x0,  0x0,  0x0,
+        0x0,  0x0,  0x0,  0x0,
+        0x0,  0x0,  0x0,  0x0,
+        0x0,  0x0,  0x0,  0x0,
+        0x0,  0x0,  0x0,  0x0
+    };
+    Avtp_CanXl_t* canxl = (Avtp_CanXl_t*)msg;
+    assert_int_equal(Avtp_CanXl_GetAcfMsgType(canxl), AVTP_ACF_TYPE_CAN_XL);
+}
+
+static void Test_CanXl_GetAcfMsgLength(void** state)
+{
+    const size_t msg_len = AVTP_CANXL_HEADER_LEN + 4;
+    uint8_t msg[msg_len] = {
+        0x22, 0x06, 0x0,  0x0,
+        0x0,  0x0,  0x0,  0x0,
+        0x0,  0x0,  0x0,  0x0,
+        0x0,  0x0,  0x0,  0x0,
+        0x0,  0x0,  0x0,  0x0,
+        0x0,  0x0,  0x0,  0x0,
+        0x0,  0x0,  0x0,  0x0
+    };
+    Avtp_CanXl_t* canxl = (Avtp_CanXl_t*)msg;
+    assert_int_equal(Avtp_CanXl_GetAcfMsgLength(canxl), 6);
 }
 
 static void Test_CanXl_GetPad(void** state)
@@ -267,7 +303,7 @@ static void Test_CanXl_GetSegmentNum(void** state)
     assert_int_equal(Avtp_CanXl_GetSegmentNum(canxl), 0xBFF);
 }
 
-static void Test_CanXl_GetPayloadLen(void** state)
+static void Test_CanXl_GetPayloadLength(void** state)
 {
     const size_t msg_len = AVTP_CANXL_HEADER_LEN + 4;
     uint8_t msg[msg_len] = {
@@ -276,14 +312,14 @@ static void Test_CanXl_GetPayloadLen(void** state)
         0x0,  0x0,  0x0,  0x0,
         0x0,  0x0,  0x0,  0x0,
         0x0,  0x0,  0x0,  0x0,
-        0x0,  0x0, 0x0,  0x0,
+        0x0,  0x0,  0x0,  0x0,
         0x0,  0x0,  0x0,  0x0
     };
     Avtp_CanXl_t* canxl = (Avtp_CanXl_t*)msg;
-    assert_int_equal(Avtp_CanXl_GetPayloadLen(canxl), 1);
+    assert_int_equal(Avtp_CanXl_GetPayloadLength(canxl), 1);
 }
 
-static void Test_CanXl_GetPayloadLen_NoPadding(void** state)
+static void Test_CanXl_GetPayloadLength_NoPadding(void** state)
 {
     const size_t msg_len = AVTP_CANXL_HEADER_LEN + 4;
     uint8_t msg[msg_len] = {
@@ -296,10 +332,10 @@ static void Test_CanXl_GetPayloadLen_NoPadding(void** state)
         0x0,  0x0,  0x0,  0x0
     };
     Avtp_CanXl_t* canxl = (Avtp_CanXl_t*)msg;
-    assert_int_equal(Avtp_CanXl_GetPayloadLen(canxl), 4);
+    assert_int_equal(Avtp_CanXl_GetPayloadLength(canxl), 4);
 }
 
-static void Test_CanXl_GetLen(void** state)
+static void Test_CanXl_GetAcfMsgLengthInBytes(void** state)
 {
     const size_t msg_len = AVTP_CANXL_HEADER_LEN + 4;
     uint8_t msg[msg_len] = {
@@ -312,7 +348,28 @@ static void Test_CanXl_GetLen(void** state)
         0x0,  0x0,  0x0,  0x0
     };
     Avtp_CanXl_t* canxl = (Avtp_CanXl_t*)msg;
-    assert_int_equal(Avtp_CanXl_GetLen(canxl), 7 * 4);
+    assert_int_equal(Avtp_CanXl_GetAcfMsgLengthInBytes(canxl), 7 * 4);
+}
+
+static void Test_CanXl_SetAcfMsgType(void** state)
+{
+    const size_t msg_len = AVTP_CANXL_HEADER_LEN + 4;
+    uint8_t msg[msg_len] = {0};
+    Avtp_CanXl_t* canxl = (Avtp_CanXl_t*)msg;
+    Avtp_CanXl_Init(canxl);
+    Avtp_CanXl_SetAcfMsgType(canxl, AVTP_ACF_TYPE_CAN_XL);
+    assert_int_equal(Avtp_CanXl_GetAcfMsgType(canxl), AVTP_ACF_TYPE_CAN_XL);
+}
+
+static void Test_CanXl_SetAcfMsgLength(void** state)
+{
+    const size_t msg_len = AVTP_CANXL_HEADER_LEN + 4;
+    uint8_t msg[msg_len] = {0};
+    Avtp_CanXl_t* canxl = (Avtp_CanXl_t*)msg;
+    Avtp_CanXl_Init(canxl);
+    Avtp_CanXl_SetAcfMsgLength(canxl, 5);
+    assert_int_equal(Avtp_CanXl_GetAcfMsgLength(canxl), 5);
+    assert_int_equal(Avtp_CanXl_GetAcfMsgLengthInBytes(canxl), 20);
 }
 
 static void Test_CanXl_SetMtv(void** state)
@@ -324,7 +381,7 @@ static void Test_CanXl_SetMtv(void** state)
     Avtp_CanXl_SetMtv(canxl, true);
 
     uint8_t expected_msg[msg_len] = {
-        0x22, 0x06, 0x20, 0x0,
+        0x22, 0x00, 0x20, 0x0,
         0x0,  0x0,  0x0,  0x0,
         0x0,  0x0,  0x0,  0x0,
         0x0,  0x0,  0x0,  0x0,
@@ -344,7 +401,7 @@ static void Test_CanXl_SetCanBusId(void** state)
     Avtp_CanXl_SetCanBusId(canxl, 0x5FF);
 
     uint8_t expected_msg[msg_len] = {
-        0x22, 0x06, 0x05, 0xFF,
+        0x22, 0x00, 0x05, 0xFF,
         0x0,  0x0,  0x0,  0x0,
         0x0,  0x0,  0x0,  0x0,
         0x0,  0x0,  0x0,  0x0,
@@ -364,7 +421,7 @@ static void Test_CanXl_SetMessageTimestamp(void** state)
     Avtp_CanXl_SetMessageTimestamp(canxl, 0xBFFFFFFFFFFFFFFFull);
 
     uint8_t expected_msg[msg_len] = {
-        0x22, 0x06, 0x0,  0x0,
+        0x22, 0x00, 0x0,  0x0,
         0xBF, 0xFF, 0xFF, 0xFF,
         0xFF, 0xFF, 0xFF, 0xFF,
         0x0,  0x0,  0x0,  0x0,
@@ -384,7 +441,7 @@ static void Test_CanXl_SetVcid(void** state)
     Avtp_CanXl_SetVcid(canxl, 0xBF);
 
     uint8_t expected_msg[msg_len] = {
-        0x22, 0x06, 0x0,  0x0,
+        0x22, 0x00, 0x0,  0x0,
         0x0,  0x0,  0x0,  0x0,
         0x0,  0x0,  0x0,  0x0,
         0xBF, 0x0,  0x0,  0x0,
@@ -404,7 +461,7 @@ static void Test_CanXl_SetSdt(void** state)
     Avtp_CanXl_SetSdt(canxl, 0xBF);
 
     uint8_t expected_msg[msg_len] = {
-        0x22, 0x06, 0x0,  0x0,
+        0x22, 0x00, 0x0,  0x0,
         0x0,  0x0,  0x0,  0x0,
         0x0,  0x0,  0x0,  0x0,
         0x0,  0xBF, 0x0,  0x0,
@@ -424,7 +481,7 @@ static void Test_CanXl_SetRrs(void** state)
     Avtp_CanXl_SetRrs(canxl, true);
 
     uint8_t expected_msg[msg_len] = {
-        0x22, 0x06, 0x0,  0x0,
+        0x22, 0x00, 0x0,  0x0,
         0x0,  0x0,  0x0,  0x0,
         0x0,  0x0,  0x0,  0x0,
         0x0,  0x0,  0x10, 0x0,
@@ -444,7 +501,7 @@ static void Test_CanXl_SetSec(void** state)
     Avtp_CanXl_SetSec(canxl, true);
 
     uint8_t expected_msg[msg_len] = {
-        0x22, 0x06, 0x0,  0x0,
+        0x22, 0x00, 0x0,  0x0,
         0x0,  0x0,  0x0,  0x0,
         0x0,  0x0,  0x0,  0x0,
         0x0,  0x0,  0x8,  0x0,
@@ -464,7 +521,7 @@ static void Test_CanXl_SetPriorityId(void** state)
     Avtp_CanXl_SetPriorityId(canxl, 0x5FF);
 
     uint8_t expected_msg[msg_len] = {
-        0x22, 0x06, 0x0,  0x0,
+        0x22, 0x00, 0x0,  0x0,
         0x0,  0x0,  0x0,  0x0,
         0x0,  0x0,  0x0,  0x0,
         0x0,  0x0,  0x05, 0xFF,
@@ -484,7 +541,7 @@ static void Test_CanXl_SetAcceptanceField(void** state)
     Avtp_CanXl_SetAcceptanceField(canxl, 0xBFFFFFFFul);
 
     uint8_t expected_msg[msg_len] = {
-        0x22, 0x06, 0x0,  0x0,
+        0x22, 0x00, 0x0,  0x0,
         0x0,  0x0,  0x0,  0x0,
         0x0,  0x0,  0x0,  0x0,
         0x0,  0x0,  0x0,  0x0,
@@ -504,7 +561,7 @@ static void Test_CanXl_SetTransactionNum(void** state)
     Avtp_CanXl_SetTransactionNum(canxl, 0xBF);
 
     uint8_t expected_msg[msg_len] = {
-        0x22, 0x06, 0x0,  0x0,
+        0x22, 0x00, 0x0,  0x0,
         0x0,  0x0,  0x0,  0x0,
         0x0,  0x0,  0x0,  0x0,
         0x0,  0x0,  0x0,  0x0,
@@ -524,7 +581,7 @@ static void Test_CanXl_SetMs(void** state)
     Avtp_CanXl_SetMs(canxl, true);
 
     uint8_t expected_msg[msg_len] = {
-        0x22, 0x06, 0x0,  0x0,
+        0x22, 0x00, 0x0,  0x0,
         0x0,  0x0,  0x0,  0x0,
         0x0,  0x0,  0x0,  0x0,
         0x0,  0x0,  0x0,  0x0,
@@ -544,7 +601,7 @@ static void Test_CanXl_SetSegmentNum(void** state)
     Avtp_CanXl_SetSegmentNum(canxl, 0xBFF);
 
     uint8_t expected_msg[msg_len] = {
-        0x22, 0x06, 0x0,  0x0,
+        0x22, 0x00, 0x0,  0x0,
         0x0,  0x0,  0x0,  0x0,
         0x0,  0x0,  0x0,  0x0,
         0x0,  0x0,  0x0,  0x0,
@@ -555,13 +612,13 @@ static void Test_CanXl_SetSegmentNum(void** state)
     assert_memory_equal(msg, expected_msg, msg_len);
 }
 
-static void Test_CanXl_SetPayloadLen(void** state)
+static void Test_CanXl_SetPayloadLength(void** state)
 {
     const size_t msg_len = AVTP_CANXL_HEADER_LEN + 4;
     uint8_t msg[msg_len] = {0};
     Avtp_CanXl_t* canxl = (Avtp_CanXl_t*)msg;
     Avtp_CanXl_Init(canxl);
-    Avtp_CanXl_SetPayloadLen(canxl, 3);
+    Avtp_CanXl_SetPayloadLength(canxl, 3);
 
     uint8_t expected_msg[msg_len] = {
         0x22, 0x07, 0x40, 0x0,
@@ -575,13 +632,13 @@ static void Test_CanXl_SetPayloadLen(void** state)
     assert_memory_equal(msg, expected_msg, msg_len);
 }
 
-static void Test_CanXl_SetPayloadLen_NoPadding(void** state)
+static void Test_CanXl_SetPayloadLength_NoPadding(void** state)
 {
     const size_t msg_len = AVTP_CANXL_HEADER_LEN + 4;
     uint8_t msg[msg_len] = {0};
     Avtp_CanXl_t* canxl = (Avtp_CanXl_t*)msg;
     Avtp_CanXl_Init(canxl);
-    Avtp_CanXl_SetPayloadLen(canxl, 4);
+    Avtp_CanXl_SetPayloadLength(canxl, 4);
 
     uint8_t expected_msg[msg_len] = {
         0x22, 0x07, 0x0,  0x0,
@@ -595,10 +652,97 @@ static void Test_CanXl_SetPayloadLen_NoPadding(void** state)
     assert_memory_equal(msg, expected_msg, msg_len);
 }
 
+static void Test_CanXl_Payload(void** state)
+{
+    const size_t msg_len = AVTP_CANXL_HEADER_LEN + 8;
+    uint8_t msg[msg_len] = {0};
+    Avtp_CanXl_t* canxl = (Avtp_CanXl_t*)msg;
+    uint8_t payload[8] = {0,1,2,3,4,5,6,7};
+
+    Avtp_CanXl_Init(canxl);
+    Avtp_CanXl_SetPayload(canxl, payload, sizeof(payload));
+
+    assert_ptr_equal(Avtp_CanXl_GetPayload(canxl), msg + AVTP_CANXL_HEADER_LEN);
+    assert_memory_equal(payload, Avtp_CanXl_GetPayload(canxl), sizeof(payload));
+}
+
+static void Test_CanXl_CreateAcfMessage(void** state)
+{
+    const size_t msg_len = AVTP_CANXL_HEADER_LEN + 8;
+    uint8_t msg[msg_len] = {0};
+    Avtp_CanXl_t* canxl = (Avtp_CanXl_t*)msg;
+    uint8_t payload[8] = {0,1,2,3,4,5,6,7};
+
+    Avtp_CanXl_CreateAcfMessage(canxl, 0x5FF, 0xBFFFFFFFul, 0xBF, payload, sizeof(payload));
+
+    assert_int_equal(Avtp_CanXl_GetAcfMsgType(canxl), AVTP_ACF_TYPE_CAN_XL);
+    assert_int_equal(Avtp_CanXl_GetPriorityId(canxl), 0x5FF);
+    assert_int_equal(Avtp_CanXl_GetAcceptanceField(canxl), 0xBFFFFFFFul);
+    assert_int_equal(Avtp_CanXl_GetSdt(canxl), 0xBF);
+    assert_memory_equal(payload, msg + AVTP_CANXL_HEADER_LEN, sizeof(payload));
+    assert_int_equal(Avtp_CanXl_GetPayloadLength(canxl), 8);
+
+    // can_bus_id, vcid and message_timestamp are set by the caller afterwards
+    Avtp_CanXl_SetCanBusId(canxl, 0x5FF);
+    Avtp_CanXl_SetVcid(canxl, 0xBF);
+    Avtp_CanXl_SetMessageTimestamp(canxl, 0x123456789ABCDEF0ULL);
+    assert_int_equal(Avtp_CanXl_GetCanBusId(canxl), 0x5FF);
+    assert_int_equal(Avtp_CanXl_GetVcid(canxl), 0xBF);
+    assert_int_equal(Avtp_CanXl_GetMessageTimestamp(canxl), 0x123456789ABCDEF0ULL);
+}
+
+static void Test_CanXl_CreateFromGarbage(void** state)
+{
+    const size_t msg_len = AVTP_CANXL_HEADER_LEN + 8;
+    uint8_t msg[msg_len];
+    Avtp_CanXl_t* canxl = (Avtp_CanXl_t*)msg;
+    uint8_t payload[8] = {0,1,2,3,4,5,6,7};
+
+    // CreateAcfMessage must fully initialize the header even on garbage input.
+    memset(msg, 0xAA, msg_len);
+    Avtp_CanXl_CreateAcfMessage(canxl, 0x5FF, 0x0, 0x0, payload, sizeof(payload));
+
+    assert_int_equal(Avtp_CanXl_GetAcfMsgType(canxl), AVTP_ACF_TYPE_CAN_XL);
+    assert_int_equal(Avtp_CanXl_IsMtv(canxl), false);
+    assert_int_equal(Avtp_CanXl_IsRrs(canxl), false);
+    assert_int_equal(Avtp_CanXl_IsSec(canxl), false);
+    assert_int_equal(Avtp_CanXl_IsMs(canxl), false);
+    assert_int_equal(Avtp_CanXl_GetCanBusId(canxl), 0);
+    assert_int_equal(Avtp_CanXl_GetMessageTimestamp(canxl), 0);
+    assert_memory_equal(payload, msg + AVTP_CANXL_HEADER_LEN, sizeof(payload));
+    assert_int_equal(Avtp_CanXl_IsValid(canxl, msg_len), 1);
+}
+
+static void Test_CanXl_IsValid(void** state)
+{
+    const size_t msg_len = AVTP_CANXL_HEADER_LEN + 32;
+    uint8_t msg[msg_len] = {0};
+    Avtp_CanXl_t* canxl = (Avtp_CanXl_t*)msg;
+    uint8_t payload[8] = {0,1,2,3,4,5,6,7};
+
+    // An Init-only PDU has AcfMsgLength == 0, so IsValid must reject it.
+    Avtp_CanXl_Init(canxl);
+    assert_int_equal(Avtp_CanXl_IsValid(canxl, msg_len), 0);
+
+    // A properly-formed frame with an 8-byte payload is valid.
+    Avtp_CanXl_CreateAcfMessage(canxl, 0x5FF, 0x0, 0x0, payload, sizeof(payload));
+    assert_int_equal(Avtp_CanXl_IsValid(canxl, msg_len), 1);
+
+    // Not a CAN XL message (zero buffer, AcfMsgType != CAN_XL).
+    memset(msg, 0, msg_len);
+    assert_int_equal(Avtp_CanXl_IsValid(canxl, msg_len), 0);
+
+    // Declared length larger than the buffer is invalid.
+    Avtp_CanXl_CreateAcfMessage(canxl, 0x5FF, 0x0, 0x0, payload, sizeof(payload));
+    assert_int_equal(Avtp_CanXl_IsValid(canxl, AVTP_CANXL_HEADER_LEN + 1), 0);
+}
+
 int main(void)
 {
     const struct CMUnitTest tests[] = {
         cmocka_unit_test(Test_CanXl_Init),
+        cmocka_unit_test(Test_CanXl_GetAcfMsgType),
+        cmocka_unit_test(Test_CanXl_GetAcfMsgLength),
         cmocka_unit_test(Test_CanXl_GetPad),
         cmocka_unit_test(Test_CanXl_IsMtv),
         cmocka_unit_test(Test_CanXl_GetCanBusId),
@@ -612,9 +756,11 @@ int main(void)
         cmocka_unit_test(Test_CanXl_GetTransactionNum),
         cmocka_unit_test(Test_CanXl_IsMs),
         cmocka_unit_test(Test_CanXl_GetSegmentNum),
-        cmocka_unit_test(Test_CanXl_GetPayloadLen),
-        cmocka_unit_test(Test_CanXl_GetPayloadLen_NoPadding),
-        cmocka_unit_test(Test_CanXl_GetLen),
+        cmocka_unit_test(Test_CanXl_GetPayloadLength),
+        cmocka_unit_test(Test_CanXl_GetPayloadLength_NoPadding),
+        cmocka_unit_test(Test_CanXl_GetAcfMsgLengthInBytes),
+        cmocka_unit_test(Test_CanXl_SetAcfMsgType),
+        cmocka_unit_test(Test_CanXl_SetAcfMsgLength),
         cmocka_unit_test(Test_CanXl_SetMtv),
         cmocka_unit_test(Test_CanXl_SetCanBusId),
         cmocka_unit_test(Test_CanXl_SetMessageTimestamp),
@@ -627,8 +773,12 @@ int main(void)
         cmocka_unit_test(Test_CanXl_SetTransactionNum),
         cmocka_unit_test(Test_CanXl_SetMs),
         cmocka_unit_test(Test_CanXl_SetSegmentNum),
-        cmocka_unit_test(Test_CanXl_SetPayloadLen),
-        cmocka_unit_test(Test_CanXl_SetPayloadLen_NoPadding)
+        cmocka_unit_test(Test_CanXl_SetPayloadLength),
+        cmocka_unit_test(Test_CanXl_SetPayloadLength_NoPadding),
+        cmocka_unit_test(Test_CanXl_Payload),
+        cmocka_unit_test(Test_CanXl_CreateAcfMessage),
+        cmocka_unit_test(Test_CanXl_CreateFromGarbage),
+        cmocka_unit_test(Test_CanXl_IsValid)
     };
 
     return cmocka_run_group_tests(tests, NULL, NULL);

--- a/unit/test-canxl.c
+++ b/unit/test-canxl.c
@@ -39,625 +39,419 @@ extern "C" {
 #include <cmocka.h>
 #include <stdio.h>
 
-static void Test_CanXl_Init(void** state)
+static void Test_CanXl_Init(void **state)
 {
     const size_t msg_len = AVTP_CANXL_HEADER_LEN + 4;
     uint8_t msg[msg_len] = {0};
-    Avtp_CanXl_t* canxl = (Avtp_CanXl_t*)msg;
+    Avtp_CanXl_t *canxl = (Avtp_CanXl_t *)msg;
 
     // Check init function while passing in a null pointer
     Avtp_CanXl_Init(NULL);
 
     Avtp_CanXl_Init(canxl);
 
-    uint8_t expected_msg[msg_len] = {
-        0x22, 0x00, 0x0,  0x0,
-        0x0,  0x0,  0x0,  0x0,
-        0x0,  0x0,  0x0,  0x0,
-        0x0,  0x0,  0x0,  0x0,
-        0x0,  0x0,  0x0,  0x0,
-        0x0,  0x0,  0x0,  0x0,
-        0x0,  0x0,  0x0,  0x0
-    };
+    uint8_t expected_msg[msg_len] = {0x22, 0x00, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0,
+                                     0x0,  0x0,  0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0,
+                                     0x0,  0x0,  0x0, 0x0, 0x0, 0x0, 0x0, 0x0};
 
     assert_memory_equal(msg, expected_msg, msg_len);
 }
 
-static void Test_CanXl_GetAcfMsgType(void** state)
+static void Test_CanXl_GetAcfMsgType(void **state)
 {
     const size_t msg_len = AVTP_CANXL_HEADER_LEN + 4;
-    uint8_t msg[msg_len] = {
-        0x22, 0x06, 0x0,  0x0,
-        0x0,  0x0,  0x0,  0x0,
-        0x0,  0x0,  0x0,  0x0,
-        0x0,  0x0,  0x0,  0x0,
-        0x0,  0x0,  0x0,  0x0,
-        0x0,  0x0,  0x0,  0x0,
-        0x0,  0x0,  0x0,  0x0
-    };
-    Avtp_CanXl_t* canxl = (Avtp_CanXl_t*)msg;
+    uint8_t msg[msg_len] = {0x22, 0x06, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0,
+                            0x0,  0x0,  0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0};
+    Avtp_CanXl_t *canxl = (Avtp_CanXl_t *)msg;
     assert_int_equal(Avtp_CanXl_GetAcfMsgType(canxl), AVTP_ACF_TYPE_CAN_XL);
 }
 
-static void Test_CanXl_GetAcfMsgLength(void** state)
+static void Test_CanXl_GetAcfMsgLength(void **state)
 {
     const size_t msg_len = AVTP_CANXL_HEADER_LEN + 4;
-    uint8_t msg[msg_len] = {
-        0x22, 0x06, 0x0,  0x0,
-        0x0,  0x0,  0x0,  0x0,
-        0x0,  0x0,  0x0,  0x0,
-        0x0,  0x0,  0x0,  0x0,
-        0x0,  0x0,  0x0,  0x0,
-        0x0,  0x0,  0x0,  0x0,
-        0x0,  0x0,  0x0,  0x0
-    };
-    Avtp_CanXl_t* canxl = (Avtp_CanXl_t*)msg;
+    uint8_t msg[msg_len] = {0x22, 0x06, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0,
+                            0x0,  0x0,  0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0};
+    Avtp_CanXl_t *canxl = (Avtp_CanXl_t *)msg;
     assert_int_equal(Avtp_CanXl_GetAcfMsgLength(canxl), 6);
 }
 
-static void Test_CanXl_GetPad(void** state)
+static void Test_CanXl_GetPad(void **state)
 {
     const size_t msg_len = AVTP_CANXL_HEADER_LEN + 4;
-    uint8_t msg[msg_len] = {
-        0x22, 0x06, 0xC0, 0x0,
-        0x0,  0x0,  0x0,  0x0,
-        0x0,  0x0,  0x0,  0x0,
-        0x0,  0x0,  0x0,  0x0,
-        0x0,  0x0,  0x0,  0x0,
-        0x0,  0x0,  0x0,  0x0,
-        0x0,  0x0,  0x0,  0x0
-    };
-    Avtp_CanXl_t* canxl = (Avtp_CanXl_t*)msg;
+    uint8_t msg[msg_len] = {0x22, 0x06, 0xC0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0,
+                            0x0,  0x0,  0x0,  0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0,
+                            0x0,  0x0,  0x0,  0x0, 0x0, 0x0, 0x0, 0x0};
+    Avtp_CanXl_t *canxl = (Avtp_CanXl_t *)msg;
     assert_int_equal(Avtp_CanXl_GetPad(canxl), 3);
 }
 
-static void Test_CanXl_IsMtv(void** state)
+static void Test_CanXl_IsMtv(void **state)
 {
     const size_t msg_len = AVTP_CANXL_HEADER_LEN + 4;
-    uint8_t msg[msg_len] = {
-        0x22, 0x06, 0x20, 0x0,
-        0x0,  0x0,  0x0,  0x0,
-        0x0,  0x0,  0x0,  0x0,
-        0x0,  0x0,  0x0,  0x0,
-        0x0,  0x0,  0x0,  0x0,
-        0x0,  0x0,  0x0,  0x0,
-        0x0,  0x0,  0x0,  0x0
-    };
-    Avtp_CanXl_t* canxl = (Avtp_CanXl_t*)msg;
+    uint8_t msg[msg_len] = {0x22, 0x06, 0x20, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0,
+                            0x0,  0x0,  0x0,  0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0,
+                            0x0,  0x0,  0x0,  0x0, 0x0, 0x0, 0x0, 0x0};
+    Avtp_CanXl_t *canxl = (Avtp_CanXl_t *)msg;
     assert_int_equal(Avtp_CanXl_IsMtv(canxl), true);
 }
 
-static void Test_CanXl_GetCanBusId(void** state)
+static void Test_CanXl_GetCanBusId(void **state)
 {
     const size_t msg_len = AVTP_CANXL_HEADER_LEN + 4;
-    uint8_t msg[msg_len] = {
-        0x22, 0x06, 0x05, 0xFF,
-        0x0,  0x0,  0x0,  0x0,
-        0x0,  0x0,  0x0,  0x0,
-        0x0,  0x0,  0x0,  0x0,
-        0x0,  0x0,  0x0,  0x0,
-        0x0,  0x0,  0x0,  0x0,
-        0x0,  0x0,  0x0,  0x0
-    };
-    Avtp_CanXl_t* canxl = (Avtp_CanXl_t*)msg;
+    uint8_t msg[msg_len] = {0x22, 0x06, 0x05, 0xFF, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0,
+                            0x0,  0x0,  0x0,  0x0,  0x0, 0x0, 0x0, 0x0, 0x0, 0x0,
+                            0x0,  0x0,  0x0,  0x0,  0x0, 0x0, 0x0, 0x0};
+    Avtp_CanXl_t *canxl = (Avtp_CanXl_t *)msg;
     assert_int_equal(Avtp_CanXl_GetCanBusId(canxl), 0x5FF);
 }
 
-static void Test_CanXl_GetMessageTimestamp(void** state)
+static void Test_CanXl_GetMessageTimestamp(void **state)
 {
     const size_t msg_len = AVTP_CANXL_HEADER_LEN + 4;
-    uint8_t msg[msg_len] = {
-        0x22, 0x06, 0x0,  0x0,
-        0xBF, 0xFF, 0xFF, 0xFF,
-        0xFF, 0xFF, 0xFF, 0xFF,
-        0x0,  0x0,  0x0,  0x0,
-        0x0,  0x0,  0x0,  0x0,
-        0x0,  0x0,  0x0,  0x0,
-        0x0,  0x0,  0x0,  0x0
-    };
-    Avtp_CanXl_t* canxl = (Avtp_CanXl_t*)msg;
+    uint8_t msg[msg_len] = {0x22, 0x06, 0x0, 0x0, 0xBF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF,
+                            0xFF, 0xFF, 0x0, 0x0, 0x0,  0x0,  0x0,  0x0,  0x0,  0x0,
+                            0x0,  0x0,  0x0, 0x0, 0x0,  0x0,  0x0,  0x0};
+    Avtp_CanXl_t *canxl = (Avtp_CanXl_t *)msg;
     assert_int_equal(Avtp_CanXl_GetMessageTimestamp(canxl), 0xBFFFFFFFFFFFFFFFull);
 }
 
-static void Test_CanXl_GetVcid(void** state)
+static void Test_CanXl_GetVcid(void **state)
 {
     const size_t msg_len = AVTP_CANXL_HEADER_LEN + 4;
-    uint8_t msg[msg_len] = {
-        0x22, 0x06, 0x0,  0x0,
-        0x0,  0x0,  0x0,  0x0,
-        0x0,  0x0,  0x0,  0x0,
-        0xBF, 0x0,  0x0,  0x0,
-        0x0,  0x0,  0x0,  0x0,
-        0x0,  0x0,  0x0,  0x0,
-        0x0,  0x0,  0x0,  0x0
-    };
-    Avtp_CanXl_t* canxl = (Avtp_CanXl_t*)msg;
+    uint8_t msg[msg_len] = {0x22, 0x06, 0x0,  0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0,
+                            0x0,  0x0,  0xBF, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0,
+                            0x0,  0x0,  0x0,  0x0, 0x0, 0x0, 0x0, 0x0};
+    Avtp_CanXl_t *canxl = (Avtp_CanXl_t *)msg;
     assert_int_equal(Avtp_CanXl_GetVcid(canxl), 0xBF);
 }
 
-static void Test_CanXl_GetSdt(void** state)
+static void Test_CanXl_GetSdt(void **state)
 {
     const size_t msg_len = AVTP_CANXL_HEADER_LEN + 4;
-    uint8_t msg[msg_len] = {
-        0x22, 0x06, 0x0,  0x0,
-        0x0,  0x0,  0x0,  0x0,
-        0x0,  0x0,  0x0,  0x0,
-        0x0,  0xBF, 0x0,  0x0,
-        0x0,  0x0,  0x0,  0x0,
-        0x0,  0x0,  0x0,  0x0,
-        0x0,  0x0,  0x0,  0x0
-    };
-    Avtp_CanXl_t* canxl = (Avtp_CanXl_t*)msg;
+    uint8_t msg[msg_len] = {0x22, 0x06, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0xBF,
+                            0x0,  0x0,  0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0};
+    Avtp_CanXl_t *canxl = (Avtp_CanXl_t *)msg;
     assert_int_equal(Avtp_CanXl_GetSdt(canxl), 0xBF);
 }
 
-static void Test_CanXl_IsRrs(void** state)
+static void Test_CanXl_IsRrs(void **state)
 {
     const size_t msg_len = AVTP_CANXL_HEADER_LEN + 4;
-    uint8_t msg[msg_len] = {
-        0x22, 0x06, 0x0,  0x0,
-        0x0,  0x0,  0x0,  0x0,
-        0x0,  0x0,  0x0,  0x0,
-        0x0,  0x0,  0x10, 0x0,
-        0x0,  0x0,  0x0,  0x0,
-        0x0,  0x0,  0x0,  0x0,
-        0x0,  0x0,  0x0,  0x0
-    };
-    Avtp_CanXl_t* canxl = (Avtp_CanXl_t*)msg;
+    uint8_t msg[msg_len] = {0x22, 0x06, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0,
+                            0x10, 0x0,  0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0};
+    Avtp_CanXl_t *canxl = (Avtp_CanXl_t *)msg;
     assert_int_equal(Avtp_CanXl_IsRrs(canxl), true);
 }
 
-static void Test_CanXl_IsSec(void** state)
+static void Test_CanXl_IsSec(void **state)
 {
     const size_t msg_len = AVTP_CANXL_HEADER_LEN + 4;
-    uint8_t msg[msg_len] = {
-        0x22, 0x06, 0x0,  0x0,
-        0x0,  0x0,  0x0,  0x0,
-        0x0,  0x0,  0x0,  0x0,
-        0x0,  0x0,  0x08, 0x0,
-        0x0,  0x0,  0x0,  0x0,
-        0x0,  0x0,  0x0,  0x0,
-        0x0,  0x0,  0x0,  0x0
-    };
-    Avtp_CanXl_t* canxl = (Avtp_CanXl_t*)msg;
+    uint8_t msg[msg_len] = {0x22, 0x06, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0,
+                            0x08, 0x0,  0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0};
+    Avtp_CanXl_t *canxl = (Avtp_CanXl_t *)msg;
     assert_int_equal(Avtp_CanXl_IsSec(canxl), true);
 }
 
-static void Test_CanXl_GetPriorityId(void** state)
+static void Test_CanXl_GetPriorityId(void **state)
 {
     const size_t msg_len = AVTP_CANXL_HEADER_LEN + 4;
-    uint8_t msg[msg_len] = {
-        0x22, 0x06, 0x0,  0x0,
-        0x0,  0x0,  0x0,  0x0,
-        0x0,  0x0,  0x0,  0x0,
-        0x0,  0x0,  0x05, 0xFF,
-        0x0,  0x0,  0x0,  0x0,
-        0x0,  0x0,  0x0,  0x0,
-        0x0,  0x0,  0x0,  0x0
-    };
-    Avtp_CanXl_t* canxl = (Avtp_CanXl_t*)msg;
+    uint8_t msg[msg_len] = {0x22, 0x06, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0,
+                            0x05, 0xFF, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0};
+    Avtp_CanXl_t *canxl = (Avtp_CanXl_t *)msg;
     assert_int_equal(Avtp_CanXl_GetPriorityId(canxl), 0x5FF);
 }
 
-static void Test_CanXl_GetAcceptanceField(void** state)
+static void Test_CanXl_GetAcceptanceField(void **state)
 {
     const size_t msg_len = AVTP_CANXL_HEADER_LEN + 4;
-    uint8_t msg[msg_len] = {
-        0x22, 0x06, 0x0,  0x0,
-        0x0,  0x0,  0x0,  0x0,
-        0x0,  0x0,  0x0,  0x0,
-        0x0,  0x0,  0x0,  0x0,
-        0xBF, 0xFF, 0xFF, 0xFF,
-        0x0,  0x0,  0x0,  0x0,
-        0x0,  0x0,  0x0,  0x0
-    };
-    Avtp_CanXl_t* canxl = (Avtp_CanXl_t*)msg;
+    uint8_t msg[msg_len] = {0x22, 0x06, 0x0, 0x0, 0x0, 0x0, 0x0,  0x0,  0x0,  0x0,
+                            0x0,  0x0,  0x0, 0x0, 0x0, 0x0, 0xBF, 0xFF, 0xFF, 0xFF,
+                            0x0,  0x0,  0x0, 0x0, 0x0, 0x0, 0x0,  0x0};
+    Avtp_CanXl_t *canxl = (Avtp_CanXl_t *)msg;
     assert_int_equal(Avtp_CanXl_GetAcceptanceField(canxl), 0xBFFFFFFFul);
 }
 
-static void Test_CanXl_GetTransactionNum(void** state)
+static void Test_CanXl_GetTransactionNum(void **state)
 {
     const size_t msg_len = AVTP_CANXL_HEADER_LEN + 4;
-    uint8_t msg[msg_len] = {
-        0x22, 0x06, 0x0,  0x0,
-        0x0,  0x0,  0x0,  0x0,
-        0x0,  0x0,  0x0,  0x0,
-        0x0,  0x0,  0x0,  0x0,
-        0x0,  0x0,  0x0,  0x0,
-        0x0,  0xBF, 0x0,  0x0,
-        0x0,  0x0,  0x0,  0x0
-    };
-    Avtp_CanXl_t* canxl = (Avtp_CanXl_t*)msg;
+    uint8_t msg[msg_len] = {0x22, 0x06, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0,
+                            0x0,  0x0,  0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0,
+                            0x0,  0xBF, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0};
+    Avtp_CanXl_t *canxl = (Avtp_CanXl_t *)msg;
     assert_int_equal(Avtp_CanXl_GetTransactionNum(canxl), 0xBF);
 }
 
-static void Test_CanXl_IsMs(void** state)
+static void Test_CanXl_IsMs(void **state)
 {
     const size_t msg_len = AVTP_CANXL_HEADER_LEN + 4;
-    uint8_t msg[msg_len] = {
-        0x22, 0x06, 0x0,  0x0,
-        0x0,  0x0,  0x0,  0x0,
-        0x0,  0x0,  0x0,  0x0,
-        0x0,  0x0,  0x0,  0x0,
-        0x0,  0x0,  0x0,  0x0,
-        0x0,  0x0,  0x10, 0x0,
-        0x0,  0x0,  0x0,  0x0
-    };
-    Avtp_CanXl_t* canxl = (Avtp_CanXl_t*)msg;
+    uint8_t msg[msg_len] = {0x22, 0x06, 0x0,  0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0,
+                            0x0,  0x0,  0x0,  0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0,
+                            0x0,  0x0,  0x10, 0x0, 0x0, 0x0, 0x0, 0x0};
+    Avtp_CanXl_t *canxl = (Avtp_CanXl_t *)msg;
     assert_int_equal(Avtp_CanXl_IsMs(canxl), true);
 }
 
-static void Test_CanXl_GetSegmentNum(void** state)
+static void Test_CanXl_GetSegmentNum(void **state)
 {
     const size_t msg_len = AVTP_CANXL_HEADER_LEN + 4;
-    uint8_t msg[msg_len] = {
-        0x22, 0x06, 0x0,  0x0,
-        0x0,  0x0,  0x0,  0x0,
-        0x0,  0x0,  0x0,  0x0,
-        0x0,  0x0,  0x0,  0x0,
-        0x0,  0x0,  0x0,  0x0,
-        0x0,  0x0,  0xB,  0xFF,
-        0x0,  0x0,  0x0,  0x0
-    };
-    Avtp_CanXl_t* canxl = (Avtp_CanXl_t*)msg;
+    uint8_t msg[msg_len] = {0x22, 0x06, 0x0, 0x0,  0x0, 0x0, 0x0, 0x0, 0x0, 0x0,
+                            0x0,  0x0,  0x0, 0x0,  0x0, 0x0, 0x0, 0x0, 0x0, 0x0,
+                            0x0,  0x0,  0xB, 0xFF, 0x0, 0x0, 0x0, 0x0};
+    Avtp_CanXl_t *canxl = (Avtp_CanXl_t *)msg;
     assert_int_equal(Avtp_CanXl_GetSegmentNum(canxl), 0xBFF);
 }
 
-static void Test_CanXl_GetPayloadLength(void** state)
+static void Test_CanXl_GetPayloadLength(void **state)
 {
     const size_t msg_len = AVTP_CANXL_HEADER_LEN + 4;
-    uint8_t msg[msg_len] = {
-        0x22, 0x07, 0xC0, 0x0,
-        0x0,  0x0,  0x0,  0x0,
-        0x0,  0x0,  0x0,  0x0,
-        0x0,  0x0,  0x0,  0x0,
-        0x0,  0x0,  0x0,  0x0,
-        0x0,  0x0,  0x0,  0x0,
-        0x0,  0x0,  0x0,  0x0
-    };
-    Avtp_CanXl_t* canxl = (Avtp_CanXl_t*)msg;
+    uint8_t msg[msg_len] = {0x22, 0x07, 0xC0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0,
+                            0x0,  0x0,  0x0,  0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0,
+                            0x0,  0x0,  0x0,  0x0, 0x0, 0x0, 0x0, 0x0};
+    Avtp_CanXl_t *canxl = (Avtp_CanXl_t *)msg;
     assert_int_equal(Avtp_CanXl_GetPayloadLength(canxl), 1);
 }
 
-static void Test_CanXl_GetPayloadLength_NoPadding(void** state)
+static void Test_CanXl_GetPayloadLength_NoPadding(void **state)
 {
     const size_t msg_len = AVTP_CANXL_HEADER_LEN + 4;
-    uint8_t msg[msg_len] = {
-        0x22, 0x07, 0x0,  0x0,
-        0x0,  0x0,  0x0,  0x0,
-        0x0,  0x0,  0x0,  0x0,
-        0x0,  0x0,  0x0,  0x0,
-        0x0,  0x0,  0x0,  0x0,
-        0x0,  0x0,  0x0,  0x0,
-        0x0,  0x0,  0x0,  0x0
-    };
-    Avtp_CanXl_t* canxl = (Avtp_CanXl_t*)msg;
+    uint8_t msg[msg_len] = {0x22, 0x07, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0,
+                            0x0,  0x0,  0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0};
+    Avtp_CanXl_t *canxl = (Avtp_CanXl_t *)msg;
     assert_int_equal(Avtp_CanXl_GetPayloadLength(canxl), 4);
 }
 
-static void Test_CanXl_GetAcfMsgLengthInBytes(void** state)
+static void Test_CanXl_GetAcfMsgLengthInBytes(void **state)
 {
     const size_t msg_len = AVTP_CANXL_HEADER_LEN + 4;
-    uint8_t msg[msg_len] = {
-        0x22, 0x07, 0x0,  0x0,
-        0x0,  0x0,  0x0,  0x0,
-        0x0,  0x0,  0x0,  0x0,
-        0x0,  0x0,  0x0,  0x0,
-        0x0,  0x0,  0x0,  0x0,
-        0x0,  0x0,  0x0,  0x0,
-        0x0,  0x0,  0x0,  0x0
-    };
-    Avtp_CanXl_t* canxl = (Avtp_CanXl_t*)msg;
+    uint8_t msg[msg_len] = {0x22, 0x07, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0,
+                            0x0,  0x0,  0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0};
+    Avtp_CanXl_t *canxl = (Avtp_CanXl_t *)msg;
     assert_int_equal(Avtp_CanXl_GetAcfMsgLengthInBytes(canxl), 7 * 4);
 }
 
-static void Test_CanXl_SetAcfMsgType(void** state)
+static void Test_CanXl_SetAcfMsgType(void **state)
 {
     const size_t msg_len = AVTP_CANXL_HEADER_LEN + 4;
     uint8_t msg[msg_len] = {0};
-    Avtp_CanXl_t* canxl = (Avtp_CanXl_t*)msg;
+    Avtp_CanXl_t *canxl = (Avtp_CanXl_t *)msg;
     Avtp_CanXl_Init(canxl);
     Avtp_CanXl_SetAcfMsgType(canxl, AVTP_ACF_TYPE_CAN_XL);
     assert_int_equal(Avtp_CanXl_GetAcfMsgType(canxl), AVTP_ACF_TYPE_CAN_XL);
 }
 
-static void Test_CanXl_SetAcfMsgLength(void** state)
+static void Test_CanXl_SetAcfMsgLength(void **state)
 {
     const size_t msg_len = AVTP_CANXL_HEADER_LEN + 4;
     uint8_t msg[msg_len] = {0};
-    Avtp_CanXl_t* canxl = (Avtp_CanXl_t*)msg;
+    Avtp_CanXl_t *canxl = (Avtp_CanXl_t *)msg;
     Avtp_CanXl_Init(canxl);
     Avtp_CanXl_SetAcfMsgLength(canxl, 5);
     assert_int_equal(Avtp_CanXl_GetAcfMsgLength(canxl), 5);
     assert_int_equal(Avtp_CanXl_GetAcfMsgLengthInBytes(canxl), 20);
 }
 
-static void Test_CanXl_SetMtv(void** state)
+static void Test_CanXl_SetMtv(void **state)
 {
     const size_t msg_len = AVTP_CANXL_HEADER_LEN + 4;
     uint8_t msg[msg_len] = {0};
-    Avtp_CanXl_t* canxl = (Avtp_CanXl_t*)msg;
+    Avtp_CanXl_t *canxl = (Avtp_CanXl_t *)msg;
     Avtp_CanXl_Init(canxl);
     Avtp_CanXl_SetMtv(canxl, true);
 
-    uint8_t expected_msg[msg_len] = {
-        0x22, 0x00, 0x20, 0x0,
-        0x0,  0x0,  0x0,  0x0,
-        0x0,  0x0,  0x0,  0x0,
-        0x0,  0x0,  0x0,  0x0,
-        0x0,  0x0,  0x0,  0x0,
-        0x0,  0x0,  0x0,  0x0,
-        0x0,  0x0,  0x0,  0x0
-    };
+    uint8_t expected_msg[msg_len] = {0x22, 0x00, 0x20, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0,
+                                     0x0,  0x0,  0x0,  0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0,
+                                     0x0,  0x0,  0x0,  0x0, 0x0, 0x0, 0x0, 0x0};
     assert_memory_equal(msg, expected_msg, msg_len);
 }
 
-static void Test_CanXl_SetCanBusId(void** state)
+static void Test_CanXl_SetCanBusId(void **state)
 {
     const size_t msg_len = AVTP_CANXL_HEADER_LEN + 4;
     uint8_t msg[msg_len] = {0};
-    Avtp_CanXl_t* canxl = (Avtp_CanXl_t*)msg;
+    Avtp_CanXl_t *canxl = (Avtp_CanXl_t *)msg;
     Avtp_CanXl_Init(canxl);
     Avtp_CanXl_SetCanBusId(canxl, 0x5FF);
 
-    uint8_t expected_msg[msg_len] = {
-        0x22, 0x00, 0x05, 0xFF,
-        0x0,  0x0,  0x0,  0x0,
-        0x0,  0x0,  0x0,  0x0,
-        0x0,  0x0,  0x0,  0x0,
-        0x0,  0x0,  0x0,  0x0,
-        0x0,  0x0,  0x0,  0x0,
-        0x0,  0x0,  0x0,  0x0
-    };
+    uint8_t expected_msg[msg_len] = {0x22, 0x00, 0x05, 0xFF, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0,
+                                     0x0,  0x0,  0x0,  0x0,  0x0, 0x0, 0x0, 0x0, 0x0, 0x0,
+                                     0x0,  0x0,  0x0,  0x0,  0x0, 0x0, 0x0, 0x0};
     assert_memory_equal(msg, expected_msg, msg_len);
 }
 
-static void Test_CanXl_SetMessageTimestamp(void** state)
+static void Test_CanXl_SetMessageTimestamp(void **state)
 {
     const size_t msg_len = AVTP_CANXL_HEADER_LEN + 4;
     uint8_t msg[msg_len] = {0};
-    Avtp_CanXl_t* canxl = (Avtp_CanXl_t*)msg;
+    Avtp_CanXl_t *canxl = (Avtp_CanXl_t *)msg;
     Avtp_CanXl_Init(canxl);
     Avtp_CanXl_SetMessageTimestamp(canxl, 0xBFFFFFFFFFFFFFFFull);
 
-    uint8_t expected_msg[msg_len] = {
-        0x22, 0x00, 0x0,  0x0,
-        0xBF, 0xFF, 0xFF, 0xFF,
-        0xFF, 0xFF, 0xFF, 0xFF,
-        0x0,  0x0,  0x0,  0x0,
-        0x0,  0x0,  0x0,  0x0,
-        0x0,  0x0,  0x0,  0x0,
-        0x0,  0x0,  0x0,  0x0
-    };
+    uint8_t expected_msg[msg_len] = {0x22, 0x00, 0x0, 0x0, 0xBF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF,
+                                     0xFF, 0xFF, 0x0, 0x0, 0x0,  0x0,  0x0,  0x0,  0x0,  0x0,
+                                     0x0,  0x0,  0x0, 0x0, 0x0,  0x0,  0x0,  0x0};
     assert_memory_equal(msg, expected_msg, msg_len);
 }
 
-static void Test_CanXl_SetVcid(void** state)
+static void Test_CanXl_SetVcid(void **state)
 {
     const size_t msg_len = AVTP_CANXL_HEADER_LEN + 4;
     uint8_t msg[msg_len] = {0};
-    Avtp_CanXl_t* canxl = (Avtp_CanXl_t*)msg;
+    Avtp_CanXl_t *canxl = (Avtp_CanXl_t *)msg;
     Avtp_CanXl_Init(canxl);
     Avtp_CanXl_SetVcid(canxl, 0xBF);
 
-    uint8_t expected_msg[msg_len] = {
-        0x22, 0x00, 0x0,  0x0,
-        0x0,  0x0,  0x0,  0x0,
-        0x0,  0x0,  0x0,  0x0,
-        0xBF, 0x0,  0x0,  0x0,
-        0x0,  0x0,  0x0,  0x0,
-        0x0,  0x0,  0x0,  0x0,
-        0x0,  0x0,  0x0,  0x0
-    };
+    uint8_t expected_msg[msg_len] = {0x22, 0x00, 0x0,  0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0,
+                                     0x0,  0x0,  0xBF, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0,
+                                     0x0,  0x0,  0x0,  0x0, 0x0, 0x0, 0x0, 0x0};
     assert_memory_equal(msg, expected_msg, msg_len);
 }
 
-static void Test_CanXl_SetSdt(void** state)
+static void Test_CanXl_SetSdt(void **state)
 {
     const size_t msg_len = AVTP_CANXL_HEADER_LEN + 4;
     uint8_t msg[msg_len] = {0};
-    Avtp_CanXl_t* canxl = (Avtp_CanXl_t*)msg;
+    Avtp_CanXl_t *canxl = (Avtp_CanXl_t *)msg;
     Avtp_CanXl_Init(canxl);
     Avtp_CanXl_SetSdt(canxl, 0xBF);
 
-    uint8_t expected_msg[msg_len] = {
-        0x22, 0x00, 0x0,  0x0,
-        0x0,  0x0,  0x0,  0x0,
-        0x0,  0x0,  0x0,  0x0,
-        0x0,  0xBF, 0x0,  0x0,
-        0x0,  0x0,  0x0,  0x0,
-        0x0,  0x0,  0x0,  0x0,
-        0x0,  0x0,  0x0,  0x0
-    };
+    uint8_t expected_msg[msg_len] = {0x22, 0x00, 0x0, 0x0,  0x0, 0x0, 0x0, 0x0, 0x0, 0x0,
+                                     0x0,  0x0,  0x0, 0xBF, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0,
+                                     0x0,  0x0,  0x0, 0x0,  0x0, 0x0, 0x0, 0x0};
     assert_memory_equal(msg, expected_msg, msg_len);
 }
 
-static void Test_CanXl_SetRrs(void** state)
+static void Test_CanXl_SetRrs(void **state)
 {
     const size_t msg_len = AVTP_CANXL_HEADER_LEN + 4;
     uint8_t msg[msg_len] = {0};
-    Avtp_CanXl_t* canxl = (Avtp_CanXl_t*)msg;
+    Avtp_CanXl_t *canxl = (Avtp_CanXl_t *)msg;
     Avtp_CanXl_Init(canxl);
     Avtp_CanXl_SetRrs(canxl, true);
 
-    uint8_t expected_msg[msg_len] = {
-        0x22, 0x00, 0x0,  0x0,
-        0x0,  0x0,  0x0,  0x0,
-        0x0,  0x0,  0x0,  0x0,
-        0x0,  0x0,  0x10, 0x0,
-        0x0,  0x0,  0x0,  0x0,
-        0x0,  0x0,  0x0,  0x0,
-        0x0,  0x0,  0x0,  0x0
-    };
+    uint8_t expected_msg[msg_len] = {0x22, 0x00, 0x0, 0x0, 0x0,  0x0, 0x0, 0x0, 0x0, 0x0,
+                                     0x0,  0x0,  0x0, 0x0, 0x10, 0x0, 0x0, 0x0, 0x0, 0x0,
+                                     0x0,  0x0,  0x0, 0x0, 0x0,  0x0, 0x0, 0x0};
     assert_memory_equal(msg, expected_msg, msg_len);
 }
 
-static void Test_CanXl_SetSec(void** state)
+static void Test_CanXl_SetSec(void **state)
 {
     const size_t msg_len = AVTP_CANXL_HEADER_LEN + 4;
     uint8_t msg[msg_len] = {0};
-    Avtp_CanXl_t* canxl = (Avtp_CanXl_t*)msg;
+    Avtp_CanXl_t *canxl = (Avtp_CanXl_t *)msg;
     Avtp_CanXl_Init(canxl);
     Avtp_CanXl_SetSec(canxl, true);
 
-    uint8_t expected_msg[msg_len] = {
-        0x22, 0x00, 0x0,  0x0,
-        0x0,  0x0,  0x0,  0x0,
-        0x0,  0x0,  0x0,  0x0,
-        0x0,  0x0,  0x8,  0x0,
-        0x0,  0x0,  0x0,  0x0,
-        0x0,  0x0,  0x0,  0x0,
-        0x0,  0x0,  0x0,  0x0
-    };
+    uint8_t expected_msg[msg_len] = {0x22, 0x00, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0,
+                                     0x0,  0x0,  0x0, 0x0, 0x8, 0x0, 0x0, 0x0, 0x0, 0x0,
+                                     0x0,  0x0,  0x0, 0x0, 0x0, 0x0, 0x0, 0x0};
     assert_memory_equal(msg, expected_msg, msg_len);
 }
 
-static void Test_CanXl_SetPriorityId(void** state)
+static void Test_CanXl_SetPriorityId(void **state)
 {
     const size_t msg_len = AVTP_CANXL_HEADER_LEN + 4;
     uint8_t msg[msg_len] = {0};
-    Avtp_CanXl_t* canxl = (Avtp_CanXl_t*)msg;
+    Avtp_CanXl_t *canxl = (Avtp_CanXl_t *)msg;
     Avtp_CanXl_Init(canxl);
     Avtp_CanXl_SetPriorityId(canxl, 0x5FF);
 
-    uint8_t expected_msg[msg_len] = {
-        0x22, 0x00, 0x0,  0x0,
-        0x0,  0x0,  0x0,  0x0,
-        0x0,  0x0,  0x0,  0x0,
-        0x0,  0x0,  0x05, 0xFF,
-        0x0,  0x0,  0x0,  0x0,
-        0x0,  0x0,  0x0,  0x0,
-        0x0,  0x0,  0x0,  0x0
-    };
+    uint8_t expected_msg[msg_len] = {0x22, 0x00, 0x0, 0x0, 0x0,  0x0,  0x0, 0x0, 0x0, 0x0,
+                                     0x0,  0x0,  0x0, 0x0, 0x05, 0xFF, 0x0, 0x0, 0x0, 0x0,
+                                     0x0,  0x0,  0x0, 0x0, 0x0,  0x0,  0x0, 0x0};
     assert_memory_equal(msg, expected_msg, msg_len);
 }
 
-static void Test_CanXl_SetAcceptanceField(void** state)
+static void Test_CanXl_SetAcceptanceField(void **state)
 {
     const size_t msg_len = AVTP_CANXL_HEADER_LEN + 4;
     uint8_t msg[msg_len] = {0};
-    Avtp_CanXl_t* canxl = (Avtp_CanXl_t*)msg;
+    Avtp_CanXl_t *canxl = (Avtp_CanXl_t *)msg;
     Avtp_CanXl_Init(canxl);
     Avtp_CanXl_SetAcceptanceField(canxl, 0xBFFFFFFFul);
 
-    uint8_t expected_msg[msg_len] = {
-        0x22, 0x00, 0x0,  0x0,
-        0x0,  0x0,  0x0,  0x0,
-        0x0,  0x0,  0x0,  0x0,
-        0x0,  0x0,  0x0,  0x0,
-        0xBF, 0xFF, 0xFF, 0xFF,
-        0x0,  0x0,  0x0,  0x0,
-        0x0,  0x0,  0x0,  0x0
-    };
+    uint8_t expected_msg[msg_len] = {0x22, 0x00, 0x0, 0x0, 0x0, 0x0, 0x0,  0x0,  0x0,  0x0,
+                                     0x0,  0x0,  0x0, 0x0, 0x0, 0x0, 0xBF, 0xFF, 0xFF, 0xFF,
+                                     0x0,  0x0,  0x0, 0x0, 0x0, 0x0, 0x0,  0x0};
     assert_memory_equal(msg, expected_msg, msg_len);
 }
 
-static void Test_CanXl_SetTransactionNum(void** state)
+static void Test_CanXl_SetTransactionNum(void **state)
 {
     const size_t msg_len = AVTP_CANXL_HEADER_LEN + 4;
     uint8_t msg[msg_len] = {0};
-    Avtp_CanXl_t* canxl = (Avtp_CanXl_t*)msg;
+    Avtp_CanXl_t *canxl = (Avtp_CanXl_t *)msg;
     Avtp_CanXl_Init(canxl);
     Avtp_CanXl_SetTransactionNum(canxl, 0xBF);
 
-    uint8_t expected_msg[msg_len] = {
-        0x22, 0x00, 0x0,  0x0,
-        0x0,  0x0,  0x0,  0x0,
-        0x0,  0x0,  0x0,  0x0,
-        0x0,  0x0,  0x0,  0x0,
-        0x0,  0x0,  0x0,  0x0,
-        0x0,  0xBF, 0x0,  0x0,
-        0x0,  0x0,  0x0,  0x0
-    };
+    uint8_t expected_msg[msg_len] = {0x22, 0x00, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0,
+                                     0x0,  0x0,  0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0,
+                                     0x0,  0xBF, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0};
     assert_memory_equal(msg, expected_msg, msg_len);
 }
 
-static void Test_CanXl_SetMs(void** state)
+static void Test_CanXl_SetMs(void **state)
 {
     const size_t msg_len = AVTP_CANXL_HEADER_LEN + 4;
     uint8_t msg[msg_len] = {0};
-    Avtp_CanXl_t* canxl = (Avtp_CanXl_t*)msg;
+    Avtp_CanXl_t *canxl = (Avtp_CanXl_t *)msg;
     Avtp_CanXl_Init(canxl);
     Avtp_CanXl_SetMs(canxl, true);
 
-    uint8_t expected_msg[msg_len] = {
-        0x22, 0x00, 0x0,  0x0,
-        0x0,  0x0,  0x0,  0x0,
-        0x0,  0x0,  0x0,  0x0,
-        0x0,  0x0,  0x0,  0x0,
-        0x0,  0x0,  0x0,  0x0,
-        0x0,  0x0,  0x10, 0x0,
-        0x0,  0x0,  0x0,  0x0
-    };
+    uint8_t expected_msg[msg_len] = {0x22, 0x00, 0x0,  0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0,
+                                     0x0,  0x0,  0x0,  0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0,
+                                     0x0,  0x0,  0x10, 0x0, 0x0, 0x0, 0x0, 0x0};
     assert_memory_equal(msg, expected_msg, msg_len);
 }
 
-static void Test_CanXl_SetSegmentNum(void** state)
+static void Test_CanXl_SetSegmentNum(void **state)
 {
     const size_t msg_len = AVTP_CANXL_HEADER_LEN + 4;
     uint8_t msg[msg_len] = {0};
-    Avtp_CanXl_t* canxl = (Avtp_CanXl_t*)msg;
+    Avtp_CanXl_t *canxl = (Avtp_CanXl_t *)msg;
     Avtp_CanXl_Init(canxl);
     Avtp_CanXl_SetSegmentNum(canxl, 0xBFF);
 
-    uint8_t expected_msg[msg_len] = {
-        0x22, 0x00, 0x0,  0x0,
-        0x0,  0x0,  0x0,  0x0,
-        0x0,  0x0,  0x0,  0x0,
-        0x0,  0x0,  0x0,  0x0,
-        0x0,  0x0,  0x0,  0x0,
-        0x0,  0x0,  0x0B, 0xFF,
-        0x0,  0x0,  0x0,  0x0
-    };
+    uint8_t expected_msg[msg_len] = {0x22, 0x00, 0x0,  0x0,  0x0, 0x0, 0x0, 0x0, 0x0, 0x0,
+                                     0x0,  0x0,  0x0,  0x0,  0x0, 0x0, 0x0, 0x0, 0x0, 0x0,
+                                     0x0,  0x0,  0x0B, 0xFF, 0x0, 0x0, 0x0, 0x0};
     assert_memory_equal(msg, expected_msg, msg_len);
 }
 
-static void Test_CanXl_SetPayloadLength(void** state)
+static void Test_CanXl_SetPayloadLength(void **state)
 {
     const size_t msg_len = AVTP_CANXL_HEADER_LEN + 4;
     uint8_t msg[msg_len] = {0};
-    Avtp_CanXl_t* canxl = (Avtp_CanXl_t*)msg;
+    Avtp_CanXl_t *canxl = (Avtp_CanXl_t *)msg;
     Avtp_CanXl_Init(canxl);
     Avtp_CanXl_SetPayloadLength(canxl, 3);
 
-    uint8_t expected_msg[msg_len] = {
-        0x22, 0x07, 0x40, 0x0,
-        0x0,  0x0,  0x0,  0x0,
-        0x0,  0x0,  0x0,  0x0,
-        0x0,  0x0,  0x0,  0x0,
-        0x0,  0x0,  0x0,  0x0,
-        0x0,  0x0,  0x0,  0x0,
-        0x0,  0x0,  0x0,  0x0
-    };
+    uint8_t expected_msg[msg_len] = {0x22, 0x07, 0x40, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0,
+                                     0x0,  0x0,  0x0,  0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0,
+                                     0x0,  0x0,  0x0,  0x0, 0x0, 0x0, 0x0, 0x0};
     assert_memory_equal(msg, expected_msg, msg_len);
 }
 
-static void Test_CanXl_SetPayloadLength_NoPadding(void** state)
+static void Test_CanXl_SetPayloadLength_NoPadding(void **state)
 {
     const size_t msg_len = AVTP_CANXL_HEADER_LEN + 4;
     uint8_t msg[msg_len] = {0};
-    Avtp_CanXl_t* canxl = (Avtp_CanXl_t*)msg;
+    Avtp_CanXl_t *canxl = (Avtp_CanXl_t *)msg;
     Avtp_CanXl_Init(canxl);
     Avtp_CanXl_SetPayloadLength(canxl, 4);
 
-    uint8_t expected_msg[msg_len] = {
-        0x22, 0x07, 0x0,  0x0,
-        0x0,  0x0,  0x0,  0x0,
-        0x0,  0x0,  0x0,  0x0,
-        0x0,  0x0,  0x0,  0x0,
-        0x0,  0x0,  0x0,  0x0,
-        0x0,  0x0,  0x0,  0x0,
-        0x0,  0x0,  0x0,  0x0
-    };
+    uint8_t expected_msg[msg_len] = {0x22, 0x07, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0,
+                                     0x0,  0x0,  0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0,
+                                     0x0,  0x0,  0x0, 0x0, 0x0, 0x0, 0x0, 0x0};
     assert_memory_equal(msg, expected_msg, msg_len);
 }
 
-static void Test_CanXl_Payload(void** state)
+static void Test_CanXl_Payload(void **state)
 {
     const size_t msg_len = AVTP_CANXL_HEADER_LEN + 8;
     uint8_t msg[msg_len] = {0};
-    Avtp_CanXl_t* canxl = (Avtp_CanXl_t*)msg;
-    uint8_t payload[8] = {0,1,2,3,4,5,6,7};
+    Avtp_CanXl_t *canxl = (Avtp_CanXl_t *)msg;
+    uint8_t payload[8] = {0, 1, 2, 3, 4, 5, 6, 7};
 
     Avtp_CanXl_Init(canxl);
     Avtp_CanXl_SetPayload(canxl, payload, sizeof(payload));
@@ -666,12 +460,12 @@ static void Test_CanXl_Payload(void** state)
     assert_memory_equal(payload, Avtp_CanXl_GetPayload(canxl), sizeof(payload));
 }
 
-static void Test_CanXl_CreateAcfMessage(void** state)
+static void Test_CanXl_CreateAcfMessage(void **state)
 {
     const size_t msg_len = AVTP_CANXL_HEADER_LEN + 8;
     uint8_t msg[msg_len] = {0};
-    Avtp_CanXl_t* canxl = (Avtp_CanXl_t*)msg;
-    uint8_t payload[8] = {0,1,2,3,4,5,6,7};
+    Avtp_CanXl_t *canxl = (Avtp_CanXl_t *)msg;
+    uint8_t payload[8] = {0, 1, 2, 3, 4, 5, 6, 7};
 
     Avtp_CanXl_CreateAcfMessage(canxl, 0x5FF, 0xBFFFFFFFul, 0xBF, payload, sizeof(payload));
 
@@ -691,12 +485,12 @@ static void Test_CanXl_CreateAcfMessage(void** state)
     assert_int_equal(Avtp_CanXl_GetMessageTimestamp(canxl), 0x123456789ABCDEF0ULL);
 }
 
-static void Test_CanXl_CreateFromGarbage(void** state)
+static void Test_CanXl_CreateFromGarbage(void **state)
 {
     const size_t msg_len = AVTP_CANXL_HEADER_LEN + 8;
     uint8_t msg[msg_len];
-    Avtp_CanXl_t* canxl = (Avtp_CanXl_t*)msg;
-    uint8_t payload[8] = {0,1,2,3,4,5,6,7};
+    Avtp_CanXl_t *canxl = (Avtp_CanXl_t *)msg;
+    uint8_t payload[8] = {0, 1, 2, 3, 4, 5, 6, 7};
 
     // CreateAcfMessage must fully initialize the header even on garbage input.
     memset(msg, 0xAA, msg_len);
@@ -713,12 +507,12 @@ static void Test_CanXl_CreateFromGarbage(void** state)
     assert_int_equal(Avtp_CanXl_IsValid(canxl, msg_len), 1);
 }
 
-static void Test_CanXl_IsValid(void** state)
+static void Test_CanXl_IsValid(void **state)
 {
     const size_t msg_len = AVTP_CANXL_HEADER_LEN + 32;
     uint8_t msg[msg_len] = {0};
-    Avtp_CanXl_t* canxl = (Avtp_CanXl_t*)msg;
-    uint8_t payload[8] = {0,1,2,3,4,5,6,7};
+    Avtp_CanXl_t *canxl = (Avtp_CanXl_t *)msg;
+    uint8_t payload[8] = {0, 1, 2, 3, 4, 5, 6, 7};
 
     // An Init-only PDU has AcfMsgLength == 0, so IsValid must reject it.
     Avtp_CanXl_Init(canxl);
@@ -739,47 +533,45 @@ static void Test_CanXl_IsValid(void** state)
 
 int main(void)
 {
-    const struct CMUnitTest tests[] = {
-        cmocka_unit_test(Test_CanXl_Init),
-        cmocka_unit_test(Test_CanXl_GetAcfMsgType),
-        cmocka_unit_test(Test_CanXl_GetAcfMsgLength),
-        cmocka_unit_test(Test_CanXl_GetPad),
-        cmocka_unit_test(Test_CanXl_IsMtv),
-        cmocka_unit_test(Test_CanXl_GetCanBusId),
-        cmocka_unit_test(Test_CanXl_GetMessageTimestamp),
-        cmocka_unit_test(Test_CanXl_GetVcid),
-        cmocka_unit_test(Test_CanXl_GetSdt),
-        cmocka_unit_test(Test_CanXl_IsRrs),
-        cmocka_unit_test(Test_CanXl_IsSec),
-        cmocka_unit_test(Test_CanXl_GetPriorityId),
-        cmocka_unit_test(Test_CanXl_GetAcceptanceField),
-        cmocka_unit_test(Test_CanXl_GetTransactionNum),
-        cmocka_unit_test(Test_CanXl_IsMs),
-        cmocka_unit_test(Test_CanXl_GetSegmentNum),
-        cmocka_unit_test(Test_CanXl_GetPayloadLength),
-        cmocka_unit_test(Test_CanXl_GetPayloadLength_NoPadding),
-        cmocka_unit_test(Test_CanXl_GetAcfMsgLengthInBytes),
-        cmocka_unit_test(Test_CanXl_SetAcfMsgType),
-        cmocka_unit_test(Test_CanXl_SetAcfMsgLength),
-        cmocka_unit_test(Test_CanXl_SetMtv),
-        cmocka_unit_test(Test_CanXl_SetCanBusId),
-        cmocka_unit_test(Test_CanXl_SetMessageTimestamp),
-        cmocka_unit_test(Test_CanXl_SetVcid),
-        cmocka_unit_test(Test_CanXl_SetSdt),
-        cmocka_unit_test(Test_CanXl_SetRrs),
-        cmocka_unit_test(Test_CanXl_SetSec),
-        cmocka_unit_test(Test_CanXl_SetPriorityId),
-        cmocka_unit_test(Test_CanXl_SetAcceptanceField),
-        cmocka_unit_test(Test_CanXl_SetTransactionNum),
-        cmocka_unit_test(Test_CanXl_SetMs),
-        cmocka_unit_test(Test_CanXl_SetSegmentNum),
-        cmocka_unit_test(Test_CanXl_SetPayloadLength),
-        cmocka_unit_test(Test_CanXl_SetPayloadLength_NoPadding),
-        cmocka_unit_test(Test_CanXl_Payload),
-        cmocka_unit_test(Test_CanXl_CreateAcfMessage),
-        cmocka_unit_test(Test_CanXl_CreateFromGarbage),
-        cmocka_unit_test(Test_CanXl_IsValid)
-    };
+    const struct CMUnitTest tests[] = {cmocka_unit_test(Test_CanXl_Init),
+                                       cmocka_unit_test(Test_CanXl_GetAcfMsgType),
+                                       cmocka_unit_test(Test_CanXl_GetAcfMsgLength),
+                                       cmocka_unit_test(Test_CanXl_GetPad),
+                                       cmocka_unit_test(Test_CanXl_IsMtv),
+                                       cmocka_unit_test(Test_CanXl_GetCanBusId),
+                                       cmocka_unit_test(Test_CanXl_GetMessageTimestamp),
+                                       cmocka_unit_test(Test_CanXl_GetVcid),
+                                       cmocka_unit_test(Test_CanXl_GetSdt),
+                                       cmocka_unit_test(Test_CanXl_IsRrs),
+                                       cmocka_unit_test(Test_CanXl_IsSec),
+                                       cmocka_unit_test(Test_CanXl_GetPriorityId),
+                                       cmocka_unit_test(Test_CanXl_GetAcceptanceField),
+                                       cmocka_unit_test(Test_CanXl_GetTransactionNum),
+                                       cmocka_unit_test(Test_CanXl_IsMs),
+                                       cmocka_unit_test(Test_CanXl_GetSegmentNum),
+                                       cmocka_unit_test(Test_CanXl_GetPayloadLength),
+                                       cmocka_unit_test(Test_CanXl_GetPayloadLength_NoPadding),
+                                       cmocka_unit_test(Test_CanXl_GetAcfMsgLengthInBytes),
+                                       cmocka_unit_test(Test_CanXl_SetAcfMsgType),
+                                       cmocka_unit_test(Test_CanXl_SetAcfMsgLength),
+                                       cmocka_unit_test(Test_CanXl_SetMtv),
+                                       cmocka_unit_test(Test_CanXl_SetCanBusId),
+                                       cmocka_unit_test(Test_CanXl_SetMessageTimestamp),
+                                       cmocka_unit_test(Test_CanXl_SetVcid),
+                                       cmocka_unit_test(Test_CanXl_SetSdt),
+                                       cmocka_unit_test(Test_CanXl_SetRrs),
+                                       cmocka_unit_test(Test_CanXl_SetSec),
+                                       cmocka_unit_test(Test_CanXl_SetPriorityId),
+                                       cmocka_unit_test(Test_CanXl_SetAcceptanceField),
+                                       cmocka_unit_test(Test_CanXl_SetTransactionNum),
+                                       cmocka_unit_test(Test_CanXl_SetMs),
+                                       cmocka_unit_test(Test_CanXl_SetSegmentNum),
+                                       cmocka_unit_test(Test_CanXl_SetPayloadLength),
+                                       cmocka_unit_test(Test_CanXl_SetPayloadLength_NoPadding),
+                                       cmocka_unit_test(Test_CanXl_Payload),
+                                       cmocka_unit_test(Test_CanXl_CreateAcfMessage),
+                                       cmocka_unit_test(Test_CanXl_CreateFromGarbage),
+                                       cmocka_unit_test(Test_CanXl_IsValid)};
 
     return cmocka_run_group_tests(tests, NULL, NULL);
 }


### PR DESCRIPTION
  - packed structs; 
  - renamed enum/table/macros (Avtp_CanXlFields_t/Avtp_CanXlFieldDesc/GET_CANXL_FIELD, and the Brief equivalents;    
  - added Get/SetAcfMsgType, Get/SetAcfMsgLength, GetAcfMsgLengthInBytes, GetPayload, SetPayload, SetPad; renamed GetLen→GetAcfMsgLengthInBytes, GetPayloadLen→GetPayloadLength (uint8_t), SetPayloadLen→SetPayloadLength (pad-zeroing); added inline CreateAcfMessage (priority_id + acceptance_field + sdt + payload) and IsValid; Init now matches Can (null-guarded, msg type only).
     - Note: CreateAcfMessage did not exist, and I am not super familiar with CAN XL but it seemed priority_id, acceptance and sdt are always needed/useful. 
 - Tests: updated names/expectations and added common-field accessors, payload helpers, CreateAcfMessage round-trip, IsValid, and garbage-buffer coverage for both.
