### PR TITLE
ABB/GBB apply API guidelines

### DIFF
--- a/include/avtp/acf/Abb.h
+++ b/include/avtp/acf/Abb.h
@@ -44,9 +44,14 @@ extern "C" {
 #include <stdbool.h>
 #include <string.h>
 
+#include "avtp/Utils.h"
 #include "avtp/Defines.h"
 #include "avtp/acf/AcfCommon.h"
-#include "avtp/Utils.h"
+
+#define GET_ABB_FIELD(field)                                                                       \
+    (Avtp_GetField(Avtp_AbbFieldDesc, AVTP_ABB_FIELD_MAX, (uint8_t *)pdu, field))
+#define SET_ABB_FIELD(field, value)                                                                \
+    (Avtp_SetField(Avtp_AbbFieldDesc, AVTP_ABB_FIELD_MAX, (uint8_t *)pdu, field, value))
 
 /**
  * Length of ACF_ABB message header in bytes.
@@ -60,7 +65,7 @@ extern "C" {
 typedef struct {
     uint8_t header[AVTP_ABB_HEADER_LEN];
     uint8_t payload[0];
-} Avtp_Abb_t;
+} __attribute__((packed)) Avtp_Abb_t;
 
 /**
  * Fields encoded in the ACF_ABB header.
@@ -84,12 +89,12 @@ typedef enum {
     AVTP_ABB_FIELD_READ_SIZE_SEGMENT_NUM,
     /* Count number of fields for bound checks */
     AVTP_ABB_FIELD_MAX
-} Avtp_AbbField_t;
+} Avtp_AbbFields_t;
 
 /**
  * This table describes all the offsets of the ACF_ABB header fields.
  */
-static const Avtp_FieldDescriptor_t __AVTP_ABB_FIELDS[AVTP_ABB_FIELD_MAX] =
+static const Avtp_FieldDescriptor_t Avtp_AbbFieldDesc[AVTP_ABB_FIELD_MAX] =
 {
     /* ACF common header fields */
     [AVTP_ABB_FIELD_ACF_MSG_TYPE]           = { .quadlet = 0, .offset =  0, .bits = 7   },
@@ -110,330 +115,464 @@ static const Avtp_FieldDescriptor_t __AVTP_ABB_FIELDS[AVTP_ABB_FIELD_MAX] =
 };
 
 /**
- * Macro to get the value of a field from an ACF_ABB message header.
- * 
- * @note This macro should not be used directly, instead use the field specific
- * getter functions defined below.
- */
-#define __Avtp_Abb_GetField(field) \
-        (Avtp_GetField(__AVTP_ABB_FIELDS, AVTP_ABB_FIELD_MAX, (uint8_t*)msg, field))
-
-/**
- * Macro to set the value of a field in an ACF_ABB message header.
- * 
- * @note This macro should not be used directly, instead use the field specific
- * setter functions defined below.
- */
-#define __Avtp_Abb_SetField(field, value) \
-        (Avtp_SetField(__AVTP_ABB_FIELDS, AVTP_ABB_FIELD_MAX, (uint8_t*)msg, field, value))
-
-/**
- * Initializes an ACF_ABB message with default values for the header fields
- * including acf_msg_type and acf_msg_length.
+ * Return the value of the ACF message type field as specified in the IEEE 1722 Specification.
  *
- * @param msg Pointer to the ACF_ABB message to initialize.
+ * @param pdu Pointer to the first bit of a 1722 ACF ABB PDU.
+ * @returns Value of the ACF message type field.
  */
-OPEN1722_INLINE void Avtp_Abb_Init(Avtp_Abb_t* msg) {
-    memset(msg, 0, sizeof(Avtp_Abb_t));
-    __Avtp_Abb_SetField(AVTP_ABB_FIELD_ACF_MSG_TYPE, AVTP_ACF_TYPE_BYTE_BUS_BRIEF);
-    __Avtp_Abb_SetField(AVTP_ABB_FIELD_ACF_MSG_LENGTH, AVTP_ABB_HEADER_LEN / AVTP_QUADLET_SIZE);
+OPEN1722_INLINE uint8_t Avtp_Abb_GetAcfMsgType(const Avtp_Abb_t* const pdu) {
+    return (uint8_t) GET_ABB_FIELD(AVTP_ABB_FIELD_ACF_MSG_TYPE);
+}
+
+/**
+ * Return the value of the ACF message length field as specified in the IEEE 1722 Specification.
+ * This returns the length in Quadlets as specified in the IEEE 1722 Specification.
+ *
+ * You can use Avtp_Abb_GetPayloadLength to get the length in bytes without padding.
+ *
+ * @param pdu Pointer to the first bit of a 1722 ACF ABB PDU.
+ * @returns Value of the ACF message length field.
+ */
+OPEN1722_INLINE uint16_t Avtp_Abb_GetAcfMsgLength(const Avtp_Abb_t* const pdu) {
+    return (uint16_t) GET_ABB_FIELD(AVTP_ABB_FIELD_ACF_MSG_LENGTH);
+}
+
+/**
+ * Return the ACF message length in bytes.
+ *
+ * @param pdu Pointer to the first bit of a 1722 ACF ABB PDU.
+ * @returns Length of the ACF message in bytes.
+ */
+OPEN1722_INLINE uint16_t Avtp_Abb_GetAcfMsgLengthInBytes(const Avtp_Abb_t* const pdu) {
+    return (uint16_t) GET_ABB_FIELD(AVTP_ABB_FIELD_ACF_MSG_LENGTH) * 4;
+}
+
+/**
+ * Set the value of the ACF message type field as specified in the IEEE 1722 Specification.
+ *
+ * @param pdu Pointer to the first bit of a 1722 ACF ABB PDU.
+ * @param value Value to set the ACF message type field to.
+ */
+OPEN1722_INLINE void Avtp_Abb_SetAcfMsgType(Avtp_Abb_t* pdu, uint8_t value) {
+    SET_ABB_FIELD(AVTP_ABB_FIELD_ACF_MSG_TYPE, value);
+}
+
+/**
+ * Set the value of the ACF message length field as specified in the IEEE 1722 Specification.
+ * Note: the size is in Quadlets as specified in the IEEE 1722 Specification.
+ * You can use Avtp_Abb_SetPayloadLength to set length in bytes and automatically set the
+ * correct padding.
+ *
+ * @param pdu Pointer to the first bit of a 1722 ACF ABB PDU.
+ * @param value Value to set the ACF message length field to.
+ */
+OPEN1722_INLINE void Avtp_Abb_SetAcfMsgLength(Avtp_Abb_t* pdu, uint16_t value) {
+    SET_ABB_FIELD(AVTP_ABB_FIELD_ACF_MSG_LENGTH, value);
 }
 
 /**
  * Returns the pad field from an ACF_ABB message header.
- * 
- * @param msg Pointer to an ACF_ABB message.
+ *
+ * @param pdu Pointer to an ACF_ABB message.
  * @returns The value of the pad field.
  */
-OPEN1722_INLINE uint8_t Avtp_Abb_GetPad(const Avtp_Abb_t* msg) {
-    return (uint8_t) __Avtp_Abb_GetField(AVTP_ABB_FIELD_PAD);
+OPEN1722_INLINE uint8_t Avtp_Abb_GetPad(const Avtp_Abb_t* const pdu) {
+    return (uint8_t) GET_ABB_FIELD(AVTP_ABB_FIELD_PAD);
 }
 
 /**
- * Returns the message timestamp valid flag (mtv) from an ACF_ABB message
- * header.
- * 
- * @param msg Pointer to an ACF_ABB message.
+ * Sets the pad field in an ACF_ABB message header.
+ *
+ * @param pdu Pointer to an ACF_ABB message.
+ * @param pad The value to set.
+ */
+OPEN1722_INLINE void Avtp_Abb_SetPad(Avtp_Abb_t* pdu, uint8_t pad) {
+    SET_ABB_FIELD(AVTP_ABB_FIELD_PAD, pad);
+}
+
+/**
+ * Returns the message timestamp valid flag (mtv) from an ACF_ABB message header.
+ *
+ * @param pdu Pointer to an ACF_ABB message.
  * @returns The value of the mtv flag.
  */
-OPEN1722_INLINE bool Avtp_Abb_IsMtv(const Avtp_Abb_t* msg) {
-    return (bool) __Avtp_Abb_GetField(AVTP_ABB_FIELD_MTV);
+OPEN1722_INLINE bool Avtp_Abb_IsMtv(const Avtp_Abb_t* const pdu) {
+    return (bool) GET_ABB_FIELD(AVTP_ABB_FIELD_MTV);
 }
 
 /**
  * Returns the value of the byte_bus_id field from an ACF_ABB message header.
- * 
- * @param msg Pointer to an ACF_ABB message.
+ *
+ * @param pdu Pointer to an ACF_ABB message.
  * @returns The value of the byte_bus_id field.
  */
-OPEN1722_INLINE uint16_t Avtp_Abb_GetByteBusId(const Avtp_Abb_t* msg) {
-    return (uint16_t) __Avtp_Abb_GetField(AVTP_ABB_FIELD_BYTE_BUS_ID);
+OPEN1722_INLINE uint16_t Avtp_Abb_GetByteBusId(const Avtp_Abb_t* const pdu) {
+    return (uint16_t) GET_ABB_FIELD(AVTP_ABB_FIELD_BYTE_BUS_ID);
 }
 
 /**
  * Returns the value of the evt field from an ACF_ABB message header.
- * 
- * @param msg Pointer to an ACF_ABB message.
+ *
+ * @param pdu Pointer to an ACF_ABB message.
  * @returns The value of the evt field.
  */
-OPEN1722_INLINE uint8_t Avtp_Abb_GetEvt(const Avtp_Abb_t* msg) {
-    return (uint8_t) __Avtp_Abb_GetField(AVTP_ABB_FIELD_EVT);
+OPEN1722_INLINE uint8_t Avtp_Abb_GetEvt(const Avtp_Abb_t* const pdu) {
+    return (uint8_t) GET_ABB_FIELD(AVTP_ABB_FIELD_EVT);
 }
 
 /**
  * Returns the value of the hs field from an ACF_ABB message header.
- * 
- * @param msg Pointer to an ACF_ABB message.
+ *
+ * @param pdu Pointer to an ACF_ABB message.
  * @returns The value of the hs field.
  */
-OPEN1722_INLINE bool Avtp_Abb_IsHs(const Avtp_Abb_t* msg) {
-    return (bool) __Avtp_Abb_GetField(AVTP_ABB_FIELD_HS);
+OPEN1722_INLINE bool Avtp_Abb_IsHs(const Avtp_Abb_t* const pdu) {
+    return (bool) GET_ABB_FIELD(AVTP_ABB_FIELD_HS);
 }
 
 /**
  * Returns the value of the cs field from an ACF_ABB message header.
- * 
- * @param msg Pointer to an ACF_ABB message.
+ *
+ * @param pdu Pointer to an ACF_ABB message.
  * @returns The value of the cs field.
  */
-OPEN1722_INLINE bool Avtp_Abb_IsCs(const Avtp_Abb_t* msg) {
-    return (bool) __Avtp_Abb_GetField(AVTP_ABB_FIELD_CS);
+OPEN1722_INLINE bool Avtp_Abb_IsCs(const Avtp_Abb_t* const pdu) {
+    return (bool) GET_ABB_FIELD(AVTP_ABB_FIELD_CS);
 }
 
 /**
- * Returns the value of the transaction_num field from an ACF_ABB message
- * header.
- * 
- * @param msg Pointer to an ACF_ABB message.
+ * Returns the value of the transaction_num field from an ACF_ABB message header.
+ *
+ * @param pdu Pointer to an ACF_ABB message.
  * @returns The value of the transaction_num field.
  */
-OPEN1722_INLINE uint8_t Avtp_Abb_GetTransactionNum(const Avtp_Abb_t* msg) {
-    return (uint8_t) __Avtp_Abb_GetField(AVTP_ABB_FIELD_TRANSACTION_NUM);
+OPEN1722_INLINE uint8_t Avtp_Abb_GetTransactionNum(const Avtp_Abb_t* const pdu) {
+    return (uint8_t) GET_ABB_FIELD(AVTP_ABB_FIELD_TRANSACTION_NUM);
 }
 
 /**
  * Returns the value of the op flag from an ACF_ABB message header.
- * 
- * @param msg Pointer to an ACF_ABB message.
+ *
+ * @param pdu Pointer to an ACF_ABB message.
  * @returns The value of the op flag.
  */
-OPEN1722_INLINE bool Avtp_Abb_IsOp(const Avtp_Abb_t* msg) {
-    return (bool) __Avtp_Abb_GetField(AVTP_ABB_FIELD_OP);
+OPEN1722_INLINE bool Avtp_Abb_IsOp(const Avtp_Abb_t* const pdu) {
+    return (bool) GET_ABB_FIELD(AVTP_ABB_FIELD_OP);
 }
 
 /**
  * Returns the value of the rsp flag from an ACF_ABB message header.
- * 
- * @param msg Pointer to an ACF_ABB message.
+ *
+ * @param pdu Pointer to an ACF_ABB message.
  * @returns The value of the rsp flag.
  */
-OPEN1722_INLINE bool Avtp_Abb_IsRsp(const Avtp_Abb_t* msg) {
-    return (bool) __Avtp_Abb_GetField(AVTP_ABB_FIELD_RSP);
+OPEN1722_INLINE bool Avtp_Abb_IsRsp(const Avtp_Abb_t* const pdu) {
+    return (bool) GET_ABB_FIELD(AVTP_ABB_FIELD_RSP);
 }
 
 /**
  * Returns the value of the err flag from an ACF_ABB message header.
- * 
- * @param msg Pointer to an ACF_ABB message.
+ *
+ * @param pdu Pointer to an ACF_ABB message.
  * @returns The value of the err flag.
  */
-OPEN1722_INLINE bool Avtp_Abb_IsErr(const Avtp_Abb_t* msg) {
-    return (bool) __Avtp_Abb_GetField(AVTP_ABB_FIELD_ERR);
+OPEN1722_INLINE bool Avtp_Abb_IsErr(const Avtp_Abb_t* const pdu) {
+    return (bool) GET_ABB_FIELD(AVTP_ABB_FIELD_ERR);
 }
 
 /**
  * Returns the value of the ms flag from an ACF_ABB message header.
- * 
- * @param msg Pointer to an ACF_ABB message.
+ *
+ * @param pdu Pointer to an ACF_ABB message.
  * @returns The value of the ms flag.
  */
-OPEN1722_INLINE bool Avtp_Abb_IsMs(const Avtp_Abb_t* msg) {
-    return (bool) __Avtp_Abb_GetField(AVTP_ABB_FIELD_MS);
+OPEN1722_INLINE bool Avtp_Abb_IsMs(const Avtp_Abb_t* const pdu) {
+    return (bool) GET_ABB_FIELD(AVTP_ABB_FIELD_MS);
 }
 
 /**
- * Returns the value of the read_size/segment_num field from an ACF_ABB message
- * header.
- * 
- * @param msg Pointer to an ACF_ABB message.
+ * Returns the value of the read_size/segment_num field from an ACF_ABB message header.
+ *
+ * @param pdu Pointer to an ACF_ABB message.
  * @returns The value of the read_size/segment_num field.
  */
-OPEN1722_INLINE uint16_t Avtp_Abb_GetReadSize(const Avtp_Abb_t* msg) {
-    return (uint16_t) __Avtp_Abb_GetField(AVTP_ABB_FIELD_READ_SIZE_SEGMENT_NUM);
+OPEN1722_INLINE uint16_t Avtp_Abb_GetReadSize(const Avtp_Abb_t* const pdu) {
+    return (uint16_t) GET_ABB_FIELD(AVTP_ABB_FIELD_READ_SIZE_SEGMENT_NUM);
 }
 
 /**
- * Returns the value of the read_size/segment_num field from an ACF_ABB message
- * header.
- * 
- * @param msg Pointer to an ACF_ABB message.
+ * Returns the value of the read_size/segment_num field from an ACF_ABB message header.
+ *
+ * @param pdu Pointer to an ACF_ABB message.
  * @returns The value of the read_size/segment_num field.
  */
-OPEN1722_INLINE uint16_t Avtp_Abb_GetSegmentNum(const Avtp_Abb_t* msg) {
-    return (uint16_t) __Avtp_Abb_GetField(AVTP_ABB_FIELD_READ_SIZE_SEGMENT_NUM);
-}
-
-/**
- * Returns the paload length from an ACF_ABB message (in bytes). This is
- * calculated based on the value of the acf_msg_length field in the header
- * as well as the value of the pad field.
- * 
- * @param msg Pointer to an ACF_ABB message.
- * @returns The payload length in bytes.
- */
-OPEN1722_INLINE uint16_t Avtp_Abb_GetPayloadLen(const Avtp_Abb_t* msg) {
-    return (uint16_t) (__Avtp_Abb_GetField(AVTP_ABB_FIELD_ACF_MSG_LENGTH) * AVTP_QUADLET_SIZE
-           - AVTP_ABB_HEADER_LEN
-           - __Avtp_Abb_GetField(AVTP_ABB_FIELD_PAD));
-}
-
-/**
- * Returns the total message length from an ACF_ABB message (in bytes)
- * including header and payload section.
- * 
- * @param msg Pointer to an ACF_ABB message.
- * @returns The total message length in bytes.
- */
-OPEN1722_INLINE uint16_t Avtp_Abb_GetLen(const Avtp_Abb_t* msg) {
-    return (uint16_t) (__Avtp_Abb_GetField(AVTP_ABB_FIELD_ACF_MSG_LENGTH) * AVTP_QUADLET_SIZE);
+OPEN1722_INLINE uint16_t Avtp_Abb_GetSegmentNum(const Avtp_Abb_t* const pdu) {
+    return (uint16_t) GET_ABB_FIELD(AVTP_ABB_FIELD_READ_SIZE_SEGMENT_NUM);
 }
 
 /**
  * Sets the value of the mtv flag in an ACF_ABB message header.
- * 
- * @param msg Pointer to an ACF_ABB message.
+ *
+ * @param pdu Pointer to an ACF_ABB message.
  * @param mtv The value to set.
  */
-OPEN1722_INLINE void Avtp_Abb_SetMtv(Avtp_Abb_t* msg, bool mtv) {
-    __Avtp_Abb_SetField(AVTP_ABB_FIELD_MTV, mtv);
+OPEN1722_INLINE void Avtp_Abb_SetMtv(Avtp_Abb_t* pdu, bool mtv) {
+    SET_ABB_FIELD(AVTP_ABB_FIELD_MTV, mtv);
 }
 
 /**
  * Sets the value of the byte_bus_id field in an ACF_ABB message header.
- * 
- * @param msg Pointer to an ACF_ABB message.
+ *
+ * @param pdu Pointer to an ACF_ABB message.
  * @param byteBusId The value to set.
  */
-OPEN1722_INLINE void Avtp_Abb_SetByteBusId(Avtp_Abb_t* msg, uint16_t byteBusId) {
-    __Avtp_Abb_SetField(AVTP_ABB_FIELD_BYTE_BUS_ID, byteBusId);
+OPEN1722_INLINE void Avtp_Abb_SetByteBusId(Avtp_Abb_t* pdu, uint16_t byteBusId) {
+    SET_ABB_FIELD(AVTP_ABB_FIELD_BYTE_BUS_ID, byteBusId);
 }
 
 /**
  * Sets the value of the evt field in an ACF_ABB message header.
- * 
- * @param msg Pointer to an ACF_ABB message.
+ *
+ * @param pdu Pointer to an ACF_ABB message.
  * @param evt The value to set.
  */
-
-OPEN1722_INLINE void Avtp_Abb_SetEvt(Avtp_Abb_t* msg, uint8_t evt) {
-    __Avtp_Abb_SetField(AVTP_ABB_FIELD_EVT, evt);
+OPEN1722_INLINE void Avtp_Abb_SetEvt(Avtp_Abb_t* pdu, uint8_t evt) {
+    SET_ABB_FIELD(AVTP_ABB_FIELD_EVT, evt);
 }
 
 /**
  * Sets the value of the hs flag in an ACF_ABB message header.
- * 
- * @param msg Pointer to an ACF_ABB message.
+ *
+ * @param pdu Pointer to an ACF_ABB message.
  * @param hs The value to set.
  */
-OPEN1722_INLINE void Avtp_Abb_SetHs(Avtp_Abb_t* msg, bool hs) {
-    __Avtp_Abb_SetField(AVTP_ABB_FIELD_HS, hs);
+OPEN1722_INLINE void Avtp_Abb_SetHs(Avtp_Abb_t* pdu, bool hs) {
+    SET_ABB_FIELD(AVTP_ABB_FIELD_HS, hs);
 }
-
 
 /**
  * Sets the value of the cs flag in an ACF_ABB message header.
- * 
- * @param msg Pointer to an ACF_ABB message.
+ *
+ * @param pdu Pointer to an ACF_ABB message.
  * @param cs The value to set.
  */
-OPEN1722_INLINE void Avtp_Abb_SetCs(Avtp_Abb_t* msg, bool cs) {
-    __Avtp_Abb_SetField(AVTP_ABB_FIELD_CS, cs);
+OPEN1722_INLINE void Avtp_Abb_SetCs(Avtp_Abb_t* pdu, bool cs) {
+    SET_ABB_FIELD(AVTP_ABB_FIELD_CS, cs);
 }
 
 /**
  * Sets the value of the transaction_num field in an ACF_ABB message header.
- * 
- * @param msg Pointer to an ACF_ABB message.
+ *
+ * @param pdu Pointer to an ACF_ABB message.
  * @param transactionNum The value to set.
  */
-OPEN1722_INLINE void Avtp_Abb_SetTransactionNum(Avtp_Abb_t* msg, uint8_t transactionNum) {
-    __Avtp_Abb_SetField(AVTP_ABB_FIELD_TRANSACTION_NUM, transactionNum);
+OPEN1722_INLINE void Avtp_Abb_SetTransactionNum(Avtp_Abb_t* pdu, uint8_t transactionNum) {
+    SET_ABB_FIELD(AVTP_ABB_FIELD_TRANSACTION_NUM, transactionNum);
 }
 
 /**
  * Sets the value of the op flag in an ACF_ABB message header.
- * 
- * @param msg Pointer to an ACF_ABB message.
+ *
+ * @param pdu Pointer to an ACF_ABB message.
  * @param op The value to set.
  */
-OPEN1722_INLINE void Avtp_Abb_SetOp(Avtp_Abb_t* msg, bool op) {
-    __Avtp_Abb_SetField(AVTP_ABB_FIELD_OP, op);
+OPEN1722_INLINE void Avtp_Abb_SetOp(Avtp_Abb_t* pdu, bool op) {
+    SET_ABB_FIELD(AVTP_ABB_FIELD_OP, op);
 }
 
 /**
  * Sets the value of the rsp flag in an ACF_ABB message header.
- * 
- * @param msg Pointer to an ACF_ABB message.
+ *
+ * @param pdu Pointer to an ACF_ABB message.
  * @param rsp The value to set.
  */
-OPEN1722_INLINE void Avtp_Abb_SetRsp(Avtp_Abb_t* msg, bool rsp) {
-    __Avtp_Abb_SetField(AVTP_ABB_FIELD_RSP, rsp);
+OPEN1722_INLINE void Avtp_Abb_SetRsp(Avtp_Abb_t* pdu, bool rsp) {
+    SET_ABB_FIELD(AVTP_ABB_FIELD_RSP, rsp);
 }
 
 /**
  * Sets the value of the err flag in an ACF_ABB message header.
- * 
- * @param msg Pointer to an ACF_ABB message.
+ *
+ * @param pdu Pointer to an ACF_ABB message.
  * @param err The value to set.
  */
-OPEN1722_INLINE void Avtp_Abb_SetErr(Avtp_Abb_t* msg, bool err) {
-    __Avtp_Abb_SetField(AVTP_ABB_FIELD_ERR, err);
+OPEN1722_INLINE void Avtp_Abb_SetErr(Avtp_Abb_t* pdu, bool err) {
+    SET_ABB_FIELD(AVTP_ABB_FIELD_ERR, err);
 }
 
 /**
  * Sets the value of the ms flag in an ACF_ABB message header.
- * 
- * @param msg Pointer to an ACF_ABB message.
+ *
+ * @param pdu Pointer to an ACF_ABB message.
  * @param ms The value to set.
  */
-OPEN1722_INLINE void Avtp_Abb_SetMs(Avtp_Abb_t* msg, bool ms) {
-    __Avtp_Abb_SetField(AVTP_ABB_FIELD_MS, ms);
+OPEN1722_INLINE void Avtp_Abb_SetMs(Avtp_Abb_t* pdu, bool ms) {
+    SET_ABB_FIELD(AVTP_ABB_FIELD_MS, ms);
 }
 
 /**
  * Sets the value of the read_size/segment_num field in an ACF_ABB message header.
- * 
- * @param msg Pointer to an ACF_ABB message.
+ *
+ * @param pdu Pointer to an ACF_ABB message.
  * @param readSize The value to set.
  */
-OPEN1722_INLINE void Avtp_Abb_SetReadSize(Avtp_Abb_t* msg, uint16_t readSize) {
-    __Avtp_Abb_SetField(AVTP_ABB_FIELD_READ_SIZE_SEGMENT_NUM, readSize);
+OPEN1722_INLINE void Avtp_Abb_SetReadSize(Avtp_Abb_t* pdu, uint16_t readSize) {
+    SET_ABB_FIELD(AVTP_ABB_FIELD_READ_SIZE_SEGMENT_NUM, readSize);
 }
 
 /**
  * Sets the value of the read_size/segment_num field in an ACF_ABB message header.
- * 
- * @param msg Pointer to an ACF_ABB message.
+ *
+ * @param pdu Pointer to an ACF_ABB message.
  * @param segmentNum The value to set.
  */
-OPEN1722_INLINE void Avtp_Abb_SetSegmentNum(Avtp_Abb_t* msg, uint16_t segmentNum) {
-    __Avtp_Abb_SetField(AVTP_ABB_FIELD_READ_SIZE_SEGMENT_NUM, segmentNum);
+OPEN1722_INLINE void Avtp_Abb_SetSegmentNum(Avtp_Abb_t* pdu, uint16_t segmentNum) {
+    SET_ABB_FIELD(AVTP_ABB_FIELD_READ_SIZE_SEGMENT_NUM, segmentNum);
 }
 
 /**
- * Sets the value of the acf_msg_length field in an ACF_ABB message header
- * based on the given payload length. This function also calculates the
- * required padding and sets the value of the pad field accordingly.
- * 
- * @param msg Pointer to an ACF_ABB message.
- * @param payloadLen The length of the payload in bytes.
+ * Returns pointer to payload of an ACF ABB frame.
+ *
+ * @param pdu Pointer to the first bit of a 1722 ACF ABB PDU.
+ * @return Pointer to ACF ABB frame payload
  */
-OPEN1722_INLINE void Avtp_Abb_SetPayloadLen(Avtp_Abb_t* msg, uint16_t payloadLen) {
-    uint16_t msgLenBytes = AVTP_ABB_HEADER_LEN + payloadLen;
+OPEN1722_INLINE const uint8_t *Avtp_Abb_GetPayload(const Avtp_Abb_t* const pdu)
+{
+    return pdu->payload;
+}
+
+/**
+ * Sets the payload in an ACF ABB frame.
+ *
+ * @param pdu Pointer to the first bit of a 1722 ACF ABB PDU.
+ * @param payload Pointer to the payload byte array
+ * @param payload_length Length of the payload
+ */
+OPEN1722_INLINE void Avtp_Abb_SetPayload(Avtp_Abb_t *pdu, uint8_t *payload,
+                                         uint16_t payload_length)
+{
+    memcpy(pdu->payload, payload, payload_length);
+}
+
+/**
+ * Finalizes the ACF ABB frame. This function will set the
+ * length and pad fields while inserting the padded bytes. This will also
+ * set padding bytes to zero if the payload length is not a multiple of 4.
+ * to avoid leaking information
+ *
+ * @param pdu Pointer to the first bit of a 1722 ACF ABB PDU.
+ * @param payload_length Length of the frame payload.
+ */
+OPEN1722_INLINE void Avtp_Abb_SetPayloadLength(Avtp_Abb_t *pdu, uint16_t payload_length)
+{
+    uint16_t msgLenBytes = AVTP_ABB_HEADER_LEN + payload_length;
     uint8_t pad = (uint8_t)(4 - (msgLenBytes % 4)) % 4;
+    if (pad > 0) {
+        memset(pdu->payload + payload_length, 0, pad);
+    }
     uint16_t msgLenQuadlets = (uint16_t)((msgLenBytes + pad) / 4);
-    __Avtp_Abb_SetField(AVTP_ABB_FIELD_ACF_MSG_LENGTH, msgLenQuadlets);
-    __Avtp_Abb_SetField(AVTP_ABB_FIELD_PAD, pad);
+    Avtp_Abb_SetPad(pdu, pad);
+    Avtp_Abb_SetAcfMsgLength(pdu, msgLenQuadlets);
+}
+
+/**
+ * Returns the length of the payload without the padding bytes and the
+ * header length of the encapsulating ACF Frame.
+ *
+ * Precondition: the caller must have validated the PDU with
+ * Avtp_Abb_IsValid(). This function performs no further bounds checking
+ * and assumes those invariants already hold.
+ *
+ * @param pdu Pointer to the first bit of a 1722 ACF ABB PDU.
+ * @return  Length of payload in bytes
+ */
+OPEN1722_INLINE uint8_t Avtp_Abb_GetPayloadLength(const Avtp_Abb_t* const pdu)
+{
+    uint8_t pad_length = Avtp_Abb_GetPad(pdu);
+    uint16_t acf_length_bytes = Avtp_Abb_GetAcfMsgLengthInBytes(pdu);
+    return (uint8_t)(acf_length_bytes - AVTP_ABB_HEADER_LEN - pad_length);
+}
+
+/**
+ * Initializes an ACF_ABB message header as specified in the IEEE 1722 Specification.
+ *
+ * @param pdu Pointer to the first bit of a 1722 ACF ABB PDU.
+ */
+OPEN1722_INLINE void Avtp_Abb_Init(Avtp_Abb_t* pdu)
+{
+    if (pdu != NULL) {
+        memset(pdu, 0, sizeof(Avtp_Abb_t));
+        Avtp_Abb_SetAcfMsgType(pdu, AVTP_ACF_TYPE_BYTE_BUS_BRIEF);
+    }
+}
+
+/**
+ * Copies the payload data, byte bus ID, op flag and transaction number into the ACF ABB frame.
+ * This function will also set the length and pad fields while inserting the padded bytes.
+ *
+ * @param pdu Pointer to the first bit of a 1722 ACF ABB PDU.
+ * @param byte_bus_id Byte bus ID
+ * @param op Operation flag
+ * @param transaction_num Transaction number
+ * @param payload Pointer to the payload byte array
+ * @param payload_length Length of the payload.
+ */
+OPEN1722_INLINE void Avtp_Abb_CreateAcfMessage(Avtp_Abb_t *pdu, uint16_t byte_bus_id, bool op,
+                                               uint8_t transaction_num, uint8_t *payload,
+                                               uint16_t payload_length)
+{
+    // Initialize the ACF ABB header
+    Avtp_Abb_Init(pdu);
+
+    // Set the byte bus ID, op flag and transaction number
+    Avtp_Abb_SetByteBusId(pdu, byte_bus_id);
+    Avtp_Abb_SetOp(pdu, op);
+    Avtp_Abb_SetTransactionNum(pdu, transaction_num);
+
+    // Copy the payload into the PDU
+    Avtp_Abb_SetPayload(pdu, payload, payload_length);
+
+    // Finalize the AVTP ABB Frame
+    Avtp_Abb_SetPayloadLength(pdu, payload_length);
+}
+
+/**
+ * Checks if the ACF ABB frame is valid by checking:
+ *     1) if the length field of AVTP/ACF messages contains a value larger than the actual size of
+ * the buffer that contains the AVTP message. 2) if other format specific invariants are not upheld
+ * @param pdu Pointer to the first bit of a 1722 ACF ABB PDU.
+ * @param bufferSize Size of the buffer containing the ACF ABB frame.
+ * @return true if the ACF ABB frame is valid, false otherwise.
+ */
+OPEN1722_INLINE bool Avtp_Abb_IsValid(const Avtp_Abb_t* const pdu, size_t bufferSize)
+{
+    if (pdu == NULL) {
+        return false;
+    }
+
+    if (bufferSize < AVTP_ABB_HEADER_LEN) {
+        return false;
+    }
+
+    if (Avtp_Abb_GetAcfMsgType(pdu) != AVTP_ACF_TYPE_BYTE_BUS_BRIEF) {
+        return false;
+    }
+
+    // Avtp_Abb_GetAcfMsgLength returns quadlets. Convert the length field to octets.
+    uint16_t msg_length_bytes = (uint16_t)Avtp_Abb_GetAcfMsgLength(pdu) * 4;
+    if (msg_length_bytes > bufferSize) {
+        return false;
+    }
+
+    /* The encoded message length must accommodate header + declared padding
+     * so the payload computation in Avtp_Abb_GetPayloadLength() doesn't
+     * underflow. */
+    uint8_t pad_length = Avtp_Abb_GetPad(pdu);
+    uint16_t header_and_pad = (uint16_t)AVTP_ABB_HEADER_LEN + pad_length;
+    if (msg_length_bytes < header_and_pad) {
+        return false;
+    }
+    return true;
 }
 
 #ifdef __cplusplus

--- a/include/avtp/acf/Abb.h
+++ b/include/avtp/acf/Abb.h
@@ -94,24 +94,23 @@ typedef enum {
 /**
  * This table describes all the offsets of the ACF_ABB header fields.
  */
-static const Avtp_FieldDescriptor_t Avtp_AbbFieldDesc[AVTP_ABB_FIELD_MAX] =
-{
+static const Avtp_FieldDescriptor_t Avtp_AbbFieldDesc[AVTP_ABB_FIELD_MAX] = {
     /* ACF common header fields */
-    [AVTP_ABB_FIELD_ACF_MSG_TYPE]           = { .quadlet = 0, .offset =  0, .bits = 7   },
-    [AVTP_ABB_FIELD_ACF_MSG_LENGTH]         = { .quadlet = 0, .offset =  7, .bits = 9   },
+    [AVTP_ABB_FIELD_ACF_MSG_TYPE] = {.quadlet = 0, .offset = 0, .bits = 7},
+    [AVTP_ABB_FIELD_ACF_MSG_LENGTH] = {.quadlet = 0, .offset = 7, .bits = 9},
     /* ACF ABB header fields */
-    [AVTP_ABB_FIELD_PAD]                    = { .quadlet = 0, .offset = 16, .bits =   2 },
-    [AVTP_ABB_FIELD_MTV]                    = { .quadlet = 0, .offset = 18, .bits =   1 },
-    [AVTP_ABB_FIELD_BYTE_BUS_ID]            = { .quadlet = 0, .offset = 21, .bits =  11 },
-    [AVTP_ABB_FIELD_EVT]                    = { .quadlet = 1, .offset =  0, .bits =   4 },
-    [AVTP_ABB_FIELD_HS]                     = { .quadlet = 1, .offset =  6, .bits =   1 },
-    [AVTP_ABB_FIELD_CS]                     = { .quadlet = 1, .offset =  7, .bits =   1 },
-    [AVTP_ABB_FIELD_TRANSACTION_NUM]        = { .quadlet = 1, .offset =  8, .bits =   8 },
-    [AVTP_ABB_FIELD_OP]                     = { .quadlet = 1, .offset = 16, .bits =   1 },
-    [AVTP_ABB_FIELD_RSP]                    = { .quadlet = 1, .offset = 17, .bits =   1 },
-    [AVTP_ABB_FIELD_ERR]                    = { .quadlet = 1, .offset = 18, .bits =   1 },
-    [AVTP_ABB_FIELD_MS]                     = { .quadlet = 1, .offset = 19, .bits =   1 },
-    [AVTP_ABB_FIELD_READ_SIZE_SEGMENT_NUM]  = { .quadlet = 1, .offset = 20, .bits =  12 },
+    [AVTP_ABB_FIELD_PAD] = {.quadlet = 0, .offset = 16, .bits = 2},
+    [AVTP_ABB_FIELD_MTV] = {.quadlet = 0, .offset = 18, .bits = 1},
+    [AVTP_ABB_FIELD_BYTE_BUS_ID] = {.quadlet = 0, .offset = 21, .bits = 11},
+    [AVTP_ABB_FIELD_EVT] = {.quadlet = 1, .offset = 0, .bits = 4},
+    [AVTP_ABB_FIELD_HS] = {.quadlet = 1, .offset = 6, .bits = 1},
+    [AVTP_ABB_FIELD_CS] = {.quadlet = 1, .offset = 7, .bits = 1},
+    [AVTP_ABB_FIELD_TRANSACTION_NUM] = {.quadlet = 1, .offset = 8, .bits = 8},
+    [AVTP_ABB_FIELD_OP] = {.quadlet = 1, .offset = 16, .bits = 1},
+    [AVTP_ABB_FIELD_RSP] = {.quadlet = 1, .offset = 17, .bits = 1},
+    [AVTP_ABB_FIELD_ERR] = {.quadlet = 1, .offset = 18, .bits = 1},
+    [AVTP_ABB_FIELD_MS] = {.quadlet = 1, .offset = 19, .bits = 1},
+    [AVTP_ABB_FIELD_READ_SIZE_SEGMENT_NUM] = {.quadlet = 1, .offset = 20, .bits = 12},
 };
 
 /**
@@ -120,8 +119,9 @@ static const Avtp_FieldDescriptor_t Avtp_AbbFieldDesc[AVTP_ABB_FIELD_MAX] =
  * @param pdu Pointer to the first bit of a 1722 ACF ABB PDU.
  * @returns Value of the ACF message type field.
  */
-OPEN1722_INLINE uint8_t Avtp_Abb_GetAcfMsgType(const Avtp_Abb_t* const pdu) {
-    return (uint8_t) GET_ABB_FIELD(AVTP_ABB_FIELD_ACF_MSG_TYPE);
+OPEN1722_INLINE uint8_t Avtp_Abb_GetAcfMsgType(const Avtp_Abb_t *const pdu)
+{
+    return (uint8_t)GET_ABB_FIELD(AVTP_ABB_FIELD_ACF_MSG_TYPE);
 }
 
 /**
@@ -133,8 +133,9 @@ OPEN1722_INLINE uint8_t Avtp_Abb_GetAcfMsgType(const Avtp_Abb_t* const pdu) {
  * @param pdu Pointer to the first bit of a 1722 ACF ABB PDU.
  * @returns Value of the ACF message length field.
  */
-OPEN1722_INLINE uint16_t Avtp_Abb_GetAcfMsgLength(const Avtp_Abb_t* const pdu) {
-    return (uint16_t) GET_ABB_FIELD(AVTP_ABB_FIELD_ACF_MSG_LENGTH);
+OPEN1722_INLINE uint16_t Avtp_Abb_GetAcfMsgLength(const Avtp_Abb_t *const pdu)
+{
+    return (uint16_t)GET_ABB_FIELD(AVTP_ABB_FIELD_ACF_MSG_LENGTH);
 }
 
 /**
@@ -143,8 +144,9 @@ OPEN1722_INLINE uint16_t Avtp_Abb_GetAcfMsgLength(const Avtp_Abb_t* const pdu) {
  * @param pdu Pointer to the first bit of a 1722 ACF ABB PDU.
  * @returns Length of the ACF message in bytes.
  */
-OPEN1722_INLINE uint16_t Avtp_Abb_GetAcfMsgLengthInBytes(const Avtp_Abb_t* const pdu) {
-    return (uint16_t) GET_ABB_FIELD(AVTP_ABB_FIELD_ACF_MSG_LENGTH) * 4;
+OPEN1722_INLINE uint16_t Avtp_Abb_GetAcfMsgLengthInBytes(const Avtp_Abb_t *const pdu)
+{
+    return (uint16_t)GET_ABB_FIELD(AVTP_ABB_FIELD_ACF_MSG_LENGTH) * 4;
 }
 
 /**
@@ -153,7 +155,8 @@ OPEN1722_INLINE uint16_t Avtp_Abb_GetAcfMsgLengthInBytes(const Avtp_Abb_t* const
  * @param pdu Pointer to the first bit of a 1722 ACF ABB PDU.
  * @param value Value to set the ACF message type field to.
  */
-OPEN1722_INLINE void Avtp_Abb_SetAcfMsgType(Avtp_Abb_t* pdu, uint8_t value) {
+OPEN1722_INLINE void Avtp_Abb_SetAcfMsgType(Avtp_Abb_t *pdu, uint8_t value)
+{
     SET_ABB_FIELD(AVTP_ABB_FIELD_ACF_MSG_TYPE, value);
 }
 
@@ -166,7 +169,8 @@ OPEN1722_INLINE void Avtp_Abb_SetAcfMsgType(Avtp_Abb_t* pdu, uint8_t value) {
  * @param pdu Pointer to the first bit of a 1722 ACF ABB PDU.
  * @param value Value to set the ACF message length field to.
  */
-OPEN1722_INLINE void Avtp_Abb_SetAcfMsgLength(Avtp_Abb_t* pdu, uint16_t value) {
+OPEN1722_INLINE void Avtp_Abb_SetAcfMsgLength(Avtp_Abb_t *pdu, uint16_t value)
+{
     SET_ABB_FIELD(AVTP_ABB_FIELD_ACF_MSG_LENGTH, value);
 }
 
@@ -176,8 +180,9 @@ OPEN1722_INLINE void Avtp_Abb_SetAcfMsgLength(Avtp_Abb_t* pdu, uint16_t value) {
  * @param pdu Pointer to an ACF_ABB message.
  * @returns The value of the pad field.
  */
-OPEN1722_INLINE uint8_t Avtp_Abb_GetPad(const Avtp_Abb_t* const pdu) {
-    return (uint8_t) GET_ABB_FIELD(AVTP_ABB_FIELD_PAD);
+OPEN1722_INLINE uint8_t Avtp_Abb_GetPad(const Avtp_Abb_t *const pdu)
+{
+    return (uint8_t)GET_ABB_FIELD(AVTP_ABB_FIELD_PAD);
 }
 
 /**
@@ -186,7 +191,8 @@ OPEN1722_INLINE uint8_t Avtp_Abb_GetPad(const Avtp_Abb_t* const pdu) {
  * @param pdu Pointer to an ACF_ABB message.
  * @param pad The value to set.
  */
-OPEN1722_INLINE void Avtp_Abb_SetPad(Avtp_Abb_t* pdu, uint8_t pad) {
+OPEN1722_INLINE void Avtp_Abb_SetPad(Avtp_Abb_t *pdu, uint8_t pad)
+{
     SET_ABB_FIELD(AVTP_ABB_FIELD_PAD, pad);
 }
 
@@ -196,8 +202,9 @@ OPEN1722_INLINE void Avtp_Abb_SetPad(Avtp_Abb_t* pdu, uint8_t pad) {
  * @param pdu Pointer to an ACF_ABB message.
  * @returns The value of the mtv flag.
  */
-OPEN1722_INLINE bool Avtp_Abb_IsMtv(const Avtp_Abb_t* const pdu) {
-    return (bool) GET_ABB_FIELD(AVTP_ABB_FIELD_MTV);
+OPEN1722_INLINE bool Avtp_Abb_IsMtv(const Avtp_Abb_t *const pdu)
+{
+    return (bool)GET_ABB_FIELD(AVTP_ABB_FIELD_MTV);
 }
 
 /**
@@ -206,8 +213,9 @@ OPEN1722_INLINE bool Avtp_Abb_IsMtv(const Avtp_Abb_t* const pdu) {
  * @param pdu Pointer to an ACF_ABB message.
  * @returns The value of the byte_bus_id field.
  */
-OPEN1722_INLINE uint16_t Avtp_Abb_GetByteBusId(const Avtp_Abb_t* const pdu) {
-    return (uint16_t) GET_ABB_FIELD(AVTP_ABB_FIELD_BYTE_BUS_ID);
+OPEN1722_INLINE uint16_t Avtp_Abb_GetByteBusId(const Avtp_Abb_t *const pdu)
+{
+    return (uint16_t)GET_ABB_FIELD(AVTP_ABB_FIELD_BYTE_BUS_ID);
 }
 
 /**
@@ -216,8 +224,9 @@ OPEN1722_INLINE uint16_t Avtp_Abb_GetByteBusId(const Avtp_Abb_t* const pdu) {
  * @param pdu Pointer to an ACF_ABB message.
  * @returns The value of the evt field.
  */
-OPEN1722_INLINE uint8_t Avtp_Abb_GetEvt(const Avtp_Abb_t* const pdu) {
-    return (uint8_t) GET_ABB_FIELD(AVTP_ABB_FIELD_EVT);
+OPEN1722_INLINE uint8_t Avtp_Abb_GetEvt(const Avtp_Abb_t *const pdu)
+{
+    return (uint8_t)GET_ABB_FIELD(AVTP_ABB_FIELD_EVT);
 }
 
 /**
@@ -226,8 +235,9 @@ OPEN1722_INLINE uint8_t Avtp_Abb_GetEvt(const Avtp_Abb_t* const pdu) {
  * @param pdu Pointer to an ACF_ABB message.
  * @returns The value of the hs field.
  */
-OPEN1722_INLINE bool Avtp_Abb_IsHs(const Avtp_Abb_t* const pdu) {
-    return (bool) GET_ABB_FIELD(AVTP_ABB_FIELD_HS);
+OPEN1722_INLINE bool Avtp_Abb_IsHs(const Avtp_Abb_t *const pdu)
+{
+    return (bool)GET_ABB_FIELD(AVTP_ABB_FIELD_HS);
 }
 
 /**
@@ -236,8 +246,9 @@ OPEN1722_INLINE bool Avtp_Abb_IsHs(const Avtp_Abb_t* const pdu) {
  * @param pdu Pointer to an ACF_ABB message.
  * @returns The value of the cs field.
  */
-OPEN1722_INLINE bool Avtp_Abb_IsCs(const Avtp_Abb_t* const pdu) {
-    return (bool) GET_ABB_FIELD(AVTP_ABB_FIELD_CS);
+OPEN1722_INLINE bool Avtp_Abb_IsCs(const Avtp_Abb_t *const pdu)
+{
+    return (bool)GET_ABB_FIELD(AVTP_ABB_FIELD_CS);
 }
 
 /**
@@ -246,8 +257,9 @@ OPEN1722_INLINE bool Avtp_Abb_IsCs(const Avtp_Abb_t* const pdu) {
  * @param pdu Pointer to an ACF_ABB message.
  * @returns The value of the transaction_num field.
  */
-OPEN1722_INLINE uint8_t Avtp_Abb_GetTransactionNum(const Avtp_Abb_t* const pdu) {
-    return (uint8_t) GET_ABB_FIELD(AVTP_ABB_FIELD_TRANSACTION_NUM);
+OPEN1722_INLINE uint8_t Avtp_Abb_GetTransactionNum(const Avtp_Abb_t *const pdu)
+{
+    return (uint8_t)GET_ABB_FIELD(AVTP_ABB_FIELD_TRANSACTION_NUM);
 }
 
 /**
@@ -256,8 +268,9 @@ OPEN1722_INLINE uint8_t Avtp_Abb_GetTransactionNum(const Avtp_Abb_t* const pdu) 
  * @param pdu Pointer to an ACF_ABB message.
  * @returns The value of the op flag.
  */
-OPEN1722_INLINE bool Avtp_Abb_IsOp(const Avtp_Abb_t* const pdu) {
-    return (bool) GET_ABB_FIELD(AVTP_ABB_FIELD_OP);
+OPEN1722_INLINE bool Avtp_Abb_IsOp(const Avtp_Abb_t *const pdu)
+{
+    return (bool)GET_ABB_FIELD(AVTP_ABB_FIELD_OP);
 }
 
 /**
@@ -266,8 +279,9 @@ OPEN1722_INLINE bool Avtp_Abb_IsOp(const Avtp_Abb_t* const pdu) {
  * @param pdu Pointer to an ACF_ABB message.
  * @returns The value of the rsp flag.
  */
-OPEN1722_INLINE bool Avtp_Abb_IsRsp(const Avtp_Abb_t* const pdu) {
-    return (bool) GET_ABB_FIELD(AVTP_ABB_FIELD_RSP);
+OPEN1722_INLINE bool Avtp_Abb_IsRsp(const Avtp_Abb_t *const pdu)
+{
+    return (bool)GET_ABB_FIELD(AVTP_ABB_FIELD_RSP);
 }
 
 /**
@@ -276,8 +290,9 @@ OPEN1722_INLINE bool Avtp_Abb_IsRsp(const Avtp_Abb_t* const pdu) {
  * @param pdu Pointer to an ACF_ABB message.
  * @returns The value of the err flag.
  */
-OPEN1722_INLINE bool Avtp_Abb_IsErr(const Avtp_Abb_t* const pdu) {
-    return (bool) GET_ABB_FIELD(AVTP_ABB_FIELD_ERR);
+OPEN1722_INLINE bool Avtp_Abb_IsErr(const Avtp_Abb_t *const pdu)
+{
+    return (bool)GET_ABB_FIELD(AVTP_ABB_FIELD_ERR);
 }
 
 /**
@@ -286,8 +301,9 @@ OPEN1722_INLINE bool Avtp_Abb_IsErr(const Avtp_Abb_t* const pdu) {
  * @param pdu Pointer to an ACF_ABB message.
  * @returns The value of the ms flag.
  */
-OPEN1722_INLINE bool Avtp_Abb_IsMs(const Avtp_Abb_t* const pdu) {
-    return (bool) GET_ABB_FIELD(AVTP_ABB_FIELD_MS);
+OPEN1722_INLINE bool Avtp_Abb_IsMs(const Avtp_Abb_t *const pdu)
+{
+    return (bool)GET_ABB_FIELD(AVTP_ABB_FIELD_MS);
 }
 
 /**
@@ -296,8 +312,9 @@ OPEN1722_INLINE bool Avtp_Abb_IsMs(const Avtp_Abb_t* const pdu) {
  * @param pdu Pointer to an ACF_ABB message.
  * @returns The value of the read_size/segment_num field.
  */
-OPEN1722_INLINE uint16_t Avtp_Abb_GetReadSize(const Avtp_Abb_t* const pdu) {
-    return (uint16_t) GET_ABB_FIELD(AVTP_ABB_FIELD_READ_SIZE_SEGMENT_NUM);
+OPEN1722_INLINE uint16_t Avtp_Abb_GetReadSize(const Avtp_Abb_t *const pdu)
+{
+    return (uint16_t)GET_ABB_FIELD(AVTP_ABB_FIELD_READ_SIZE_SEGMENT_NUM);
 }
 
 /**
@@ -306,8 +323,9 @@ OPEN1722_INLINE uint16_t Avtp_Abb_GetReadSize(const Avtp_Abb_t* const pdu) {
  * @param pdu Pointer to an ACF_ABB message.
  * @returns The value of the read_size/segment_num field.
  */
-OPEN1722_INLINE uint16_t Avtp_Abb_GetSegmentNum(const Avtp_Abb_t* const pdu) {
-    return (uint16_t) GET_ABB_FIELD(AVTP_ABB_FIELD_READ_SIZE_SEGMENT_NUM);
+OPEN1722_INLINE uint16_t Avtp_Abb_GetSegmentNum(const Avtp_Abb_t *const pdu)
+{
+    return (uint16_t)GET_ABB_FIELD(AVTP_ABB_FIELD_READ_SIZE_SEGMENT_NUM);
 }
 
 /**
@@ -316,7 +334,8 @@ OPEN1722_INLINE uint16_t Avtp_Abb_GetSegmentNum(const Avtp_Abb_t* const pdu) {
  * @param pdu Pointer to an ACF_ABB message.
  * @param mtv The value to set.
  */
-OPEN1722_INLINE void Avtp_Abb_SetMtv(Avtp_Abb_t* pdu, bool mtv) {
+OPEN1722_INLINE void Avtp_Abb_SetMtv(Avtp_Abb_t *pdu, bool mtv)
+{
     SET_ABB_FIELD(AVTP_ABB_FIELD_MTV, mtv);
 }
 
@@ -326,7 +345,8 @@ OPEN1722_INLINE void Avtp_Abb_SetMtv(Avtp_Abb_t* pdu, bool mtv) {
  * @param pdu Pointer to an ACF_ABB message.
  * @param byteBusId The value to set.
  */
-OPEN1722_INLINE void Avtp_Abb_SetByteBusId(Avtp_Abb_t* pdu, uint16_t byteBusId) {
+OPEN1722_INLINE void Avtp_Abb_SetByteBusId(Avtp_Abb_t *pdu, uint16_t byteBusId)
+{
     SET_ABB_FIELD(AVTP_ABB_FIELD_BYTE_BUS_ID, byteBusId);
 }
 
@@ -336,7 +356,8 @@ OPEN1722_INLINE void Avtp_Abb_SetByteBusId(Avtp_Abb_t* pdu, uint16_t byteBusId) 
  * @param pdu Pointer to an ACF_ABB message.
  * @param evt The value to set.
  */
-OPEN1722_INLINE void Avtp_Abb_SetEvt(Avtp_Abb_t* pdu, uint8_t evt) {
+OPEN1722_INLINE void Avtp_Abb_SetEvt(Avtp_Abb_t *pdu, uint8_t evt)
+{
     SET_ABB_FIELD(AVTP_ABB_FIELD_EVT, evt);
 }
 
@@ -346,7 +367,8 @@ OPEN1722_INLINE void Avtp_Abb_SetEvt(Avtp_Abb_t* pdu, uint8_t evt) {
  * @param pdu Pointer to an ACF_ABB message.
  * @param hs The value to set.
  */
-OPEN1722_INLINE void Avtp_Abb_SetHs(Avtp_Abb_t* pdu, bool hs) {
+OPEN1722_INLINE void Avtp_Abb_SetHs(Avtp_Abb_t *pdu, bool hs)
+{
     SET_ABB_FIELD(AVTP_ABB_FIELD_HS, hs);
 }
 
@@ -356,7 +378,8 @@ OPEN1722_INLINE void Avtp_Abb_SetHs(Avtp_Abb_t* pdu, bool hs) {
  * @param pdu Pointer to an ACF_ABB message.
  * @param cs The value to set.
  */
-OPEN1722_INLINE void Avtp_Abb_SetCs(Avtp_Abb_t* pdu, bool cs) {
+OPEN1722_INLINE void Avtp_Abb_SetCs(Avtp_Abb_t *pdu, bool cs)
+{
     SET_ABB_FIELD(AVTP_ABB_FIELD_CS, cs);
 }
 
@@ -366,7 +389,8 @@ OPEN1722_INLINE void Avtp_Abb_SetCs(Avtp_Abb_t* pdu, bool cs) {
  * @param pdu Pointer to an ACF_ABB message.
  * @param transactionNum The value to set.
  */
-OPEN1722_INLINE void Avtp_Abb_SetTransactionNum(Avtp_Abb_t* pdu, uint8_t transactionNum) {
+OPEN1722_INLINE void Avtp_Abb_SetTransactionNum(Avtp_Abb_t *pdu, uint8_t transactionNum)
+{
     SET_ABB_FIELD(AVTP_ABB_FIELD_TRANSACTION_NUM, transactionNum);
 }
 
@@ -376,7 +400,8 @@ OPEN1722_INLINE void Avtp_Abb_SetTransactionNum(Avtp_Abb_t* pdu, uint8_t transac
  * @param pdu Pointer to an ACF_ABB message.
  * @param op The value to set.
  */
-OPEN1722_INLINE void Avtp_Abb_SetOp(Avtp_Abb_t* pdu, bool op) {
+OPEN1722_INLINE void Avtp_Abb_SetOp(Avtp_Abb_t *pdu, bool op)
+{
     SET_ABB_FIELD(AVTP_ABB_FIELD_OP, op);
 }
 
@@ -386,7 +411,8 @@ OPEN1722_INLINE void Avtp_Abb_SetOp(Avtp_Abb_t* pdu, bool op) {
  * @param pdu Pointer to an ACF_ABB message.
  * @param rsp The value to set.
  */
-OPEN1722_INLINE void Avtp_Abb_SetRsp(Avtp_Abb_t* pdu, bool rsp) {
+OPEN1722_INLINE void Avtp_Abb_SetRsp(Avtp_Abb_t *pdu, bool rsp)
+{
     SET_ABB_FIELD(AVTP_ABB_FIELD_RSP, rsp);
 }
 
@@ -396,7 +422,8 @@ OPEN1722_INLINE void Avtp_Abb_SetRsp(Avtp_Abb_t* pdu, bool rsp) {
  * @param pdu Pointer to an ACF_ABB message.
  * @param err The value to set.
  */
-OPEN1722_INLINE void Avtp_Abb_SetErr(Avtp_Abb_t* pdu, bool err) {
+OPEN1722_INLINE void Avtp_Abb_SetErr(Avtp_Abb_t *pdu, bool err)
+{
     SET_ABB_FIELD(AVTP_ABB_FIELD_ERR, err);
 }
 
@@ -406,7 +433,8 @@ OPEN1722_INLINE void Avtp_Abb_SetErr(Avtp_Abb_t* pdu, bool err) {
  * @param pdu Pointer to an ACF_ABB message.
  * @param ms The value to set.
  */
-OPEN1722_INLINE void Avtp_Abb_SetMs(Avtp_Abb_t* pdu, bool ms) {
+OPEN1722_INLINE void Avtp_Abb_SetMs(Avtp_Abb_t *pdu, bool ms)
+{
     SET_ABB_FIELD(AVTP_ABB_FIELD_MS, ms);
 }
 
@@ -416,7 +444,8 @@ OPEN1722_INLINE void Avtp_Abb_SetMs(Avtp_Abb_t* pdu, bool ms) {
  * @param pdu Pointer to an ACF_ABB message.
  * @param readSize The value to set.
  */
-OPEN1722_INLINE void Avtp_Abb_SetReadSize(Avtp_Abb_t* pdu, uint16_t readSize) {
+OPEN1722_INLINE void Avtp_Abb_SetReadSize(Avtp_Abb_t *pdu, uint16_t readSize)
+{
     SET_ABB_FIELD(AVTP_ABB_FIELD_READ_SIZE_SEGMENT_NUM, readSize);
 }
 
@@ -426,7 +455,8 @@ OPEN1722_INLINE void Avtp_Abb_SetReadSize(Avtp_Abb_t* pdu, uint16_t readSize) {
  * @param pdu Pointer to an ACF_ABB message.
  * @param segmentNum The value to set.
  */
-OPEN1722_INLINE void Avtp_Abb_SetSegmentNum(Avtp_Abb_t* pdu, uint16_t segmentNum) {
+OPEN1722_INLINE void Avtp_Abb_SetSegmentNum(Avtp_Abb_t *pdu, uint16_t segmentNum)
+{
     SET_ABB_FIELD(AVTP_ABB_FIELD_READ_SIZE_SEGMENT_NUM, segmentNum);
 }
 
@@ -436,7 +466,7 @@ OPEN1722_INLINE void Avtp_Abb_SetSegmentNum(Avtp_Abb_t* pdu, uint16_t segmentNum
  * @param pdu Pointer to the first bit of a 1722 ACF ABB PDU.
  * @return Pointer to ACF ABB frame payload
  */
-OPEN1722_INLINE const uint8_t *Avtp_Abb_GetPayload(const Avtp_Abb_t* const pdu)
+OPEN1722_INLINE const uint8_t *Avtp_Abb_GetPayload(const Avtp_Abb_t *const pdu)
 {
     return pdu->payload;
 }
@@ -448,8 +478,7 @@ OPEN1722_INLINE const uint8_t *Avtp_Abb_GetPayload(const Avtp_Abb_t* const pdu)
  * @param payload Pointer to the payload byte array
  * @param payload_length Length of the payload
  */
-OPEN1722_INLINE void Avtp_Abb_SetPayload(Avtp_Abb_t *pdu, uint8_t *payload,
-                                         uint16_t payload_length)
+OPEN1722_INLINE void Avtp_Abb_SetPayload(Avtp_Abb_t *pdu, uint8_t *payload, uint16_t payload_length)
 {
     memcpy(pdu->payload, payload, payload_length);
 }
@@ -486,7 +515,7 @@ OPEN1722_INLINE void Avtp_Abb_SetPayloadLength(Avtp_Abb_t *pdu, uint16_t payload
  * @param pdu Pointer to the first bit of a 1722 ACF ABB PDU.
  * @return  Length of payload in bytes
  */
-OPEN1722_INLINE uint8_t Avtp_Abb_GetPayloadLength(const Avtp_Abb_t* const pdu)
+OPEN1722_INLINE uint8_t Avtp_Abb_GetPayloadLength(const Avtp_Abb_t *const pdu)
 {
     uint8_t pad_length = Avtp_Abb_GetPad(pdu);
     uint16_t acf_length_bytes = Avtp_Abb_GetAcfMsgLengthInBytes(pdu);
@@ -498,7 +527,7 @@ OPEN1722_INLINE uint8_t Avtp_Abb_GetPayloadLength(const Avtp_Abb_t* const pdu)
  *
  * @param pdu Pointer to the first bit of a 1722 ACF ABB PDU.
  */
-OPEN1722_INLINE void Avtp_Abb_Init(Avtp_Abb_t* pdu)
+OPEN1722_INLINE void Avtp_Abb_Init(Avtp_Abb_t *pdu)
 {
     if (pdu != NULL) {
         memset(pdu, 0, sizeof(Avtp_Abb_t));
@@ -544,7 +573,7 @@ OPEN1722_INLINE void Avtp_Abb_CreateAcfMessage(Avtp_Abb_t *pdu, uint16_t byte_bu
  * @param bufferSize Size of the buffer containing the ACF ABB frame.
  * @return true if the ACF ABB frame is valid, false otherwise.
  */
-OPEN1722_INLINE bool Avtp_Abb_IsValid(const Avtp_Abb_t* const pdu, size_t bufferSize)
+OPEN1722_INLINE bool Avtp_Abb_IsValid(const Avtp_Abb_t *const pdu, size_t bufferSize)
 {
     if (pdu == NULL) {
         return false;

--- a/include/avtp/acf/Gbb.h
+++ b/include/avtp/acf/Gbb.h
@@ -44,9 +44,14 @@ extern "C" {
 #include <stdbool.h>
 #include <string.h>
 
+#include "avtp/Utils.h"
 #include "avtp/Defines.h"
 #include "avtp/acf/AcfCommon.h"
-#include "avtp/Utils.h"
+
+#define GET_GBB_FIELD(field)                                                                       \
+    (Avtp_GetField(Avtp_GbbFieldDesc, AVTP_GBB_FIELD_MAX, (uint8_t *)pdu, field))
+#define SET_GBB_FIELD(field, value)                                                                \
+    (Avtp_SetField(Avtp_GbbFieldDesc, AVTP_GBB_FIELD_MAX, (uint8_t *)pdu, field, value))
 
 /**
  * Length of ACF_GBB message header in bytes.
@@ -60,7 +65,7 @@ extern "C" {
 typedef struct {
     uint8_t header[AVTP_GBB_HEADER_LEN];
     uint8_t payload[0];
-} Avtp_Gbb_t;
+} __attribute__((packed)) Avtp_Gbb_t;
 
 /**
  * Fields encoded in the ACF_GBB header.
@@ -85,12 +90,12 @@ typedef enum {
     AVTP_GBB_FIELD_READ_SIZE_SEGMENT_NUM,
     /* Count number of fields for bound checks */
     AVTP_GBB_FIELD_MAX
-} Avtp_GbbField_t;
+} Avtp_GbbFields_t;
 
 /**
  * This table describes all the offsets of the ACF_GBB header fields.
  */
-static const Avtp_FieldDescriptor_t __AVTP_GBB_FIELDS[AVTP_GBB_FIELD_MAX] =
+static const Avtp_FieldDescriptor_t Avtp_GbbFieldDesc[AVTP_GBB_FIELD_MAX] =
 {
     /* ACF common header fields */
     [AVTP_GBB_FIELD_ACF_MSG_TYPE]           = { .quadlet = 0, .offset =  0, .bits = 7 },
@@ -112,351 +117,484 @@ static const Avtp_FieldDescriptor_t __AVTP_GBB_FIELDS[AVTP_GBB_FIELD_MAX] =
 };
 
 /**
- * Macro to get the value of a field from an ACF_GBB message header.
- * 
- * @note This macro should not be used directly, instead use the field specific
- * getter functions defined below.
- */
-#define __Avtp_Gbb_GetField(field) \
-        (Avtp_GetField(__AVTP_GBB_FIELDS, AVTP_GBB_FIELD_MAX, (uint8_t*)msg, field))
-
-/**
- * Macro to set the value of a field in an ACF_GBB message header.
- * 
- * @note This macro should not be used directly, instead use the field specific
- * setter functions defined below.
- */
-#define __Avtp_Gbb_SetField(field, value) \
-        (Avtp_SetField(__AVTP_GBB_FIELDS, AVTP_GBB_FIELD_MAX, (uint8_t*)msg, field, value))
-
-/**
- * Initializes an ACF_GBB message with default values for the header fields
- * including acf_msg_type and acf_msg_length.
+ * Return the value of the ACF message type field as specified in the IEEE 1722 Specification.
  *
- * @param msg Pointer to the ACF_GBB message to initialize.
+ * @param pdu Pointer to the first bit of a 1722 ACF GBB PDU.
+ * @returns Value of the ACF message type field.
  */
-OPEN1722_INLINE void Avtp_Gbb_Init(Avtp_Gbb_t* msg) {
-    memset(msg, 0, sizeof(Avtp_Gbb_t));
-    __Avtp_Gbb_SetField(AVTP_GBB_FIELD_ACF_MSG_TYPE, AVTP_ACF_TYPE_BYTE_BUS);
-    __Avtp_Gbb_SetField(AVTP_GBB_FIELD_ACF_MSG_LENGTH, AVTP_GBB_HEADER_LEN / AVTP_QUADLET_SIZE);
+OPEN1722_INLINE uint8_t Avtp_Gbb_GetAcfMsgType(const Avtp_Gbb_t* const pdu) {
+    return (uint8_t) GET_GBB_FIELD(AVTP_GBB_FIELD_ACF_MSG_TYPE);
+}
+
+/**
+ * Return the value of the ACF message length field as specified in the IEEE 1722 Specification.
+ * This returns the length in Quadlets as specified in the IEEE 1722 Specification.
+ *
+ * You can use Avtp_Gbb_GetPayloadLength to get the length in bytes without padding.
+ *
+ * @param pdu Pointer to the first bit of a 1722 ACF GBB PDU.
+ * @returns Value of the ACF message length field.
+ */
+OPEN1722_INLINE uint16_t Avtp_Gbb_GetAcfMsgLength(const Avtp_Gbb_t* const pdu) {
+    return (uint16_t) GET_GBB_FIELD(AVTP_GBB_FIELD_ACF_MSG_LENGTH);
+}
+
+/**
+ * Return the ACF message length in bytes.
+ *
+ * @param pdu Pointer to the first bit of a 1722 ACF GBB PDU.
+ * @returns Length of the ACF message in bytes.
+ */
+OPEN1722_INLINE uint16_t Avtp_Gbb_GetAcfMsgLengthInBytes(const Avtp_Gbb_t* const pdu) {
+    return (uint16_t) GET_GBB_FIELD(AVTP_GBB_FIELD_ACF_MSG_LENGTH) * 4;
+}
+
+/**
+ * Set the value of the ACF message type field as specified in the IEEE 1722 Specification.
+ *
+ * @param pdu Pointer to the first bit of a 1722 ACF GBB PDU.
+ * @param value Value to set the ACF message type field to.
+ */
+OPEN1722_INLINE void Avtp_Gbb_SetAcfMsgType(Avtp_Gbb_t* pdu, uint8_t value) {
+    SET_GBB_FIELD(AVTP_GBB_FIELD_ACF_MSG_TYPE, value);
+}
+
+/**
+ * Set the value of the ACF message length field as specified in the IEEE 1722 Specification.
+ * Note: the size is in Quadlets as specified in the IEEE 1722 Specification.
+ * You can use Avtp_Gbb_SetPayloadLength to set length in bytes and automatically set the
+ * correct padding.
+ *
+ * @param pdu Pointer to the first bit of a 1722 ACF GBB PDU.
+ * @param value Value to set the ACF message length field to.
+ */
+OPEN1722_INLINE void Avtp_Gbb_SetAcfMsgLength(Avtp_Gbb_t* pdu, uint16_t value) {
+    SET_GBB_FIELD(AVTP_GBB_FIELD_ACF_MSG_LENGTH, value);
 }
 
 /**
  * Returns the pad field from an ACF_GBB message header.
- * 
- * @param msg Pointer to an ACF_GBB message.
+ *
+ * @param pdu Pointer to an ACF_GBB message.
  * @returns The value of the pad field.
  */
-OPEN1722_INLINE uint8_t Avtp_Gbb_GetPad(const Avtp_Gbb_t* msg) {
-    return (uint8_t) __Avtp_Gbb_GetField(AVTP_GBB_FIELD_PAD);
+OPEN1722_INLINE uint8_t Avtp_Gbb_GetPad(const Avtp_Gbb_t* const pdu) {
+    return (uint8_t) GET_GBB_FIELD(AVTP_GBB_FIELD_PAD);
 }
 
 /**
- * Returns the message timestamp valid flag (mtv) from an ACF_GBB message
- * header.
- * 
- * @param msg Pointer to an ACF_GBB message.
+ * Sets the pad field in an ACF_GBB message header.
+ *
+ * @param pdu Pointer to an ACF_GBB message.
+ * @param pad The value to set.
+ */
+OPEN1722_INLINE void Avtp_Gbb_SetPad(Avtp_Gbb_t* pdu, uint8_t pad) {
+    SET_GBB_FIELD(AVTP_GBB_FIELD_PAD, pad);
+}
+
+/**
+ * Returns the message timestamp valid flag (mtv) from an ACF_GBB message header.
+ *
+ * @param pdu Pointer to an ACF_GBB message.
  * @returns The value of the mtv flag.
  */
-OPEN1722_INLINE bool Avtp_Gbb_IsMtv(const Avtp_Gbb_t* msg) {
-    return (bool) __Avtp_Gbb_GetField(AVTP_GBB_FIELD_MTV);
+OPEN1722_INLINE bool Avtp_Gbb_IsMtv(const Avtp_Gbb_t* const pdu) {
+    return (bool) GET_GBB_FIELD(AVTP_GBB_FIELD_MTV);
 }
 
 /**
  * Returns the value of the byte_bus_id field from an ACF_GBB message header.
- * 
- * @param msg Pointer to an ACF_GBB message.
+ *
+ * @param pdu Pointer to an ACF_GBB message.
  * @returns The value of the byte_bus_id field.
  */
-OPEN1722_INLINE uint16_t Avtp_Gbb_GetByteBusId(const Avtp_Gbb_t* msg) {
-    return (uint16_t) __Avtp_Gbb_GetField(AVTP_GBB_FIELD_BYTE_BUS_ID);
+OPEN1722_INLINE uint16_t Avtp_Gbb_GetByteBusId(const Avtp_Gbb_t* const pdu) {
+    return (uint16_t) GET_GBB_FIELD(AVTP_GBB_FIELD_BYTE_BUS_ID);
 }
 
 /**
- * Returns the value of the message_timestamp field from an ACF_GBB message
- * header.
- * 
- * @param msg Pointer to an ACF_GBB message.
+ * Returns the value of the message_timestamp field from an ACF_GBB message header.
+ *
+ * @param pdu Pointer to an ACF_GBB message.
  * @returns The value of the message_timestamp field.
  */
-OPEN1722_INLINE uint64_t Avtp_Gbb_GetMessageTimestamp(const Avtp_Gbb_t* msg) {
-    return (uint64_t) __Avtp_Gbb_GetField(AVTP_GBB_FIELD_MESSAGE_TIMESTAMP);
+OPEN1722_INLINE uint64_t Avtp_Gbb_GetMessageTimestamp(const Avtp_Gbb_t* const pdu) {
+    return (uint64_t) GET_GBB_FIELD(AVTP_GBB_FIELD_MESSAGE_TIMESTAMP);
 }
 
 /**
  * Returns the value of the evt field from an ACF_GBB message header.
- * 
- * @param msg Pointer to an ACF_GBB message.
+ *
+ * @param pdu Pointer to an ACF_GBB message.
  * @returns The value of the evt field.
  */
-OPEN1722_INLINE uint8_t Avtp_Gbb_GetEvt(const Avtp_Gbb_t* msg) {
-    return (uint8_t) __Avtp_Gbb_GetField(AVTP_GBB_FIELD_EVT);
+OPEN1722_INLINE uint8_t Avtp_Gbb_GetEvt(const Avtp_Gbb_t* const pdu) {
+    return (uint8_t) GET_GBB_FIELD(AVTP_GBB_FIELD_EVT);
 }
 
 /**
  * Returns the value of the hs field from an ACF_GBB message header.
- * 
- * @param msg Pointer to an ACF_GBB message.
+ *
+ * @param pdu Pointer to an ACF_GBB message.
  * @returns The value of the hs field.
  */
-OPEN1722_INLINE bool Avtp_Gbb_IsHs(const Avtp_Gbb_t* msg) {
-    return (bool) __Avtp_Gbb_GetField(AVTP_GBB_FIELD_HS);
+OPEN1722_INLINE bool Avtp_Gbb_IsHs(const Avtp_Gbb_t* const pdu) {
+    return (bool) GET_GBB_FIELD(AVTP_GBB_FIELD_HS);
 }
 
 /**
  * Returns the value of the cs field from an ACF_GBB message header.
- * 
- * @param msg Pointer to an ACF_GBB message.
+ *
+ * @param pdu Pointer to an ACF_GBB message.
  * @returns The value of the cs field.
  */
-OPEN1722_INLINE bool Avtp_Gbb_IsCs(const Avtp_Gbb_t* msg) {
-    return (bool) __Avtp_Gbb_GetField(AVTP_GBB_FIELD_CS);
+OPEN1722_INLINE bool Avtp_Gbb_IsCs(const Avtp_Gbb_t* const pdu) {
+    return (bool) GET_GBB_FIELD(AVTP_GBB_FIELD_CS);
 }
 
 /**
- * Returns the value of the transaction_num field from an ACF_GBB message
- * header.
- * 
- * @param msg Pointer to an ACF_GBB message.
+ * Returns the value of the transaction_num field from an ACF_GBB message header.
+ *
+ * @param pdu Pointer to an ACF_GBB message.
  * @returns The value of the transaction_num field.
  */
-OPEN1722_INLINE uint8_t Avtp_Gbb_GetTransactionNum(const Avtp_Gbb_t* msg) {
-    return (uint8_t) __Avtp_Gbb_GetField(AVTP_GBB_FIELD_TRANSACTION_NUM);
+OPEN1722_INLINE uint8_t Avtp_Gbb_GetTransactionNum(const Avtp_Gbb_t* const pdu) {
+    return (uint8_t) GET_GBB_FIELD(AVTP_GBB_FIELD_TRANSACTION_NUM);
 }
 
 /**
  * Returns the value of the op flag from an ACF_GBB message header.
- * 
- * @param msg Pointer to an ACF_GBB message.
+ *
+ * @param pdu Pointer to an ACF_GBB message.
  * @returns The value of the op flag.
  */
-OPEN1722_INLINE bool Avtp_Gbb_IsOp(const Avtp_Gbb_t* msg) {
-    return (bool) __Avtp_Gbb_GetField(AVTP_GBB_FIELD_OP);
+OPEN1722_INLINE bool Avtp_Gbb_IsOp(const Avtp_Gbb_t* const pdu) {
+    return (bool) GET_GBB_FIELD(AVTP_GBB_FIELD_OP);
 }
 
 /**
  * Returns the value of the rsp flag from an ACF_GBB message header.
- * 
- * @param msg Pointer to an ACF_GBB message.
+ *
+ * @param pdu Pointer to an ACF_GBB message.
  * @returns The value of the rsp flag.
  */
-OPEN1722_INLINE bool Avtp_Gbb_IsRsp(const Avtp_Gbb_t* msg) {
-    return (bool) __Avtp_Gbb_GetField(AVTP_GBB_FIELD_RSP);
+OPEN1722_INLINE bool Avtp_Gbb_IsRsp(const Avtp_Gbb_t* const pdu) {
+    return (bool) GET_GBB_FIELD(AVTP_GBB_FIELD_RSP);
 }
 
 /**
  * Returns the value of the err flag from an ACF_GBB message header.
- * 
- * @param msg Pointer to an ACF_GBB message.
+ *
+ * @param pdu Pointer to an ACF_GBB message.
  * @returns The value of the err flag.
  */
-OPEN1722_INLINE bool Avtp_Gbb_IsErr(const Avtp_Gbb_t* msg) {
-    return (bool) __Avtp_Gbb_GetField(AVTP_GBB_FIELD_ERR);
+OPEN1722_INLINE bool Avtp_Gbb_IsErr(const Avtp_Gbb_t* const pdu) {
+    return (bool) GET_GBB_FIELD(AVTP_GBB_FIELD_ERR);
 }
 
 /**
  * Returns the value of the ms flag from an ACF_GBB message header.
- * 
- * @param msg Pointer to an ACF_GBB message.
+ *
+ * @param pdu Pointer to an ACF_GBB message.
  * @returns The value of the ms flag.
  */
-OPEN1722_INLINE bool Avtp_Gbb_IsMs(const Avtp_Gbb_t* msg) {
-    return (bool) __Avtp_Gbb_GetField(AVTP_GBB_FIELD_MS);
+OPEN1722_INLINE bool Avtp_Gbb_IsMs(const Avtp_Gbb_t* const pdu) {
+    return (bool) GET_GBB_FIELD(AVTP_GBB_FIELD_MS);
 }
 
 /**
- * Returns the value of the read_size/segment_num field from an ACF_GBB message
- * header.
- * 
- * @param msg Pointer to an ACF_GBB message.
+ * Returns the value of the read_size/segment_num field from an ACF_GBB message header.
+ *
+ * @param pdu Pointer to an ACF_GBB message.
  * @returns The value of the read_size/segment_num field.
  */
-OPEN1722_INLINE uint16_t Avtp_Gbb_GetReadSize(const Avtp_Gbb_t* msg) {
-    return (uint16_t) __Avtp_Gbb_GetField(AVTP_GBB_FIELD_READ_SIZE_SEGMENT_NUM);
+OPEN1722_INLINE uint16_t Avtp_Gbb_GetReadSize(const Avtp_Gbb_t* const pdu) {
+    return (uint16_t) GET_GBB_FIELD(AVTP_GBB_FIELD_READ_SIZE_SEGMENT_NUM);
 }
 
 /**
- * Returns the value of the read_size/segment_num field from an ACF_GBB message
- * header.
- * 
- * @param msg Pointer to an ACF_GBB message.
+ * Returns the value of the read_size/segment_num field from an ACF_GBB message header.
+ *
+ * @param pdu Pointer to an ACF_GBB message.
  * @returns The value of the read_size/segment_num field.
  */
-OPEN1722_INLINE uint16_t Avtp_Gbb_GetSegmentNum(const Avtp_Gbb_t* msg) {
-    return (uint16_t) __Avtp_Gbb_GetField(AVTP_GBB_FIELD_READ_SIZE_SEGMENT_NUM);
-}
-
-/**
- * Returns the paload length from an ACF_GBB message (in bytes). This is
- * calculated based on the value of the acf_msg_length field in the header
- * as well as the value of the pad field.
- * 
- * @param msg Pointer to an ACF_GBB message.
- * @returns The payload length in bytes.
- */
-OPEN1722_INLINE uint16_t Avtp_Gbb_GetPayloadLen(const Avtp_Gbb_t* msg) {
-    return (uint16_t) (__Avtp_Gbb_GetField(AVTP_GBB_FIELD_ACF_MSG_LENGTH) * AVTP_QUADLET_SIZE
-           - AVTP_GBB_HEADER_LEN
-           - __Avtp_Gbb_GetField(AVTP_GBB_FIELD_PAD));
-}
-
-/**
- * Returns the total message length from an ACF_GBB message (in bytes)
- * including header and payload section.
- * 
- * @param msg Pointer to an ACF_GBB message.
- * @returns The total message length in bytes.
- */
-OPEN1722_INLINE uint16_t Avtp_Gbb_GetLen(const Avtp_Gbb_t* msg) {
-    return (uint16_t) (__Avtp_Gbb_GetField(AVTP_GBB_FIELD_ACF_MSG_LENGTH) * AVTP_QUADLET_SIZE);
+OPEN1722_INLINE uint16_t Avtp_Gbb_GetSegmentNum(const Avtp_Gbb_t* const pdu) {
+    return (uint16_t) GET_GBB_FIELD(AVTP_GBB_FIELD_READ_SIZE_SEGMENT_NUM);
 }
 
 /**
  * Sets the value of the mtv flag in an ACF_GBB message header.
- * 
- * @param msg Pointer to an ACF_GBB message.
+ *
+ * @param pdu Pointer to an ACF_GBB message.
  * @param mtv The value to set.
  */
-OPEN1722_INLINE void Avtp_Gbb_SetMtv(Avtp_Gbb_t* msg, bool mtv) {
-    __Avtp_Gbb_SetField(AVTP_GBB_FIELD_MTV, mtv);
+OPEN1722_INLINE void Avtp_Gbb_SetMtv(Avtp_Gbb_t* pdu, bool mtv) {
+    SET_GBB_FIELD(AVTP_GBB_FIELD_MTV, mtv);
 }
 
 /**
  * Sets the value of the byte_bus_id field in an ACF_GBB message header.
- * 
- * @param msg Pointer to an ACF_GBB message.
+ *
+ * @param pdu Pointer to an ACF_GBB message.
  * @param byteBusId The value to set.
  */
-OPEN1722_INLINE void Avtp_Gbb_SetByteBusId(Avtp_Gbb_t* msg, uint16_t byteBusId) {
-    __Avtp_Gbb_SetField(AVTP_GBB_FIELD_BYTE_BUS_ID, byteBusId);
+OPEN1722_INLINE void Avtp_Gbb_SetByteBusId(Avtp_Gbb_t* pdu, uint16_t byteBusId) {
+    SET_GBB_FIELD(AVTP_GBB_FIELD_BYTE_BUS_ID, byteBusId);
 }
 
 /**
  * Sets the value of the message_timestamp field in an ACF_GBB message header.
- * 
- * @param msg Pointer to an ACF_GBB message.
+ *
+ * @param pdu Pointer to an ACF_GBB message.
  * @param messageTimestamp The value to set.
  */
-OPEN1722_INLINE void Avtp_Gbb_SetMessageTimestamp(Avtp_Gbb_t* msg, uint64_t messageTimestamp) {
-    __Avtp_Gbb_SetField(AVTP_GBB_FIELD_MESSAGE_TIMESTAMP, messageTimestamp);
+OPEN1722_INLINE void Avtp_Gbb_SetMessageTimestamp(Avtp_Gbb_t* pdu, uint64_t messageTimestamp) {
+    SET_GBB_FIELD(AVTP_GBB_FIELD_MESSAGE_TIMESTAMP, messageTimestamp);
 }
 
 /**
  * Sets the value of the evt field in an ACF_GBB message header.
- * 
- * @param msg Pointer to an ACF_GBB message.
+ *
+ * @param pdu Pointer to an ACF_GBB message.
  * @param evt The value to set.
  */
-
-OPEN1722_INLINE void Avtp_Gbb_SetEvt(Avtp_Gbb_t* msg, uint8_t evt) {
-    __Avtp_Gbb_SetField(AVTP_GBB_FIELD_EVT, evt);
+OPEN1722_INLINE void Avtp_Gbb_SetEvt(Avtp_Gbb_t* pdu, uint8_t evt) {
+    SET_GBB_FIELD(AVTP_GBB_FIELD_EVT, evt);
 }
 
 /**
  * Sets the value of the hs flag in an ACF_GBB message header.
- * 
- * @param msg Pointer to an ACF_GBB message.
+ *
+ * @param pdu Pointer to an ACF_GBB message.
  * @param hs The value to set.
  */
-OPEN1722_INLINE void Avtp_Gbb_SetHs(Avtp_Gbb_t* msg, bool hs) {
-    __Avtp_Gbb_SetField(AVTP_GBB_FIELD_HS, hs);
+OPEN1722_INLINE void Avtp_Gbb_SetHs(Avtp_Gbb_t* pdu, bool hs) {
+    SET_GBB_FIELD(AVTP_GBB_FIELD_HS, hs);
 }
-
 
 /**
  * Sets the value of the cs flag in an ACF_GBB message header.
- * 
- * @param msg Pointer to an ACF_GBB message.
+ *
+ * @param pdu Pointer to an ACF_GBB message.
  * @param cs The value to set.
  */
-OPEN1722_INLINE void Avtp_Gbb_SetCs(Avtp_Gbb_t* msg, bool cs) {
-    __Avtp_Gbb_SetField(AVTP_GBB_FIELD_CS, cs);
+OPEN1722_INLINE void Avtp_Gbb_SetCs(Avtp_Gbb_t* pdu, bool cs) {
+    SET_GBB_FIELD(AVTP_GBB_FIELD_CS, cs);
 }
 
 /**
  * Sets the value of the transaction_num field in an ACF_GBB message header.
- * 
- * @param msg Pointer to an ACF_GBB message.
+ *
+ * @param pdu Pointer to an ACF_GBB message.
  * @param transactionNum The value to set.
  */
-OPEN1722_INLINE void Avtp_Gbb_SetTransactionNum(Avtp_Gbb_t* msg, uint8_t transactionNum) {
-    __Avtp_Gbb_SetField(AVTP_GBB_FIELD_TRANSACTION_NUM, transactionNum);
+OPEN1722_INLINE void Avtp_Gbb_SetTransactionNum(Avtp_Gbb_t* pdu, uint8_t transactionNum) {
+    SET_GBB_FIELD(AVTP_GBB_FIELD_TRANSACTION_NUM, transactionNum);
 }
 
 /**
  * Sets the value of the op flag in an ACF_GBB message header.
- * 
- * @param msg Pointer to an ACF_GBB message.
+ *
+ * @param pdu Pointer to an ACF_GBB message.
  * @param op The value to set.
  */
-OPEN1722_INLINE void Avtp_Gbb_SetOp(Avtp_Gbb_t* msg, bool op) {
-    __Avtp_Gbb_SetField(AVTP_GBB_FIELD_OP, op);
+OPEN1722_INLINE void Avtp_Gbb_SetOp(Avtp_Gbb_t* pdu, bool op) {
+    SET_GBB_FIELD(AVTP_GBB_FIELD_OP, op);
 }
 
 /**
  * Sets the value of the rsp flag in an ACF_GBB message header.
- * 
- * @param msg Pointer to an ACF_GBB message.
+ *
+ * @param pdu Pointer to an ACF_GBB message.
  * @param rsp The value to set.
  */
-OPEN1722_INLINE void Avtp_Gbb_SetRsp(Avtp_Gbb_t* msg, bool rsp) {
-    __Avtp_Gbb_SetField(AVTP_GBB_FIELD_RSP, rsp);
+OPEN1722_INLINE void Avtp_Gbb_SetRsp(Avtp_Gbb_t* pdu, bool rsp) {
+    SET_GBB_FIELD(AVTP_GBB_FIELD_RSP, rsp);
 }
 
 /**
  * Sets the value of the err flag in an ACF_GBB message header.
- * 
- * @param msg Pointer to an ACF_GBB message.
+ *
+ * @param pdu Pointer to an ACF_GBB message.
  * @param err The value to set.
  */
-OPEN1722_INLINE void Avtp_Gbb_SetErr(Avtp_Gbb_t* msg, bool err) {
-    __Avtp_Gbb_SetField(AVTP_GBB_FIELD_ERR, err);
+OPEN1722_INLINE void Avtp_Gbb_SetErr(Avtp_Gbb_t* pdu, bool err) {
+    SET_GBB_FIELD(AVTP_GBB_FIELD_ERR, err);
 }
 
 /**
  * Sets the value of the ms flag in an ACF_GBB message header.
- * 
- * @param msg Pointer to an ACF_GBB message.
+ *
+ * @param pdu Pointer to an ACF_GBB message.
  * @param ms The value to set.
  */
-OPEN1722_INLINE void Avtp_Gbb_SetMs(Avtp_Gbb_t* msg, bool ms) {
-    __Avtp_Gbb_SetField(AVTP_GBB_FIELD_MS, ms);
+OPEN1722_INLINE void Avtp_Gbb_SetMs(Avtp_Gbb_t* pdu, bool ms) {
+    SET_GBB_FIELD(AVTP_GBB_FIELD_MS, ms);
 }
 
 /**
  * Sets the value of the read_size/segment_num field in an ACF_GBB message header.
- * 
- * @param msg Pointer to an ACF_GBB message.
+ *
+ * @param pdu Pointer to an ACF_GBB message.
  * @param readSize The value to set.
  */
-OPEN1722_INLINE void Avtp_Gbb_SetReadSize(Avtp_Gbb_t* msg, uint16_t readSize) {
-    __Avtp_Gbb_SetField(AVTP_GBB_FIELD_READ_SIZE_SEGMENT_NUM, readSize);
+OPEN1722_INLINE void Avtp_Gbb_SetReadSize(Avtp_Gbb_t* pdu, uint16_t readSize) {
+    SET_GBB_FIELD(AVTP_GBB_FIELD_READ_SIZE_SEGMENT_NUM, readSize);
 }
 
 /**
  * Sets the value of the read_size/segment_num field in an ACF_GBB message header.
- * 
- * @param msg Pointer to an ACF_GBB message.
+ *
+ * @param pdu Pointer to an ACF_GBB message.
  * @param segmentNum The value to set.
  */
-OPEN1722_INLINE void Avtp_Gbb_SetSegmentNum(Avtp_Gbb_t* msg, uint16_t segmentNum) {
-    __Avtp_Gbb_SetField(AVTP_GBB_FIELD_READ_SIZE_SEGMENT_NUM, segmentNum);
+OPEN1722_INLINE void Avtp_Gbb_SetSegmentNum(Avtp_Gbb_t* pdu, uint16_t segmentNum) {
+    SET_GBB_FIELD(AVTP_GBB_FIELD_READ_SIZE_SEGMENT_NUM, segmentNum);
 }
 
 /**
- * Sets the value of the acf_msg_length field in an ACF_GBB message header
- * based on the given payload length. This function also calculates the
- * required padding and sets the value of the pad field accordingly.
- * 
- * @param msg Pointer to an ACF_GBB message.
- * @param payloadLen The length of the payload in bytes.
+ * Returns pointer to payload of an ACF GBB frame.
+ *
+ * @param pdu Pointer to the first bit of a 1722 ACF GBB PDU.
+ * @return Pointer to ACF GBB frame payload
  */
-OPEN1722_INLINE void Avtp_Gbb_SetPayloadLen(Avtp_Gbb_t* msg, uint16_t payloadLen) {
-    uint16_t msgLenBytes = AVTP_GBB_HEADER_LEN + payloadLen;
-    uint8_t pad = (uint8_t) (4 - (msgLenBytes % 4)) % 4;
-    uint16_t msgLenQuadlets = (uint16_t) ((msgLenBytes + pad) / 4);
-    __Avtp_Gbb_SetField(AVTP_GBB_FIELD_ACF_MSG_LENGTH, msgLenQuadlets);
-    __Avtp_Gbb_SetField(AVTP_GBB_FIELD_PAD, pad);
+OPEN1722_INLINE const uint8_t *Avtp_Gbb_GetPayload(const Avtp_Gbb_t* const pdu)
+{
+    return pdu->payload;
+}
+
+/**
+ * Sets the payload in an ACF GBB frame.
+ *
+ * @param pdu Pointer to the first bit of a 1722 ACF GBB PDU.
+ * @param payload Pointer to the payload byte array
+ * @param payload_length Length of the payload
+ */
+OPEN1722_INLINE void Avtp_Gbb_SetPayload(Avtp_Gbb_t *pdu, uint8_t *payload,
+                                         uint16_t payload_length)
+{
+    memcpy(pdu->payload, payload, payload_length);
+}
+
+/**
+ * Finalizes the ACF GBB frame. This function will set the
+ * length and pad fields while inserting the padded bytes. This will also
+ * set padding bytes to zero if the payload length is not a multiple of 4.
+ * to avoid leaking information
+ *
+ * @param pdu Pointer to the first bit of a 1722 ACF GBB PDU.
+ * @param payload_length Length of the frame payload.
+ */
+OPEN1722_INLINE void Avtp_Gbb_SetPayloadLength(Avtp_Gbb_t *pdu, uint16_t payload_length)
+{
+    uint16_t msgLenBytes = AVTP_GBB_HEADER_LEN + payload_length;
+    uint8_t pad = (uint8_t)(4 - (msgLenBytes % 4)) % 4;
+    if (pad > 0) {
+        memset(pdu->payload + payload_length, 0, pad);
+    }
+    uint16_t msgLenQuadlets = (uint16_t)((msgLenBytes + pad) / 4);
+    Avtp_Gbb_SetPad(pdu, pad);
+    Avtp_Gbb_SetAcfMsgLength(pdu, msgLenQuadlets);
+}
+
+/**
+ * Returns the length of the payload without the padding bytes and the
+ * header length of the encapsulating ACF Frame.
+ *
+ * Precondition: the caller must have validated the PDU with
+ * Avtp_Gbb_IsValid(). This function performs no further bounds checking
+ * and assumes those invariants already hold.
+ *
+ * @param pdu Pointer to the first bit of a 1722 ACF GBB PDU.
+ * @return  Length of payload in bytes
+ */
+OPEN1722_INLINE uint8_t Avtp_Gbb_GetPayloadLength(const Avtp_Gbb_t* const pdu)
+{
+    uint8_t pad_length = Avtp_Gbb_GetPad(pdu);
+    uint16_t acf_length_bytes = Avtp_Gbb_GetAcfMsgLengthInBytes(pdu);
+    return (uint8_t)(acf_length_bytes - AVTP_GBB_HEADER_LEN - pad_length);
+}
+
+/**
+ * Initializes an ACF_GBB message header as specified in the IEEE 1722 Specification.
+ *
+ * @param pdu Pointer to the first bit of a 1722 ACF GBB PDU.
+ */
+OPEN1722_INLINE void Avtp_Gbb_Init(Avtp_Gbb_t* pdu)
+{
+    if (pdu != NULL) {
+        memset(pdu, 0, sizeof(Avtp_Gbb_t));
+        Avtp_Gbb_SetAcfMsgType(pdu, AVTP_ACF_TYPE_BYTE_BUS);
+    }
+}
+
+/**
+ * Copies the payload data, byte bus ID, op flag and transaction number into the ACF GBB frame.
+ * This function will also set the length and pad fields while inserting the padded bytes.
+ *
+ * @param pdu Pointer to the first bit of a 1722 ACF GBB PDU.
+ * @param byte_bus_id Byte bus ID
+ * @param op Operation flag
+ * @param transaction_num Transaction number
+ * @param payload Pointer to the payload byte array
+ * @param payload_length Length of the payload.
+ */
+OPEN1722_INLINE void Avtp_Gbb_CreateAcfMessage(Avtp_Gbb_t *pdu, uint16_t byte_bus_id, bool op,
+                                               uint8_t transaction_num, uint8_t *payload,
+                                               uint16_t payload_length)
+{
+    // Initialize the ACF GBB header
+    Avtp_Gbb_Init(pdu);
+
+    // Set the byte bus ID, op flag and transaction number
+    Avtp_Gbb_SetByteBusId(pdu, byte_bus_id);
+    Avtp_Gbb_SetOp(pdu, op);
+    Avtp_Gbb_SetTransactionNum(pdu, transaction_num);
+
+    // Copy the payload into the PDU
+    Avtp_Gbb_SetPayload(pdu, payload, payload_length);
+
+    // Finalize the AVTP GBB Frame
+    Avtp_Gbb_SetPayloadLength(pdu, payload_length);
+}
+
+/**
+ * Checks if the ACF GBB frame is valid by checking:
+ *     1) if the length field of AVTP/ACF messages contains a value larger than the actual size of
+ * the buffer that contains the AVTP message. 2) if other format specific invariants are not upheld
+ * @param pdu Pointer to the first bit of a 1722 ACF GBB PDU.
+ * @param bufferSize Size of the buffer containing the ACF GBB frame.
+ * @return true if the ACF GBB frame is valid, false otherwise.
+ */
+OPEN1722_INLINE bool Avtp_Gbb_IsValid(const Avtp_Gbb_t* const pdu, size_t bufferSize)
+{
+    if (pdu == NULL) {
+        return false;
+    }
+
+    if (bufferSize < AVTP_GBB_HEADER_LEN) {
+        return false;
+    }
+
+    if (Avtp_Gbb_GetAcfMsgType(pdu) != AVTP_ACF_TYPE_BYTE_BUS) {
+        return false;
+    }
+
+    // Avtp_Gbb_GetAcfMsgLength returns quadlets. Convert the length field to octets.
+    uint16_t msg_length_bytes = (uint16_t)Avtp_Gbb_GetAcfMsgLength(pdu) * 4;
+    if (msg_length_bytes > bufferSize) {
+        return false;
+    }
+
+    /* The encoded message length must accommodate header + declared padding
+     * so the payload computation in Avtp_Gbb_GetPayloadLength() doesn't
+     * underflow. */
+    uint8_t pad_length = Avtp_Gbb_GetPad(pdu);
+    uint16_t header_and_pad = (uint16_t)AVTP_GBB_HEADER_LEN + pad_length;
+    if (msg_length_bytes < header_and_pad) {
+        return false;
+    }
+    return true;
 }
 
 #ifdef __cplusplus

--- a/include/avtp/acf/Gbb.h
+++ b/include/avtp/acf/Gbb.h
@@ -95,25 +95,24 @@ typedef enum {
 /**
  * This table describes all the offsets of the ACF_GBB header fields.
  */
-static const Avtp_FieldDescriptor_t Avtp_GbbFieldDesc[AVTP_GBB_FIELD_MAX] =
-{
+static const Avtp_FieldDescriptor_t Avtp_GbbFieldDesc[AVTP_GBB_FIELD_MAX] = {
     /* ACF common header fields */
-    [AVTP_GBB_FIELD_ACF_MSG_TYPE]           = { .quadlet = 0, .offset =  0, .bits = 7 },
-    [AVTP_GBB_FIELD_ACF_MSG_LENGTH]         = { .quadlet = 0, .offset =  7, .bits = 9 },
+    [AVTP_GBB_FIELD_ACF_MSG_TYPE] = {.quadlet = 0, .offset = 0, .bits = 7},
+    [AVTP_GBB_FIELD_ACF_MSG_LENGTH] = {.quadlet = 0, .offset = 7, .bits = 9},
     /* ACF GBB header fields */
-    [AVTP_GBB_FIELD_PAD]                    = { .quadlet = 0, .offset = 16, .bits =   2 },
-    [AVTP_GBB_FIELD_MTV]                    = { .quadlet = 0, .offset = 18, .bits =   1 },
-    [AVTP_GBB_FIELD_BYTE_BUS_ID]            = { .quadlet = 0, .offset = 21, .bits =  11 },
-    [AVTP_GBB_FIELD_MESSAGE_TIMESTAMP]      = { .quadlet = 1, .offset =  0, .bits =  64 },
-    [AVTP_GBB_FIELD_EVT]                    = { .quadlet = 3, .offset =  0, .bits =   4 },
-    [AVTP_GBB_FIELD_HS]                     = { .quadlet = 3, .offset =  6, .bits =   1 },
-    [AVTP_GBB_FIELD_CS]                     = { .quadlet = 3, .offset =  7, .bits =   1 },
-    [AVTP_GBB_FIELD_TRANSACTION_NUM]        = { .quadlet = 3, .offset =  8, .bits =   8 },
-    [AVTP_GBB_FIELD_OP]                     = { .quadlet = 3, .offset = 16, .bits =   1 },
-    [AVTP_GBB_FIELD_RSP]                    = { .quadlet = 3, .offset = 17, .bits =   1 },
-    [AVTP_GBB_FIELD_ERR]                    = { .quadlet = 3, .offset = 18, .bits =   1 },
-    [AVTP_GBB_FIELD_MS]                     = { .quadlet = 3, .offset = 19, .bits =   1 },
-    [AVTP_GBB_FIELD_READ_SIZE_SEGMENT_NUM]  = { .quadlet = 3, .offset = 20, .bits =  12 },
+    [AVTP_GBB_FIELD_PAD] = {.quadlet = 0, .offset = 16, .bits = 2},
+    [AVTP_GBB_FIELD_MTV] = {.quadlet = 0, .offset = 18, .bits = 1},
+    [AVTP_GBB_FIELD_BYTE_BUS_ID] = {.quadlet = 0, .offset = 21, .bits = 11},
+    [AVTP_GBB_FIELD_MESSAGE_TIMESTAMP] = {.quadlet = 1, .offset = 0, .bits = 64},
+    [AVTP_GBB_FIELD_EVT] = {.quadlet = 3, .offset = 0, .bits = 4},
+    [AVTP_GBB_FIELD_HS] = {.quadlet = 3, .offset = 6, .bits = 1},
+    [AVTP_GBB_FIELD_CS] = {.quadlet = 3, .offset = 7, .bits = 1},
+    [AVTP_GBB_FIELD_TRANSACTION_NUM] = {.quadlet = 3, .offset = 8, .bits = 8},
+    [AVTP_GBB_FIELD_OP] = {.quadlet = 3, .offset = 16, .bits = 1},
+    [AVTP_GBB_FIELD_RSP] = {.quadlet = 3, .offset = 17, .bits = 1},
+    [AVTP_GBB_FIELD_ERR] = {.quadlet = 3, .offset = 18, .bits = 1},
+    [AVTP_GBB_FIELD_MS] = {.quadlet = 3, .offset = 19, .bits = 1},
+    [AVTP_GBB_FIELD_READ_SIZE_SEGMENT_NUM] = {.quadlet = 3, .offset = 20, .bits = 12},
 };
 
 /**
@@ -122,8 +121,9 @@ static const Avtp_FieldDescriptor_t Avtp_GbbFieldDesc[AVTP_GBB_FIELD_MAX] =
  * @param pdu Pointer to the first bit of a 1722 ACF GBB PDU.
  * @returns Value of the ACF message type field.
  */
-OPEN1722_INLINE uint8_t Avtp_Gbb_GetAcfMsgType(const Avtp_Gbb_t* const pdu) {
-    return (uint8_t) GET_GBB_FIELD(AVTP_GBB_FIELD_ACF_MSG_TYPE);
+OPEN1722_INLINE uint8_t Avtp_Gbb_GetAcfMsgType(const Avtp_Gbb_t *const pdu)
+{
+    return (uint8_t)GET_GBB_FIELD(AVTP_GBB_FIELD_ACF_MSG_TYPE);
 }
 
 /**
@@ -135,8 +135,9 @@ OPEN1722_INLINE uint8_t Avtp_Gbb_GetAcfMsgType(const Avtp_Gbb_t* const pdu) {
  * @param pdu Pointer to the first bit of a 1722 ACF GBB PDU.
  * @returns Value of the ACF message length field.
  */
-OPEN1722_INLINE uint16_t Avtp_Gbb_GetAcfMsgLength(const Avtp_Gbb_t* const pdu) {
-    return (uint16_t) GET_GBB_FIELD(AVTP_GBB_FIELD_ACF_MSG_LENGTH);
+OPEN1722_INLINE uint16_t Avtp_Gbb_GetAcfMsgLength(const Avtp_Gbb_t *const pdu)
+{
+    return (uint16_t)GET_GBB_FIELD(AVTP_GBB_FIELD_ACF_MSG_LENGTH);
 }
 
 /**
@@ -145,8 +146,9 @@ OPEN1722_INLINE uint16_t Avtp_Gbb_GetAcfMsgLength(const Avtp_Gbb_t* const pdu) {
  * @param pdu Pointer to the first bit of a 1722 ACF GBB PDU.
  * @returns Length of the ACF message in bytes.
  */
-OPEN1722_INLINE uint16_t Avtp_Gbb_GetAcfMsgLengthInBytes(const Avtp_Gbb_t* const pdu) {
-    return (uint16_t) GET_GBB_FIELD(AVTP_GBB_FIELD_ACF_MSG_LENGTH) * 4;
+OPEN1722_INLINE uint16_t Avtp_Gbb_GetAcfMsgLengthInBytes(const Avtp_Gbb_t *const pdu)
+{
+    return (uint16_t)GET_GBB_FIELD(AVTP_GBB_FIELD_ACF_MSG_LENGTH) * 4;
 }
 
 /**
@@ -155,7 +157,8 @@ OPEN1722_INLINE uint16_t Avtp_Gbb_GetAcfMsgLengthInBytes(const Avtp_Gbb_t* const
  * @param pdu Pointer to the first bit of a 1722 ACF GBB PDU.
  * @param value Value to set the ACF message type field to.
  */
-OPEN1722_INLINE void Avtp_Gbb_SetAcfMsgType(Avtp_Gbb_t* pdu, uint8_t value) {
+OPEN1722_INLINE void Avtp_Gbb_SetAcfMsgType(Avtp_Gbb_t *pdu, uint8_t value)
+{
     SET_GBB_FIELD(AVTP_GBB_FIELD_ACF_MSG_TYPE, value);
 }
 
@@ -168,7 +171,8 @@ OPEN1722_INLINE void Avtp_Gbb_SetAcfMsgType(Avtp_Gbb_t* pdu, uint8_t value) {
  * @param pdu Pointer to the first bit of a 1722 ACF GBB PDU.
  * @param value Value to set the ACF message length field to.
  */
-OPEN1722_INLINE void Avtp_Gbb_SetAcfMsgLength(Avtp_Gbb_t* pdu, uint16_t value) {
+OPEN1722_INLINE void Avtp_Gbb_SetAcfMsgLength(Avtp_Gbb_t *pdu, uint16_t value)
+{
     SET_GBB_FIELD(AVTP_GBB_FIELD_ACF_MSG_LENGTH, value);
 }
 
@@ -178,8 +182,9 @@ OPEN1722_INLINE void Avtp_Gbb_SetAcfMsgLength(Avtp_Gbb_t* pdu, uint16_t value) {
  * @param pdu Pointer to an ACF_GBB message.
  * @returns The value of the pad field.
  */
-OPEN1722_INLINE uint8_t Avtp_Gbb_GetPad(const Avtp_Gbb_t* const pdu) {
-    return (uint8_t) GET_GBB_FIELD(AVTP_GBB_FIELD_PAD);
+OPEN1722_INLINE uint8_t Avtp_Gbb_GetPad(const Avtp_Gbb_t *const pdu)
+{
+    return (uint8_t)GET_GBB_FIELD(AVTP_GBB_FIELD_PAD);
 }
 
 /**
@@ -188,7 +193,8 @@ OPEN1722_INLINE uint8_t Avtp_Gbb_GetPad(const Avtp_Gbb_t* const pdu) {
  * @param pdu Pointer to an ACF_GBB message.
  * @param pad The value to set.
  */
-OPEN1722_INLINE void Avtp_Gbb_SetPad(Avtp_Gbb_t* pdu, uint8_t pad) {
+OPEN1722_INLINE void Avtp_Gbb_SetPad(Avtp_Gbb_t *pdu, uint8_t pad)
+{
     SET_GBB_FIELD(AVTP_GBB_FIELD_PAD, pad);
 }
 
@@ -198,8 +204,9 @@ OPEN1722_INLINE void Avtp_Gbb_SetPad(Avtp_Gbb_t* pdu, uint8_t pad) {
  * @param pdu Pointer to an ACF_GBB message.
  * @returns The value of the mtv flag.
  */
-OPEN1722_INLINE bool Avtp_Gbb_IsMtv(const Avtp_Gbb_t* const pdu) {
-    return (bool) GET_GBB_FIELD(AVTP_GBB_FIELD_MTV);
+OPEN1722_INLINE bool Avtp_Gbb_IsMtv(const Avtp_Gbb_t *const pdu)
+{
+    return (bool)GET_GBB_FIELD(AVTP_GBB_FIELD_MTV);
 }
 
 /**
@@ -208,8 +215,9 @@ OPEN1722_INLINE bool Avtp_Gbb_IsMtv(const Avtp_Gbb_t* const pdu) {
  * @param pdu Pointer to an ACF_GBB message.
  * @returns The value of the byte_bus_id field.
  */
-OPEN1722_INLINE uint16_t Avtp_Gbb_GetByteBusId(const Avtp_Gbb_t* const pdu) {
-    return (uint16_t) GET_GBB_FIELD(AVTP_GBB_FIELD_BYTE_BUS_ID);
+OPEN1722_INLINE uint16_t Avtp_Gbb_GetByteBusId(const Avtp_Gbb_t *const pdu)
+{
+    return (uint16_t)GET_GBB_FIELD(AVTP_GBB_FIELD_BYTE_BUS_ID);
 }
 
 /**
@@ -218,8 +226,9 @@ OPEN1722_INLINE uint16_t Avtp_Gbb_GetByteBusId(const Avtp_Gbb_t* const pdu) {
  * @param pdu Pointer to an ACF_GBB message.
  * @returns The value of the message_timestamp field.
  */
-OPEN1722_INLINE uint64_t Avtp_Gbb_GetMessageTimestamp(const Avtp_Gbb_t* const pdu) {
-    return (uint64_t) GET_GBB_FIELD(AVTP_GBB_FIELD_MESSAGE_TIMESTAMP);
+OPEN1722_INLINE uint64_t Avtp_Gbb_GetMessageTimestamp(const Avtp_Gbb_t *const pdu)
+{
+    return (uint64_t)GET_GBB_FIELD(AVTP_GBB_FIELD_MESSAGE_TIMESTAMP);
 }
 
 /**
@@ -228,8 +237,9 @@ OPEN1722_INLINE uint64_t Avtp_Gbb_GetMessageTimestamp(const Avtp_Gbb_t* const pd
  * @param pdu Pointer to an ACF_GBB message.
  * @returns The value of the evt field.
  */
-OPEN1722_INLINE uint8_t Avtp_Gbb_GetEvt(const Avtp_Gbb_t* const pdu) {
-    return (uint8_t) GET_GBB_FIELD(AVTP_GBB_FIELD_EVT);
+OPEN1722_INLINE uint8_t Avtp_Gbb_GetEvt(const Avtp_Gbb_t *const pdu)
+{
+    return (uint8_t)GET_GBB_FIELD(AVTP_GBB_FIELD_EVT);
 }
 
 /**
@@ -238,8 +248,9 @@ OPEN1722_INLINE uint8_t Avtp_Gbb_GetEvt(const Avtp_Gbb_t* const pdu) {
  * @param pdu Pointer to an ACF_GBB message.
  * @returns The value of the hs field.
  */
-OPEN1722_INLINE bool Avtp_Gbb_IsHs(const Avtp_Gbb_t* const pdu) {
-    return (bool) GET_GBB_FIELD(AVTP_GBB_FIELD_HS);
+OPEN1722_INLINE bool Avtp_Gbb_IsHs(const Avtp_Gbb_t *const pdu)
+{
+    return (bool)GET_GBB_FIELD(AVTP_GBB_FIELD_HS);
 }
 
 /**
@@ -248,8 +259,9 @@ OPEN1722_INLINE bool Avtp_Gbb_IsHs(const Avtp_Gbb_t* const pdu) {
  * @param pdu Pointer to an ACF_GBB message.
  * @returns The value of the cs field.
  */
-OPEN1722_INLINE bool Avtp_Gbb_IsCs(const Avtp_Gbb_t* const pdu) {
-    return (bool) GET_GBB_FIELD(AVTP_GBB_FIELD_CS);
+OPEN1722_INLINE bool Avtp_Gbb_IsCs(const Avtp_Gbb_t *const pdu)
+{
+    return (bool)GET_GBB_FIELD(AVTP_GBB_FIELD_CS);
 }
 
 /**
@@ -258,8 +270,9 @@ OPEN1722_INLINE bool Avtp_Gbb_IsCs(const Avtp_Gbb_t* const pdu) {
  * @param pdu Pointer to an ACF_GBB message.
  * @returns The value of the transaction_num field.
  */
-OPEN1722_INLINE uint8_t Avtp_Gbb_GetTransactionNum(const Avtp_Gbb_t* const pdu) {
-    return (uint8_t) GET_GBB_FIELD(AVTP_GBB_FIELD_TRANSACTION_NUM);
+OPEN1722_INLINE uint8_t Avtp_Gbb_GetTransactionNum(const Avtp_Gbb_t *const pdu)
+{
+    return (uint8_t)GET_GBB_FIELD(AVTP_GBB_FIELD_TRANSACTION_NUM);
 }
 
 /**
@@ -268,8 +281,9 @@ OPEN1722_INLINE uint8_t Avtp_Gbb_GetTransactionNum(const Avtp_Gbb_t* const pdu) 
  * @param pdu Pointer to an ACF_GBB message.
  * @returns The value of the op flag.
  */
-OPEN1722_INLINE bool Avtp_Gbb_IsOp(const Avtp_Gbb_t* const pdu) {
-    return (bool) GET_GBB_FIELD(AVTP_GBB_FIELD_OP);
+OPEN1722_INLINE bool Avtp_Gbb_IsOp(const Avtp_Gbb_t *const pdu)
+{
+    return (bool)GET_GBB_FIELD(AVTP_GBB_FIELD_OP);
 }
 
 /**
@@ -278,8 +292,9 @@ OPEN1722_INLINE bool Avtp_Gbb_IsOp(const Avtp_Gbb_t* const pdu) {
  * @param pdu Pointer to an ACF_GBB message.
  * @returns The value of the rsp flag.
  */
-OPEN1722_INLINE bool Avtp_Gbb_IsRsp(const Avtp_Gbb_t* const pdu) {
-    return (bool) GET_GBB_FIELD(AVTP_GBB_FIELD_RSP);
+OPEN1722_INLINE bool Avtp_Gbb_IsRsp(const Avtp_Gbb_t *const pdu)
+{
+    return (bool)GET_GBB_FIELD(AVTP_GBB_FIELD_RSP);
 }
 
 /**
@@ -288,8 +303,9 @@ OPEN1722_INLINE bool Avtp_Gbb_IsRsp(const Avtp_Gbb_t* const pdu) {
  * @param pdu Pointer to an ACF_GBB message.
  * @returns The value of the err flag.
  */
-OPEN1722_INLINE bool Avtp_Gbb_IsErr(const Avtp_Gbb_t* const pdu) {
-    return (bool) GET_GBB_FIELD(AVTP_GBB_FIELD_ERR);
+OPEN1722_INLINE bool Avtp_Gbb_IsErr(const Avtp_Gbb_t *const pdu)
+{
+    return (bool)GET_GBB_FIELD(AVTP_GBB_FIELD_ERR);
 }
 
 /**
@@ -298,8 +314,9 @@ OPEN1722_INLINE bool Avtp_Gbb_IsErr(const Avtp_Gbb_t* const pdu) {
  * @param pdu Pointer to an ACF_GBB message.
  * @returns The value of the ms flag.
  */
-OPEN1722_INLINE bool Avtp_Gbb_IsMs(const Avtp_Gbb_t* const pdu) {
-    return (bool) GET_GBB_FIELD(AVTP_GBB_FIELD_MS);
+OPEN1722_INLINE bool Avtp_Gbb_IsMs(const Avtp_Gbb_t *const pdu)
+{
+    return (bool)GET_GBB_FIELD(AVTP_GBB_FIELD_MS);
 }
 
 /**
@@ -308,8 +325,9 @@ OPEN1722_INLINE bool Avtp_Gbb_IsMs(const Avtp_Gbb_t* const pdu) {
  * @param pdu Pointer to an ACF_GBB message.
  * @returns The value of the read_size/segment_num field.
  */
-OPEN1722_INLINE uint16_t Avtp_Gbb_GetReadSize(const Avtp_Gbb_t* const pdu) {
-    return (uint16_t) GET_GBB_FIELD(AVTP_GBB_FIELD_READ_SIZE_SEGMENT_NUM);
+OPEN1722_INLINE uint16_t Avtp_Gbb_GetReadSize(const Avtp_Gbb_t *const pdu)
+{
+    return (uint16_t)GET_GBB_FIELD(AVTP_GBB_FIELD_READ_SIZE_SEGMENT_NUM);
 }
 
 /**
@@ -318,8 +336,9 @@ OPEN1722_INLINE uint16_t Avtp_Gbb_GetReadSize(const Avtp_Gbb_t* const pdu) {
  * @param pdu Pointer to an ACF_GBB message.
  * @returns The value of the read_size/segment_num field.
  */
-OPEN1722_INLINE uint16_t Avtp_Gbb_GetSegmentNum(const Avtp_Gbb_t* const pdu) {
-    return (uint16_t) GET_GBB_FIELD(AVTP_GBB_FIELD_READ_SIZE_SEGMENT_NUM);
+OPEN1722_INLINE uint16_t Avtp_Gbb_GetSegmentNum(const Avtp_Gbb_t *const pdu)
+{
+    return (uint16_t)GET_GBB_FIELD(AVTP_GBB_FIELD_READ_SIZE_SEGMENT_NUM);
 }
 
 /**
@@ -328,7 +347,8 @@ OPEN1722_INLINE uint16_t Avtp_Gbb_GetSegmentNum(const Avtp_Gbb_t* const pdu) {
  * @param pdu Pointer to an ACF_GBB message.
  * @param mtv The value to set.
  */
-OPEN1722_INLINE void Avtp_Gbb_SetMtv(Avtp_Gbb_t* pdu, bool mtv) {
+OPEN1722_INLINE void Avtp_Gbb_SetMtv(Avtp_Gbb_t *pdu, bool mtv)
+{
     SET_GBB_FIELD(AVTP_GBB_FIELD_MTV, mtv);
 }
 
@@ -338,7 +358,8 @@ OPEN1722_INLINE void Avtp_Gbb_SetMtv(Avtp_Gbb_t* pdu, bool mtv) {
  * @param pdu Pointer to an ACF_GBB message.
  * @param byteBusId The value to set.
  */
-OPEN1722_INLINE void Avtp_Gbb_SetByteBusId(Avtp_Gbb_t* pdu, uint16_t byteBusId) {
+OPEN1722_INLINE void Avtp_Gbb_SetByteBusId(Avtp_Gbb_t *pdu, uint16_t byteBusId)
+{
     SET_GBB_FIELD(AVTP_GBB_FIELD_BYTE_BUS_ID, byteBusId);
 }
 
@@ -348,7 +369,8 @@ OPEN1722_INLINE void Avtp_Gbb_SetByteBusId(Avtp_Gbb_t* pdu, uint16_t byteBusId) 
  * @param pdu Pointer to an ACF_GBB message.
  * @param messageTimestamp The value to set.
  */
-OPEN1722_INLINE void Avtp_Gbb_SetMessageTimestamp(Avtp_Gbb_t* pdu, uint64_t messageTimestamp) {
+OPEN1722_INLINE void Avtp_Gbb_SetMessageTimestamp(Avtp_Gbb_t *pdu, uint64_t messageTimestamp)
+{
     SET_GBB_FIELD(AVTP_GBB_FIELD_MESSAGE_TIMESTAMP, messageTimestamp);
 }
 
@@ -358,7 +380,8 @@ OPEN1722_INLINE void Avtp_Gbb_SetMessageTimestamp(Avtp_Gbb_t* pdu, uint64_t mess
  * @param pdu Pointer to an ACF_GBB message.
  * @param evt The value to set.
  */
-OPEN1722_INLINE void Avtp_Gbb_SetEvt(Avtp_Gbb_t* pdu, uint8_t evt) {
+OPEN1722_INLINE void Avtp_Gbb_SetEvt(Avtp_Gbb_t *pdu, uint8_t evt)
+{
     SET_GBB_FIELD(AVTP_GBB_FIELD_EVT, evt);
 }
 
@@ -368,7 +391,8 @@ OPEN1722_INLINE void Avtp_Gbb_SetEvt(Avtp_Gbb_t* pdu, uint8_t evt) {
  * @param pdu Pointer to an ACF_GBB message.
  * @param hs The value to set.
  */
-OPEN1722_INLINE void Avtp_Gbb_SetHs(Avtp_Gbb_t* pdu, bool hs) {
+OPEN1722_INLINE void Avtp_Gbb_SetHs(Avtp_Gbb_t *pdu, bool hs)
+{
     SET_GBB_FIELD(AVTP_GBB_FIELD_HS, hs);
 }
 
@@ -378,7 +402,8 @@ OPEN1722_INLINE void Avtp_Gbb_SetHs(Avtp_Gbb_t* pdu, bool hs) {
  * @param pdu Pointer to an ACF_GBB message.
  * @param cs The value to set.
  */
-OPEN1722_INLINE void Avtp_Gbb_SetCs(Avtp_Gbb_t* pdu, bool cs) {
+OPEN1722_INLINE void Avtp_Gbb_SetCs(Avtp_Gbb_t *pdu, bool cs)
+{
     SET_GBB_FIELD(AVTP_GBB_FIELD_CS, cs);
 }
 
@@ -388,7 +413,8 @@ OPEN1722_INLINE void Avtp_Gbb_SetCs(Avtp_Gbb_t* pdu, bool cs) {
  * @param pdu Pointer to an ACF_GBB message.
  * @param transactionNum The value to set.
  */
-OPEN1722_INLINE void Avtp_Gbb_SetTransactionNum(Avtp_Gbb_t* pdu, uint8_t transactionNum) {
+OPEN1722_INLINE void Avtp_Gbb_SetTransactionNum(Avtp_Gbb_t *pdu, uint8_t transactionNum)
+{
     SET_GBB_FIELD(AVTP_GBB_FIELD_TRANSACTION_NUM, transactionNum);
 }
 
@@ -398,7 +424,8 @@ OPEN1722_INLINE void Avtp_Gbb_SetTransactionNum(Avtp_Gbb_t* pdu, uint8_t transac
  * @param pdu Pointer to an ACF_GBB message.
  * @param op The value to set.
  */
-OPEN1722_INLINE void Avtp_Gbb_SetOp(Avtp_Gbb_t* pdu, bool op) {
+OPEN1722_INLINE void Avtp_Gbb_SetOp(Avtp_Gbb_t *pdu, bool op)
+{
     SET_GBB_FIELD(AVTP_GBB_FIELD_OP, op);
 }
 
@@ -408,7 +435,8 @@ OPEN1722_INLINE void Avtp_Gbb_SetOp(Avtp_Gbb_t* pdu, bool op) {
  * @param pdu Pointer to an ACF_GBB message.
  * @param rsp The value to set.
  */
-OPEN1722_INLINE void Avtp_Gbb_SetRsp(Avtp_Gbb_t* pdu, bool rsp) {
+OPEN1722_INLINE void Avtp_Gbb_SetRsp(Avtp_Gbb_t *pdu, bool rsp)
+{
     SET_GBB_FIELD(AVTP_GBB_FIELD_RSP, rsp);
 }
 
@@ -418,7 +446,8 @@ OPEN1722_INLINE void Avtp_Gbb_SetRsp(Avtp_Gbb_t* pdu, bool rsp) {
  * @param pdu Pointer to an ACF_GBB message.
  * @param err The value to set.
  */
-OPEN1722_INLINE void Avtp_Gbb_SetErr(Avtp_Gbb_t* pdu, bool err) {
+OPEN1722_INLINE void Avtp_Gbb_SetErr(Avtp_Gbb_t *pdu, bool err)
+{
     SET_GBB_FIELD(AVTP_GBB_FIELD_ERR, err);
 }
 
@@ -428,7 +457,8 @@ OPEN1722_INLINE void Avtp_Gbb_SetErr(Avtp_Gbb_t* pdu, bool err) {
  * @param pdu Pointer to an ACF_GBB message.
  * @param ms The value to set.
  */
-OPEN1722_INLINE void Avtp_Gbb_SetMs(Avtp_Gbb_t* pdu, bool ms) {
+OPEN1722_INLINE void Avtp_Gbb_SetMs(Avtp_Gbb_t *pdu, bool ms)
+{
     SET_GBB_FIELD(AVTP_GBB_FIELD_MS, ms);
 }
 
@@ -438,7 +468,8 @@ OPEN1722_INLINE void Avtp_Gbb_SetMs(Avtp_Gbb_t* pdu, bool ms) {
  * @param pdu Pointer to an ACF_GBB message.
  * @param readSize The value to set.
  */
-OPEN1722_INLINE void Avtp_Gbb_SetReadSize(Avtp_Gbb_t* pdu, uint16_t readSize) {
+OPEN1722_INLINE void Avtp_Gbb_SetReadSize(Avtp_Gbb_t *pdu, uint16_t readSize)
+{
     SET_GBB_FIELD(AVTP_GBB_FIELD_READ_SIZE_SEGMENT_NUM, readSize);
 }
 
@@ -448,7 +479,8 @@ OPEN1722_INLINE void Avtp_Gbb_SetReadSize(Avtp_Gbb_t* pdu, uint16_t readSize) {
  * @param pdu Pointer to an ACF_GBB message.
  * @param segmentNum The value to set.
  */
-OPEN1722_INLINE void Avtp_Gbb_SetSegmentNum(Avtp_Gbb_t* pdu, uint16_t segmentNum) {
+OPEN1722_INLINE void Avtp_Gbb_SetSegmentNum(Avtp_Gbb_t *pdu, uint16_t segmentNum)
+{
     SET_GBB_FIELD(AVTP_GBB_FIELD_READ_SIZE_SEGMENT_NUM, segmentNum);
 }
 
@@ -458,7 +490,7 @@ OPEN1722_INLINE void Avtp_Gbb_SetSegmentNum(Avtp_Gbb_t* pdu, uint16_t segmentNum
  * @param pdu Pointer to the first bit of a 1722 ACF GBB PDU.
  * @return Pointer to ACF GBB frame payload
  */
-OPEN1722_INLINE const uint8_t *Avtp_Gbb_GetPayload(const Avtp_Gbb_t* const pdu)
+OPEN1722_INLINE const uint8_t *Avtp_Gbb_GetPayload(const Avtp_Gbb_t *const pdu)
 {
     return pdu->payload;
 }
@@ -470,8 +502,7 @@ OPEN1722_INLINE const uint8_t *Avtp_Gbb_GetPayload(const Avtp_Gbb_t* const pdu)
  * @param payload Pointer to the payload byte array
  * @param payload_length Length of the payload
  */
-OPEN1722_INLINE void Avtp_Gbb_SetPayload(Avtp_Gbb_t *pdu, uint8_t *payload,
-                                         uint16_t payload_length)
+OPEN1722_INLINE void Avtp_Gbb_SetPayload(Avtp_Gbb_t *pdu, uint8_t *payload, uint16_t payload_length)
 {
     memcpy(pdu->payload, payload, payload_length);
 }
@@ -508,7 +539,7 @@ OPEN1722_INLINE void Avtp_Gbb_SetPayloadLength(Avtp_Gbb_t *pdu, uint16_t payload
  * @param pdu Pointer to the first bit of a 1722 ACF GBB PDU.
  * @return  Length of payload in bytes
  */
-OPEN1722_INLINE uint8_t Avtp_Gbb_GetPayloadLength(const Avtp_Gbb_t* const pdu)
+OPEN1722_INLINE uint8_t Avtp_Gbb_GetPayloadLength(const Avtp_Gbb_t *const pdu)
 {
     uint8_t pad_length = Avtp_Gbb_GetPad(pdu);
     uint16_t acf_length_bytes = Avtp_Gbb_GetAcfMsgLengthInBytes(pdu);
@@ -520,7 +551,7 @@ OPEN1722_INLINE uint8_t Avtp_Gbb_GetPayloadLength(const Avtp_Gbb_t* const pdu)
  *
  * @param pdu Pointer to the first bit of a 1722 ACF GBB PDU.
  */
-OPEN1722_INLINE void Avtp_Gbb_Init(Avtp_Gbb_t* pdu)
+OPEN1722_INLINE void Avtp_Gbb_Init(Avtp_Gbb_t *pdu)
 {
     if (pdu != NULL) {
         memset(pdu, 0, sizeof(Avtp_Gbb_t));
@@ -566,7 +597,7 @@ OPEN1722_INLINE void Avtp_Gbb_CreateAcfMessage(Avtp_Gbb_t *pdu, uint16_t byte_bu
  * @param bufferSize Size of the buffer containing the ACF GBB frame.
  * @return true if the ACF GBB frame is valid, false otherwise.
  */
-OPEN1722_INLINE bool Avtp_Gbb_IsValid(const Avtp_Gbb_t* const pdu, size_t bufferSize)
+OPEN1722_INLINE bool Avtp_Gbb_IsValid(const Avtp_Gbb_t *const pdu, size_t bufferSize)
 {
     if (pdu == NULL) {
         return false;

--- a/unit/test-abb.c
+++ b/unit/test-abb.c
@@ -44,15 +44,43 @@ static void Test_Abb_Init(void** state)
     const size_t msg_len = AVTP_ABB_HEADER_LEN + 4;
     uint8_t msg[msg_len] = {0};
     Avtp_Abb_t* abb = (Avtp_Abb_t*)msg;
+
+    // Check init function while passing in a null pointer
+    Avtp_Abb_Init(NULL);
+
     Avtp_Abb_Init(abb);
 
     uint8_t expected_msg[msg_len] = {
-        0x1C, 0x02, 0x0,  0x0,
+        0x1C, 0x00, 0x0,  0x0,
         0x0,  0x0,  0x0,  0x0,
         0x0,  0x0,  0x0,  0x0
     };
 
     assert_memory_equal(msg, expected_msg, msg_len);
+}
+
+static void Test_Abb_GetAcfMsgType(void** state)
+{
+    const size_t msg_len = AVTP_ABB_HEADER_LEN + 4;
+    uint8_t msg[msg_len] = {
+        0x1C, 0x02, 0x0,  0x0,
+        0x0,  0x0,  0x0,  0x0,
+        0x0,  0x0,  0x0,  0x0
+    };
+    Avtp_Abb_t* abb = (Avtp_Abb_t*)msg;
+    assert_int_equal(Avtp_Abb_GetAcfMsgType(abb), AVTP_ACF_TYPE_BYTE_BUS_BRIEF);
+}
+
+static void Test_Abb_GetAcfMsgLength(void** state)
+{
+    const size_t msg_len = AVTP_ABB_HEADER_LEN + 4;
+    uint8_t msg[msg_len] = {
+        0x1C, 0x02, 0x0,  0x0,
+        0x0,  0x0,  0x0,  0x0,
+        0x0,  0x0,  0x0,  0x0
+    };
+    Avtp_Abb_t* abb = (Avtp_Abb_t*)msg;
+    assert_int_equal(Avtp_Abb_GetAcfMsgLength(abb), 2);
 }
 
 static void Test_Abb_GetPad(void** state)
@@ -211,7 +239,7 @@ static void Test_Abb_GetSegmentNum(void** state)
     assert_int_equal(Avtp_Abb_GetSegmentNum(abb), 0xBFF);
 }
 
-static void Test_Abb_GetPayloadLen(void** state)
+static void Test_Abb_GetPayloadLength(void** state)
 {
     const size_t msg_len = AVTP_ABB_HEADER_LEN + 4;
     uint8_t msg[msg_len] = {
@@ -220,10 +248,10 @@ static void Test_Abb_GetPayloadLen(void** state)
         0x0,  0x0,  0x0,  0x0
     };
     Avtp_Abb_t* abb = (Avtp_Abb_t*)msg;
-    assert_int_equal(Avtp_Abb_GetPayloadLen(abb), 1);
+    assert_int_equal(Avtp_Abb_GetPayloadLength(abb), 1);
 }
 
-static void Test_Abb_GetPayloadLen_NoPadding(void** state)
+static void Test_Abb_GetPayloadLength_NoPadding(void** state)
 {
     const size_t msg_len = AVTP_ABB_HEADER_LEN + 4;
     uint8_t msg[msg_len] = {
@@ -232,10 +260,10 @@ static void Test_Abb_GetPayloadLen_NoPadding(void** state)
         0x0,  0x0,  0x0,  0x0
     };
     Avtp_Abb_t* abb = (Avtp_Abb_t*)msg;
-    assert_int_equal(Avtp_Abb_GetPayloadLen(abb), 4);
+    assert_int_equal(Avtp_Abb_GetPayloadLength(abb), 4);
 }
 
-static void Test_Abb_GetLen(void** state)
+static void Test_Abb_GetAcfMsgLengthInBytes(void** state)
 {
     const size_t msg_len = AVTP_ABB_HEADER_LEN + 4;
     uint8_t msg[msg_len] = {
@@ -244,7 +272,28 @@ static void Test_Abb_GetLen(void** state)
         0x0,  0x0,  0x0,  0x0
     };
     Avtp_Abb_t* abb = (Avtp_Abb_t*)msg;
-    assert_int_equal(Avtp_Abb_GetLen(abb), 3 * 4);
+    assert_int_equal(Avtp_Abb_GetAcfMsgLengthInBytes(abb), 3 * 4);
+}
+
+static void Test_Abb_SetAcfMsgType(void** state)
+{
+    const size_t msg_len = AVTP_ABB_HEADER_LEN + 4;
+    uint8_t msg[msg_len] = {0};
+    Avtp_Abb_t* abb = (Avtp_Abb_t*)msg;
+    Avtp_Abb_Init(abb);
+    Avtp_Abb_SetAcfMsgType(abb, AVTP_ACF_TYPE_BYTE_BUS_BRIEF);
+    assert_int_equal(Avtp_Abb_GetAcfMsgType(abb), AVTP_ACF_TYPE_BYTE_BUS_BRIEF);
+}
+
+static void Test_Abb_SetAcfMsgLength(void** state)
+{
+    const size_t msg_len = AVTP_ABB_HEADER_LEN + 4;
+    uint8_t msg[msg_len] = {0};
+    Avtp_Abb_t* abb = (Avtp_Abb_t*)msg;
+    Avtp_Abb_Init(abb);
+    Avtp_Abb_SetAcfMsgLength(abb, 5);
+    assert_int_equal(Avtp_Abb_GetAcfMsgLength(abb), 5);
+    assert_int_equal(Avtp_Abb_GetAcfMsgLengthInBytes(abb), 20);
 }
 
 static void Test_Abb_SetMtv(void** state)
@@ -256,7 +305,7 @@ static void Test_Abb_SetMtv(void** state)
     Avtp_Abb_SetMtv(abb, true);
 
     uint8_t expected_msg[msg_len] = {
-        0x1C, 0x02, 0x20, 0x0,
+        0x1C, 0x00, 0x20, 0x0,
         0x0,  0x0,  0x0,  0x0,
         0x0,  0x0,  0x0,  0x0
     };
@@ -272,7 +321,7 @@ static void Test_Abb_SetByteBusId(void** state)
     Avtp_Abb_SetByteBusId(abb, 0x5FF);
 
     uint8_t expected_msg[msg_len] = {
-        0x1C, 0x02, 0x5,  0xFF,
+        0x1C, 0x00, 0x5,  0xFF,
         0x0,  0x0,  0x0,  0x0,
         0x0,  0x0,  0x0,  0x0
     };
@@ -288,7 +337,7 @@ static void Test_Abb_SetEvt(void** state)
     Avtp_Abb_SetEvt(abb, 0xB);
 
     uint8_t expected_msg[msg_len] = {
-        0x1C, 0x02, 0x0,  0x0,
+        0x1C, 0x00, 0x0,  0x0,
         0xB0, 0x0,  0x0,  0x0,
         0x0,  0x0,  0x0,  0x0
     };
@@ -304,7 +353,7 @@ static void Test_Abb_SetHs(void** state)
     Avtp_Abb_SetHs(abb, true);
 
     uint8_t expected_msg[msg_len] = {
-        0x1C, 0x02, 0x0,  0x0,
+        0x1C, 0x00, 0x0,  0x0,
         0x2,  0x0,  0x0,  0x0,
         0x0,  0x0,  0x0,  0x0
     };
@@ -320,7 +369,7 @@ static void Test_Abb_SetCs(void** state)
     Avtp_Abb_SetCs(abb, true);
 
     uint8_t expected_msg[msg_len] = {
-        0x1C, 0x02, 0x0,  0x0,
+        0x1C, 0x00, 0x0,  0x0,
         0x1,  0x0,  0x0,  0x0,
         0x0,  0x0,  0x0,  0x0
     };
@@ -336,7 +385,7 @@ static void Test_Abb_SetTransactionNum(void** state)
     Avtp_Abb_SetTransactionNum(abb, 0xBF);
 
     uint8_t expected_msg[msg_len] = {
-        0x1C, 0x02, 0x0,  0x0,
+        0x1C, 0x00, 0x0,  0x0,
         0x0,  0xBF, 0x0,  0x0,
         0x0,  0x0,  0x0,  0x0
     };
@@ -352,7 +401,7 @@ static void Test_Abb_SetOp(void** state)
     Avtp_Abb_SetOp(abb, true);
 
     uint8_t expected_msg[msg_len] = {
-        0x1C, 0x02, 0x0,  0x0,
+        0x1C, 0x00, 0x0,  0x0,
         0x0,  0x0,  0x80, 0x0,
         0x0,  0x0,  0x0,  0x0
     };
@@ -368,7 +417,7 @@ static void Test_Abb_SetRsp(void** state)
     Avtp_Abb_SetRsp(abb, true);
 
     uint8_t expected_msg[msg_len] = {
-        0x1C, 0x02, 0x0,  0x0,
+        0x1C, 0x00, 0x0,  0x0,
         0x0,  0x0,  0x40, 0x0,
         0x0,  0x0,  0x0,  0x0
     };
@@ -384,7 +433,7 @@ static void Test_Abb_SetErr(void** state)
     Avtp_Abb_SetErr(abb, true);
 
     uint8_t expected_msg[msg_len] = {
-        0x1C, 0x02, 0x0,  0x0,
+        0x1C, 0x00, 0x0,  0x0,
         0x0,  0x0,  0x20, 0x0,
         0x0,  0x0,  0x0,  0x0
     };
@@ -400,7 +449,7 @@ static void Test_Abb_SetMs(void** state)
     Avtp_Abb_SetMs(abb, true);
 
     uint8_t expected_msg[msg_len] = {
-        0x1C, 0x02, 0x0,  0x0,
+        0x1C, 0x00, 0x0,  0x0,
         0x0,  0x0,  0x10, 0x0,
         0x0,  0x0,  0x0,  0x0
     };
@@ -416,7 +465,7 @@ static void Test_Abb_SetReadSize(void** state)
     Avtp_Abb_SetReadSize(abb, 0xBFF);
 
     uint8_t expected_msg[msg_len] = {
-        0x1C, 0x02, 0x0,  0x0,
+        0x1C, 0x00, 0x0,  0x0,
         0x0,  0x0,  0xB,  0xFF,
         0x0,  0x0,  0x0,  0x0
     };
@@ -432,20 +481,20 @@ static void Test_Abb_SetSegmentNum(void** state)
     Avtp_Abb_SetSegmentNum(abb, 0xBFF);
 
     uint8_t expected_msg[msg_len] = {
-        0x1C, 0x02, 0x0,  0x0,
+        0x1C, 0x00, 0x0,  0x0,
         0x0,  0x0,  0xB,  0xFF,
         0x0,  0x0,  0x0,  0x0
     };
     assert_memory_equal(msg, expected_msg, msg_len);
 }
 
-static void Test_Abb_SetPayloadLen(void** state)
+static void Test_Abb_SetPayloadLength(void** state)
 {
     const size_t msg_len = AVTP_ABB_HEADER_LEN + 4;
     uint8_t msg[msg_len] = {0};
     Avtp_Abb_t* abb = (Avtp_Abb_t*)msg;
     Avtp_Abb_Init(abb);
-    Avtp_Abb_SetPayloadLen(abb, 3);
+    Avtp_Abb_SetPayloadLength(abb, 3);
 
     uint8_t expected_msg[msg_len] = {
         0x1C, 0x03, 0x40, 0x0,
@@ -455,13 +504,13 @@ static void Test_Abb_SetPayloadLen(void** state)
     assert_memory_equal(msg, expected_msg, msg_len);
 }
 
-static void Test_Abb_SetPayloadLen_NoPadding(void** state)
+static void Test_Abb_SetPayloadLength_NoPadding(void** state)
 {
     const size_t msg_len = AVTP_ABB_HEADER_LEN + 4;
     uint8_t msg[msg_len] = {0};
     Avtp_Abb_t* abb = (Avtp_Abb_t*)msg;
     Avtp_Abb_Init(abb);
-    Avtp_Abb_SetPayloadLen(abb, 4);
+    Avtp_Abb_SetPayloadLength(abb, 4);
 
     uint8_t expected_msg[msg_len] = {
         0x1C, 0x03, 0x0,  0x0,
@@ -471,10 +520,89 @@ static void Test_Abb_SetPayloadLen_NoPadding(void** state)
     assert_memory_equal(msg, expected_msg, msg_len);
 }
 
+static void Test_Abb_Payload(void** state)
+{
+    const size_t msg_len = AVTP_ABB_HEADER_LEN + 8;
+    uint8_t msg[msg_len] = {0};
+    Avtp_Abb_t* abb = (Avtp_Abb_t*)msg;
+    uint8_t payload[8] = {0,1,2,3,4,5,6,7};
+
+    Avtp_Abb_Init(abb);
+    Avtp_Abb_SetPayload(abb, payload, sizeof(payload));
+
+    assert_ptr_equal(Avtp_Abb_GetPayload(abb), msg + AVTP_ABB_HEADER_LEN);
+    assert_memory_equal(payload, Avtp_Abb_GetPayload(abb), sizeof(payload));
+}
+
+static void Test_Abb_CreateAcfMessage(void** state)
+{
+    const size_t msg_len = AVTP_ABB_HEADER_LEN + 8;
+    uint8_t msg[msg_len] = {0};
+    Avtp_Abb_t* abb = (Avtp_Abb_t*)msg;
+    uint8_t payload[8] = {0,1,2,3,4,5,6,7};
+
+    Avtp_Abb_CreateAcfMessage(abb, 0x5FF, true, 0xBF, payload, sizeof(payload));
+
+    assert_int_equal(Avtp_Abb_GetAcfMsgType(abb), AVTP_ACF_TYPE_BYTE_BUS_BRIEF);
+    assert_int_equal(Avtp_Abb_GetByteBusId(abb), 0x5FF);
+    assert_int_equal(Avtp_Abb_IsOp(abb), true);
+    assert_int_equal(Avtp_Abb_GetTransactionNum(abb), 0xBF);
+    assert_memory_equal(payload, msg + AVTP_ABB_HEADER_LEN, sizeof(payload));
+    assert_int_equal(Avtp_Abb_GetPayloadLength(abb), 8);
+}
+
+static void Test_Abb_CreateFromGarbage(void** state)
+{
+    const size_t msg_len = AVTP_ABB_HEADER_LEN + 8;
+    uint8_t msg[msg_len];
+    Avtp_Abb_t* abb = (Avtp_Abb_t*)msg;
+    uint8_t payload[8] = {0,1,2,3,4,5,6,7};
+
+    // CreateAcfMessage must fully initialize the header even on garbage input.
+    memset(msg, 0xAA, msg_len);
+    Avtp_Abb_CreateAcfMessage(abb, 0x5FF, true, 0xBF, payload, sizeof(payload));
+
+    assert_int_equal(Avtp_Abb_GetAcfMsgType(abb), AVTP_ACF_TYPE_BYTE_BUS_BRIEF);
+    assert_int_equal(Avtp_Abb_IsMtv(abb), false);
+    assert_int_equal(Avtp_Abb_IsHs(abb), false);
+    assert_int_equal(Avtp_Abb_IsCs(abb), false);
+    assert_int_equal(Avtp_Abb_IsRsp(abb), false);
+    assert_int_equal(Avtp_Abb_IsErr(abb), false);
+    assert_int_equal(Avtp_Abb_IsMs(abb), false);
+    assert_memory_equal(payload, msg + AVTP_ABB_HEADER_LEN, sizeof(payload));
+    assert_int_equal(Avtp_Abb_IsValid(abb, msg_len), 1);
+}
+
+static void Test_Abb_IsValid(void** state)
+{
+    const size_t msg_len = AVTP_ABB_HEADER_LEN + 32;
+    uint8_t msg[msg_len] = {0};
+    Avtp_Abb_t* abb = (Avtp_Abb_t*)msg;
+    uint8_t payload[8] = {0,1,2,3,4,5,6,7};
+
+    // An Init-only PDU has AcfMsgLength == 0, so IsValid must reject it.
+    Avtp_Abb_Init(abb);
+    assert_int_equal(Avtp_Abb_IsValid(abb, msg_len), 0);
+
+    // A properly-formed frame with an 8-byte payload is valid.
+    Avtp_Abb_CreateAcfMessage(abb, 0x5FF, true, 0xBF, payload, sizeof(payload));
+    assert_int_equal(Avtp_Abb_IsValid(abb, msg_len), 1);
+
+    // Not an ABB message (zero buffer, AcfMsgType != BYTE_BUS_BRIEF).
+    memset(msg, 0, msg_len);
+    assert_int_equal(Avtp_Abb_IsValid(abb, msg_len), 0);
+
+    // Declared length larger than the buffer is invalid.
+    Avtp_Abb_CreateAcfMessage(abb, 0x5FF, true, 0xBF, payload, sizeof(payload));
+    assert_int_equal(Avtp_Abb_IsValid(abb, AVTP_ABB_HEADER_LEN + 1), 0);
+}
+
 int main(void)
 {
     const struct CMUnitTest tests[] = {
         cmocka_unit_test(Test_Abb_Init),
+        cmocka_unit_test(Test_Abb_GetAcfMsgType),
+        cmocka_unit_test(Test_Abb_GetAcfMsgLength),
         cmocka_unit_test(Test_Abb_GetPad),
         cmocka_unit_test(Test_Abb_IsMtv),
         cmocka_unit_test(Test_Abb_GetByteBusId),
@@ -488,9 +616,11 @@ int main(void)
         cmocka_unit_test(Test_Abb_IsMs),
         cmocka_unit_test(Test_Abb_GetReadSize),
         cmocka_unit_test(Test_Abb_GetSegmentNum),
-        cmocka_unit_test(Test_Abb_GetPayloadLen),
-        cmocka_unit_test(Test_Abb_GetPayloadLen_NoPadding),
-        cmocka_unit_test(Test_Abb_GetLen),
+        cmocka_unit_test(Test_Abb_GetPayloadLength),
+        cmocka_unit_test(Test_Abb_GetPayloadLength_NoPadding),
+        cmocka_unit_test(Test_Abb_GetAcfMsgLengthInBytes),
+        cmocka_unit_test(Test_Abb_SetAcfMsgType),
+        cmocka_unit_test(Test_Abb_SetAcfMsgLength),
         cmocka_unit_test(Test_Abb_SetMtv),
         cmocka_unit_test(Test_Abb_SetByteBusId),
         cmocka_unit_test(Test_Abb_SetEvt),
@@ -503,8 +633,12 @@ int main(void)
         cmocka_unit_test(Test_Abb_SetMs),
         cmocka_unit_test(Test_Abb_SetReadSize),
         cmocka_unit_test(Test_Abb_SetSegmentNum),
-        cmocka_unit_test(Test_Abb_SetPayloadLen),
-        cmocka_unit_test(Test_Abb_SetPayloadLen_NoPadding),
+        cmocka_unit_test(Test_Abb_SetPayloadLength),
+        cmocka_unit_test(Test_Abb_SetPayloadLength_NoPadding),
+        cmocka_unit_test(Test_Abb_Payload),
+        cmocka_unit_test(Test_Abb_CreateAcfMessage),
+        cmocka_unit_test(Test_Abb_CreateFromGarbage),
+        cmocka_unit_test(Test_Abb_IsValid)
     };
 
     return cmocka_run_group_tests(tests, NULL, NULL);

--- a/unit/test-abb.c
+++ b/unit/test-abb.c
@@ -39,493 +39,361 @@ extern "C" {
 #include <cmocka.h>
 #include <stdio.h>
 
-static void Test_Abb_Init(void** state)
+static void Test_Abb_Init(void **state)
 {
     const size_t msg_len = AVTP_ABB_HEADER_LEN + 4;
     uint8_t msg[msg_len] = {0};
-    Avtp_Abb_t* abb = (Avtp_Abb_t*)msg;
+    Avtp_Abb_t *abb = (Avtp_Abb_t *)msg;
 
     // Check init function while passing in a null pointer
     Avtp_Abb_Init(NULL);
 
     Avtp_Abb_Init(abb);
 
-    uint8_t expected_msg[msg_len] = {
-        0x1C, 0x00, 0x0,  0x0,
-        0x0,  0x0,  0x0,  0x0,
-        0x0,  0x0,  0x0,  0x0
-    };
+    uint8_t expected_msg[msg_len] = {0x1C, 0x00, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0};
 
     assert_memory_equal(msg, expected_msg, msg_len);
 }
 
-static void Test_Abb_GetAcfMsgType(void** state)
+static void Test_Abb_GetAcfMsgType(void **state)
 {
     const size_t msg_len = AVTP_ABB_HEADER_LEN + 4;
-    uint8_t msg[msg_len] = {
-        0x1C, 0x02, 0x0,  0x0,
-        0x0,  0x0,  0x0,  0x0,
-        0x0,  0x0,  0x0,  0x0
-    };
-    Avtp_Abb_t* abb = (Avtp_Abb_t*)msg;
+    uint8_t msg[msg_len] = {0x1C, 0x02, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0};
+    Avtp_Abb_t *abb = (Avtp_Abb_t *)msg;
     assert_int_equal(Avtp_Abb_GetAcfMsgType(abb), AVTP_ACF_TYPE_BYTE_BUS_BRIEF);
 }
 
-static void Test_Abb_GetAcfMsgLength(void** state)
+static void Test_Abb_GetAcfMsgLength(void **state)
 {
     const size_t msg_len = AVTP_ABB_HEADER_LEN + 4;
-    uint8_t msg[msg_len] = {
-        0x1C, 0x02, 0x0,  0x0,
-        0x0,  0x0,  0x0,  0x0,
-        0x0,  0x0,  0x0,  0x0
-    };
-    Avtp_Abb_t* abb = (Avtp_Abb_t*)msg;
+    uint8_t msg[msg_len] = {0x1C, 0x02, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0};
+    Avtp_Abb_t *abb = (Avtp_Abb_t *)msg;
     assert_int_equal(Avtp_Abb_GetAcfMsgLength(abb), 2);
 }
 
-static void Test_Abb_GetPad(void** state)
+static void Test_Abb_GetPad(void **state)
 {
     const size_t msg_len = AVTP_ABB_HEADER_LEN + 4;
-    uint8_t msg[msg_len] = {
-        0x1C, 0x02, 0xC0, 0x0,
-        0x0,  0x0,  0x0,  0x0,
-        0x0,  0x0,  0x0,  0x0
-    };
-    Avtp_Abb_t* abb = (Avtp_Abb_t*)msg;
+    uint8_t msg[msg_len] = {0x1C, 0x02, 0xC0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0};
+    Avtp_Abb_t *abb = (Avtp_Abb_t *)msg;
     assert_int_equal(Avtp_Abb_GetPad(abb), 3);
 }
 
-static void Test_Abb_IsMtv(void** state)
+static void Test_Abb_IsMtv(void **state)
 {
     const size_t msg_len = AVTP_ABB_HEADER_LEN + 4;
-    uint8_t msg[msg_len] = {
-        0x1C, 0x02, 0x20, 0x0,
-        0x0,  0x0,  0x0,  0x0,
-        0x0,  0x0,  0x0,  0x0
-    };
-    Avtp_Abb_t* abb = (Avtp_Abb_t*)msg;
+    uint8_t msg[msg_len] = {0x1C, 0x02, 0x20, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0};
+    Avtp_Abb_t *abb = (Avtp_Abb_t *)msg;
     assert_int_equal(Avtp_Abb_IsMtv(abb), true);
 }
 
-static void Test_Abb_GetByteBusId(void** state)
+static void Test_Abb_GetByteBusId(void **state)
 {
     const size_t msg_len = AVTP_ABB_HEADER_LEN + 4;
-    uint8_t msg[msg_len] = {
-        0x1C, 0x02, 0x05, 0xFF,
-        0x0,  0x0,  0x0,  0x0,
-        0x0,  0x0,  0x0,  0x0
-    };
-    Avtp_Abb_t* abb = (Avtp_Abb_t*)msg;
+    uint8_t msg[msg_len] = {0x1C, 0x02, 0x05, 0xFF, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0};
+    Avtp_Abb_t *abb = (Avtp_Abb_t *)msg;
     assert_int_equal(Avtp_Abb_GetByteBusId(abb), 0x5FF);
 }
 
-static void Test_Abb_GetEvt(void** state)
+static void Test_Abb_GetEvt(void **state)
 {
     const size_t msg_len = AVTP_ABB_HEADER_LEN + 4;
-    uint8_t msg[msg_len] = {
-        0x1C, 0x02, 0x0,  0x0,
-        0xB0, 0x0,  0x0,  0x0,
-        0x0,  0x0,  0x0,  0x0
-    };
-    Avtp_Abb_t* abb = (Avtp_Abb_t*)msg;
+    uint8_t msg[msg_len] = {0x1C, 0x02, 0x0, 0x0, 0xB0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0};
+    Avtp_Abb_t *abb = (Avtp_Abb_t *)msg;
     assert_int_equal(Avtp_Abb_GetEvt(abb), 0xB);
 }
 
-static void Test_Abb_IsHs(void** state)
+static void Test_Abb_IsHs(void **state)
 {
     const size_t msg_len = AVTP_ABB_HEADER_LEN + 4;
-    uint8_t msg[msg_len] = {
-        0x1C, 0x02, 0x0,  0x0,
-        0x2,  0x0,  0x0,  0x0,
-        0x0,  0x0,  0x0,  0x0
-    };
-    Avtp_Abb_t* abb = (Avtp_Abb_t*)msg;
+    uint8_t msg[msg_len] = {0x1C, 0x02, 0x0, 0x0, 0x2, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0};
+    Avtp_Abb_t *abb = (Avtp_Abb_t *)msg;
     assert_int_equal(Avtp_Abb_IsHs(abb), true);
 }
 
-static void Test_Abb_IsCs(void** state)
+static void Test_Abb_IsCs(void **state)
 {
     const size_t msg_len = AVTP_ABB_HEADER_LEN + 4;
-    uint8_t msg[msg_len] = {
-        0x1C, 0x02, 0x0,  0x0,
-        0x1,  0x0,  0x0,  0x0,
-        0x0,  0x0,  0x0,  0x0
-    };
-    Avtp_Abb_t* abb = (Avtp_Abb_t*)msg;
+    uint8_t msg[msg_len] = {0x1C, 0x02, 0x0, 0x0, 0x1, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0};
+    Avtp_Abb_t *abb = (Avtp_Abb_t *)msg;
     assert_int_equal(Avtp_Abb_IsCs(abb), true);
 }
 
-static void Test_Abb_GetTransactionNum(void** state)
+static void Test_Abb_GetTransactionNum(void **state)
 {
     const size_t msg_len = AVTP_ABB_HEADER_LEN + 4;
-    uint8_t msg[msg_len] = {
-        0x1C, 0x02, 0x0,  0x0,
-        0x0,  0xBF, 0x0,  0x0,
-        0x0,  0x0,  0x0,  0x0
-    };
-    Avtp_Abb_t* abb = (Avtp_Abb_t*)msg;
+    uint8_t msg[msg_len] = {0x1C, 0x02, 0x0, 0x0, 0x0, 0xBF, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0};
+    Avtp_Abb_t *abb = (Avtp_Abb_t *)msg;
     assert_int_equal(Avtp_Abb_GetTransactionNum(abb), 0xBF);
 }
 
-static void Test_Abb_IsOp(void** state)
+static void Test_Abb_IsOp(void **state)
 {
     const size_t msg_len = AVTP_ABB_HEADER_LEN + 4;
-    uint8_t msg[msg_len] = {
-        0x1C, 0x02, 0x0,  0x0,
-        0x0,  0x0,  0x80, 0x0,
-        0x0,  0x0,  0x0,  0x0
-    };
-    Avtp_Abb_t* abb = (Avtp_Abb_t*)msg;
+    uint8_t msg[msg_len] = {0x1C, 0x02, 0x0, 0x0, 0x0, 0x0, 0x80, 0x0, 0x0, 0x0, 0x0, 0x0};
+    Avtp_Abb_t *abb = (Avtp_Abb_t *)msg;
     assert_int_equal(Avtp_Abb_IsOp(abb), true);
 }
 
-static void Test_Abb_IsRsp(void** state)
+static void Test_Abb_IsRsp(void **state)
 {
     const size_t msg_len = AVTP_ABB_HEADER_LEN + 4;
-    uint8_t msg[msg_len] = {
-        0x1C, 0x02, 0x0,  0x0,
-        0x0,  0x0,  0x40, 0x0,
-        0x0,  0x0,  0x0,  0x0
-    };
-    Avtp_Abb_t* abb = (Avtp_Abb_t*)msg;
+    uint8_t msg[msg_len] = {0x1C, 0x02, 0x0, 0x0, 0x0, 0x0, 0x40, 0x0, 0x0, 0x0, 0x0, 0x0};
+    Avtp_Abb_t *abb = (Avtp_Abb_t *)msg;
     assert_int_equal(Avtp_Abb_IsRsp(abb), true);
 }
 
-static void Test_Abb_IsErr(void** state)
+static void Test_Abb_IsErr(void **state)
 {
     const size_t msg_len = AVTP_ABB_HEADER_LEN + 4;
-    uint8_t msg[msg_len] = {
-        0x1C, 0x02, 0x0,  0x0,
-        0x0,  0x0,  0x20, 0x0,
-        0x0,  0x0,  0x0,  0x0
-    };
-    Avtp_Abb_t* abb = (Avtp_Abb_t*)msg;
+    uint8_t msg[msg_len] = {0x1C, 0x02, 0x0, 0x0, 0x0, 0x0, 0x20, 0x0, 0x0, 0x0, 0x0, 0x0};
+    Avtp_Abb_t *abb = (Avtp_Abb_t *)msg;
     assert_int_equal(Avtp_Abb_IsErr(abb), true);
 }
 
-static void Test_Abb_IsMs(void** state)
+static void Test_Abb_IsMs(void **state)
 {
     const size_t msg_len = AVTP_ABB_HEADER_LEN + 4;
-    uint8_t msg[msg_len] = {
-        0x1C, 0x02, 0x0,  0x0,
-        0x0,  0x0,  0x10, 0x0,
-        0x0,  0x0,  0x0,  0x0
-    };
-    Avtp_Abb_t* abb = (Avtp_Abb_t*)msg;
+    uint8_t msg[msg_len] = {0x1C, 0x02, 0x0, 0x0, 0x0, 0x0, 0x10, 0x0, 0x0, 0x0, 0x0, 0x0};
+    Avtp_Abb_t *abb = (Avtp_Abb_t *)msg;
     assert_int_equal(Avtp_Abb_IsMs(abb), true);
 }
 
-static void Test_Abb_GetReadSize(void** state)
+static void Test_Abb_GetReadSize(void **state)
 {
     const size_t msg_len = AVTP_ABB_HEADER_LEN + 4;
-    uint8_t msg[msg_len] = {
-        0x1C, 0x02, 0x0,  0x0,
-        0x0,  0x0,  0x0B, 0xFF,
-        0x0,  0x0,  0x0,  0x0
-    };
-    Avtp_Abb_t* abb = (Avtp_Abb_t*)msg;
+    uint8_t msg[msg_len] = {0x1C, 0x02, 0x0, 0x0, 0x0, 0x0, 0x0B, 0xFF, 0x0, 0x0, 0x0, 0x0};
+    Avtp_Abb_t *abb = (Avtp_Abb_t *)msg;
     assert_int_equal(Avtp_Abb_GetReadSize(abb), 0xBFF);
 }
 
-static void Test_Abb_GetSegmentNum(void** state)
+static void Test_Abb_GetSegmentNum(void **state)
 {
     const size_t msg_len = AVTP_ABB_HEADER_LEN + 4;
-    uint8_t msg[msg_len] = {
-        0x1C, 0x02, 0x0,  0x0,
-        0x0,  0x0,  0x0B, 0xFF,
-        0x0,  0x0,  0x0,  0x0
-    };
-    Avtp_Abb_t* abb = (Avtp_Abb_t*)msg;
+    uint8_t msg[msg_len] = {0x1C, 0x02, 0x0, 0x0, 0x0, 0x0, 0x0B, 0xFF, 0x0, 0x0, 0x0, 0x0};
+    Avtp_Abb_t *abb = (Avtp_Abb_t *)msg;
     assert_int_equal(Avtp_Abb_GetSegmentNum(abb), 0xBFF);
 }
 
-static void Test_Abb_GetPayloadLength(void** state)
+static void Test_Abb_GetPayloadLength(void **state)
 {
     const size_t msg_len = AVTP_ABB_HEADER_LEN + 4;
-    uint8_t msg[msg_len] = {
-        0x1C, 0x03, 0xC0, 0x0,
-        0x0,  0x0,  0x0B, 0xFF,
-        0x0,  0x0,  0x0,  0x0
-    };
-    Avtp_Abb_t* abb = (Avtp_Abb_t*)msg;
+    uint8_t msg[msg_len] = {0x1C, 0x03, 0xC0, 0x0, 0x0, 0x0, 0x0B, 0xFF, 0x0, 0x0, 0x0, 0x0};
+    Avtp_Abb_t *abb = (Avtp_Abb_t *)msg;
     assert_int_equal(Avtp_Abb_GetPayloadLength(abb), 1);
 }
 
-static void Test_Abb_GetPayloadLength_NoPadding(void** state)
+static void Test_Abb_GetPayloadLength_NoPadding(void **state)
 {
     const size_t msg_len = AVTP_ABB_HEADER_LEN + 4;
-    uint8_t msg[msg_len] = {
-        0x1C, 0x03, 0x0,  0x0,
-        0x0,  0x0,  0x0B, 0xFF,
-        0x0,  0x0,  0x0,  0x0
-    };
-    Avtp_Abb_t* abb = (Avtp_Abb_t*)msg;
+    uint8_t msg[msg_len] = {0x1C, 0x03, 0x0, 0x0, 0x0, 0x0, 0x0B, 0xFF, 0x0, 0x0, 0x0, 0x0};
+    Avtp_Abb_t *abb = (Avtp_Abb_t *)msg;
     assert_int_equal(Avtp_Abb_GetPayloadLength(abb), 4);
 }
 
-static void Test_Abb_GetAcfMsgLengthInBytes(void** state)
+static void Test_Abb_GetAcfMsgLengthInBytes(void **state)
 {
     const size_t msg_len = AVTP_ABB_HEADER_LEN + 4;
-    uint8_t msg[msg_len] = {
-        0x1C, 0x03, 0x0,  0x0,
-        0x0,  0x0,  0x0B, 0xFF,
-        0x0,  0x0,  0x0,  0x0
-    };
-    Avtp_Abb_t* abb = (Avtp_Abb_t*)msg;
+    uint8_t msg[msg_len] = {0x1C, 0x03, 0x0, 0x0, 0x0, 0x0, 0x0B, 0xFF, 0x0, 0x0, 0x0, 0x0};
+    Avtp_Abb_t *abb = (Avtp_Abb_t *)msg;
     assert_int_equal(Avtp_Abb_GetAcfMsgLengthInBytes(abb), 3 * 4);
 }
 
-static void Test_Abb_SetAcfMsgType(void** state)
+static void Test_Abb_SetAcfMsgType(void **state)
 {
     const size_t msg_len = AVTP_ABB_HEADER_LEN + 4;
     uint8_t msg[msg_len] = {0};
-    Avtp_Abb_t* abb = (Avtp_Abb_t*)msg;
+    Avtp_Abb_t *abb = (Avtp_Abb_t *)msg;
     Avtp_Abb_Init(abb);
     Avtp_Abb_SetAcfMsgType(abb, AVTP_ACF_TYPE_BYTE_BUS_BRIEF);
     assert_int_equal(Avtp_Abb_GetAcfMsgType(abb), AVTP_ACF_TYPE_BYTE_BUS_BRIEF);
 }
 
-static void Test_Abb_SetAcfMsgLength(void** state)
+static void Test_Abb_SetAcfMsgLength(void **state)
 {
     const size_t msg_len = AVTP_ABB_HEADER_LEN + 4;
     uint8_t msg[msg_len] = {0};
-    Avtp_Abb_t* abb = (Avtp_Abb_t*)msg;
+    Avtp_Abb_t *abb = (Avtp_Abb_t *)msg;
     Avtp_Abb_Init(abb);
     Avtp_Abb_SetAcfMsgLength(abb, 5);
     assert_int_equal(Avtp_Abb_GetAcfMsgLength(abb), 5);
     assert_int_equal(Avtp_Abb_GetAcfMsgLengthInBytes(abb), 20);
 }
 
-static void Test_Abb_SetMtv(void** state)
+static void Test_Abb_SetMtv(void **state)
 {
     const size_t msg_len = AVTP_ABB_HEADER_LEN + 4;
     uint8_t msg[msg_len] = {0};
-    Avtp_Abb_t* abb = (Avtp_Abb_t*)msg;
+    Avtp_Abb_t *abb = (Avtp_Abb_t *)msg;
     Avtp_Abb_Init(abb);
     Avtp_Abb_SetMtv(abb, true);
 
-    uint8_t expected_msg[msg_len] = {
-        0x1C, 0x00, 0x20, 0x0,
-        0x0,  0x0,  0x0,  0x0,
-        0x0,  0x0,  0x0,  0x0
-    };
+    uint8_t expected_msg[msg_len] = {0x1C, 0x00, 0x20, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0};
     assert_memory_equal(msg, expected_msg, msg_len);
 }
 
-static void Test_Abb_SetByteBusId(void** state)
+static void Test_Abb_SetByteBusId(void **state)
 {
     const size_t msg_len = AVTP_ABB_HEADER_LEN + 4;
     uint8_t msg[msg_len] = {0};
-    Avtp_Abb_t* abb = (Avtp_Abb_t*)msg;
+    Avtp_Abb_t *abb = (Avtp_Abb_t *)msg;
     Avtp_Abb_Init(abb);
     Avtp_Abb_SetByteBusId(abb, 0x5FF);
 
-    uint8_t expected_msg[msg_len] = {
-        0x1C, 0x00, 0x5,  0xFF,
-        0x0,  0x0,  0x0,  0x0,
-        0x0,  0x0,  0x0,  0x0
-    };
+    uint8_t expected_msg[msg_len] = {0x1C, 0x00, 0x5, 0xFF, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0};
     assert_memory_equal(msg, expected_msg, msg_len);
 }
 
-static void Test_Abb_SetEvt(void** state)
+static void Test_Abb_SetEvt(void **state)
 {
     const size_t msg_len = AVTP_ABB_HEADER_LEN + 4;
     uint8_t msg[msg_len] = {0};
-    Avtp_Abb_t* abb = (Avtp_Abb_t*)msg;
+    Avtp_Abb_t *abb = (Avtp_Abb_t *)msg;
     Avtp_Abb_Init(abb);
     Avtp_Abb_SetEvt(abb, 0xB);
 
-    uint8_t expected_msg[msg_len] = {
-        0x1C, 0x00, 0x0,  0x0,
-        0xB0, 0x0,  0x0,  0x0,
-        0x0,  0x0,  0x0,  0x0
-    };
+    uint8_t expected_msg[msg_len] = {0x1C, 0x00, 0x0, 0x0, 0xB0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0};
     assert_memory_equal(msg, expected_msg, msg_len);
 }
 
-static void Test_Abb_SetHs(void** state)
+static void Test_Abb_SetHs(void **state)
 {
     const size_t msg_len = AVTP_ABB_HEADER_LEN + 4;
     uint8_t msg[msg_len] = {0};
-    Avtp_Abb_t* abb = (Avtp_Abb_t*)msg;
+    Avtp_Abb_t *abb = (Avtp_Abb_t *)msg;
     Avtp_Abb_Init(abb);
     Avtp_Abb_SetHs(abb, true);
 
-    uint8_t expected_msg[msg_len] = {
-        0x1C, 0x00, 0x0,  0x0,
-        0x2,  0x0,  0x0,  0x0,
-        0x0,  0x0,  0x0,  0x0
-    };
+    uint8_t expected_msg[msg_len] = {0x1C, 0x00, 0x0, 0x0, 0x2, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0};
     assert_memory_equal(msg, expected_msg, msg_len);
 }
 
-static void Test_Abb_SetCs(void** state)
+static void Test_Abb_SetCs(void **state)
 {
     const size_t msg_len = AVTP_ABB_HEADER_LEN + 4;
     uint8_t msg[msg_len] = {0};
-    Avtp_Abb_t* abb = (Avtp_Abb_t*)msg;
+    Avtp_Abb_t *abb = (Avtp_Abb_t *)msg;
     Avtp_Abb_Init(abb);
     Avtp_Abb_SetCs(abb, true);
 
-    uint8_t expected_msg[msg_len] = {
-        0x1C, 0x00, 0x0,  0x0,
-        0x1,  0x0,  0x0,  0x0,
-        0x0,  0x0,  0x0,  0x0
-    };
+    uint8_t expected_msg[msg_len] = {0x1C, 0x00, 0x0, 0x0, 0x1, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0};
     assert_memory_equal(msg, expected_msg, msg_len);
 }
 
-static void Test_Abb_SetTransactionNum(void** state)
+static void Test_Abb_SetTransactionNum(void **state)
 {
     const size_t msg_len = AVTP_ABB_HEADER_LEN + 4;
     uint8_t msg[msg_len] = {0};
-    Avtp_Abb_t* abb = (Avtp_Abb_t*)msg;
+    Avtp_Abb_t *abb = (Avtp_Abb_t *)msg;
     Avtp_Abb_Init(abb);
     Avtp_Abb_SetTransactionNum(abb, 0xBF);
 
-    uint8_t expected_msg[msg_len] = {
-        0x1C, 0x00, 0x0,  0x0,
-        0x0,  0xBF, 0x0,  0x0,
-        0x0,  0x0,  0x0,  0x0
-    };
+    uint8_t expected_msg[msg_len] = {0x1C, 0x00, 0x0, 0x0, 0x0, 0xBF, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0};
     assert_memory_equal(msg, expected_msg, msg_len);
 }
 
-static void Test_Abb_SetOp(void** state)
+static void Test_Abb_SetOp(void **state)
 {
     const size_t msg_len = AVTP_ABB_HEADER_LEN + 4;
     uint8_t msg[msg_len] = {0};
-    Avtp_Abb_t* abb = (Avtp_Abb_t*)msg;
+    Avtp_Abb_t *abb = (Avtp_Abb_t *)msg;
     Avtp_Abb_Init(abb);
     Avtp_Abb_SetOp(abb, true);
 
-    uint8_t expected_msg[msg_len] = {
-        0x1C, 0x00, 0x0,  0x0,
-        0x0,  0x0,  0x80, 0x0,
-        0x0,  0x0,  0x0,  0x0
-    };
+    uint8_t expected_msg[msg_len] = {0x1C, 0x00, 0x0, 0x0, 0x0, 0x0, 0x80, 0x0, 0x0, 0x0, 0x0, 0x0};
     assert_memory_equal(msg, expected_msg, msg_len);
 }
 
-static void Test_Abb_SetRsp(void** state)
+static void Test_Abb_SetRsp(void **state)
 {
     const size_t msg_len = AVTP_ABB_HEADER_LEN + 4;
     uint8_t msg[msg_len] = {0};
-    Avtp_Abb_t* abb = (Avtp_Abb_t*)msg;
+    Avtp_Abb_t *abb = (Avtp_Abb_t *)msg;
     Avtp_Abb_Init(abb);
     Avtp_Abb_SetRsp(abb, true);
 
-    uint8_t expected_msg[msg_len] = {
-        0x1C, 0x00, 0x0,  0x0,
-        0x0,  0x0,  0x40, 0x0,
-        0x0,  0x0,  0x0,  0x0
-    };
+    uint8_t expected_msg[msg_len] = {0x1C, 0x00, 0x0, 0x0, 0x0, 0x0, 0x40, 0x0, 0x0, 0x0, 0x0, 0x0};
     assert_memory_equal(msg, expected_msg, msg_len);
 }
 
-static void Test_Abb_SetErr(void** state)
+static void Test_Abb_SetErr(void **state)
 {
     const size_t msg_len = AVTP_ABB_HEADER_LEN + 4;
     uint8_t msg[msg_len] = {0};
-    Avtp_Abb_t* abb = (Avtp_Abb_t*)msg;
+    Avtp_Abb_t *abb = (Avtp_Abb_t *)msg;
     Avtp_Abb_Init(abb);
     Avtp_Abb_SetErr(abb, true);
 
-    uint8_t expected_msg[msg_len] = {
-        0x1C, 0x00, 0x0,  0x0,
-        0x0,  0x0,  0x20, 0x0,
-        0x0,  0x0,  0x0,  0x0
-    };
+    uint8_t expected_msg[msg_len] = {0x1C, 0x00, 0x0, 0x0, 0x0, 0x0, 0x20, 0x0, 0x0, 0x0, 0x0, 0x0};
     assert_memory_equal(msg, expected_msg, msg_len);
 }
 
-static void Test_Abb_SetMs(void** state)
+static void Test_Abb_SetMs(void **state)
 {
     const size_t msg_len = AVTP_ABB_HEADER_LEN + 4;
     uint8_t msg[msg_len] = {0};
-    Avtp_Abb_t* abb = (Avtp_Abb_t*)msg;
+    Avtp_Abb_t *abb = (Avtp_Abb_t *)msg;
     Avtp_Abb_Init(abb);
     Avtp_Abb_SetMs(abb, true);
 
-    uint8_t expected_msg[msg_len] = {
-        0x1C, 0x00, 0x0,  0x0,
-        0x0,  0x0,  0x10, 0x0,
-        0x0,  0x0,  0x0,  0x0
-    };
+    uint8_t expected_msg[msg_len] = {0x1C, 0x00, 0x0, 0x0, 0x0, 0x0, 0x10, 0x0, 0x0, 0x0, 0x0, 0x0};
     assert_memory_equal(msg, expected_msg, msg_len);
 }
 
-static void Test_Abb_SetReadSize(void** state)
+static void Test_Abb_SetReadSize(void **state)
 {
     const size_t msg_len = AVTP_ABB_HEADER_LEN + 4;
     uint8_t msg[msg_len] = {0};
-    Avtp_Abb_t* abb = (Avtp_Abb_t*)msg;
+    Avtp_Abb_t *abb = (Avtp_Abb_t *)msg;
     Avtp_Abb_Init(abb);
     Avtp_Abb_SetReadSize(abb, 0xBFF);
 
-    uint8_t expected_msg[msg_len] = {
-        0x1C, 0x00, 0x0,  0x0,
-        0x0,  0x0,  0xB,  0xFF,
-        0x0,  0x0,  0x0,  0x0
-    };
+    uint8_t expected_msg[msg_len] = {0x1C, 0x00, 0x0, 0x0, 0x0, 0x0, 0xB, 0xFF, 0x0, 0x0, 0x0, 0x0};
     assert_memory_equal(msg, expected_msg, msg_len);
 }
 
-static void Test_Abb_SetSegmentNum(void** state)
+static void Test_Abb_SetSegmentNum(void **state)
 {
     const size_t msg_len = AVTP_ABB_HEADER_LEN + 4;
     uint8_t msg[msg_len] = {0};
-    Avtp_Abb_t* abb = (Avtp_Abb_t*)msg;
+    Avtp_Abb_t *abb = (Avtp_Abb_t *)msg;
     Avtp_Abb_Init(abb);
     Avtp_Abb_SetSegmentNum(abb, 0xBFF);
 
-    uint8_t expected_msg[msg_len] = {
-        0x1C, 0x00, 0x0,  0x0,
-        0x0,  0x0,  0xB,  0xFF,
-        0x0,  0x0,  0x0,  0x0
-    };
+    uint8_t expected_msg[msg_len] = {0x1C, 0x00, 0x0, 0x0, 0x0, 0x0, 0xB, 0xFF, 0x0, 0x0, 0x0, 0x0};
     assert_memory_equal(msg, expected_msg, msg_len);
 }
 
-static void Test_Abb_SetPayloadLength(void** state)
+static void Test_Abb_SetPayloadLength(void **state)
 {
     const size_t msg_len = AVTP_ABB_HEADER_LEN + 4;
     uint8_t msg[msg_len] = {0};
-    Avtp_Abb_t* abb = (Avtp_Abb_t*)msg;
+    Avtp_Abb_t *abb = (Avtp_Abb_t *)msg;
     Avtp_Abb_Init(abb);
     Avtp_Abb_SetPayloadLength(abb, 3);
 
-    uint8_t expected_msg[msg_len] = {
-        0x1C, 0x03, 0x40, 0x0,
-        0x0,  0x0,  0x0,  0x0,
-        0x0,  0x0,  0x0,  0x0
-    };
+    uint8_t expected_msg[msg_len] = {0x1C, 0x03, 0x40, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0};
     assert_memory_equal(msg, expected_msg, msg_len);
 }
 
-static void Test_Abb_SetPayloadLength_NoPadding(void** state)
+static void Test_Abb_SetPayloadLength_NoPadding(void **state)
 {
     const size_t msg_len = AVTP_ABB_HEADER_LEN + 4;
     uint8_t msg[msg_len] = {0};
-    Avtp_Abb_t* abb = (Avtp_Abb_t*)msg;
+    Avtp_Abb_t *abb = (Avtp_Abb_t *)msg;
     Avtp_Abb_Init(abb);
     Avtp_Abb_SetPayloadLength(abb, 4);
 
-    uint8_t expected_msg[msg_len] = {
-        0x1C, 0x03, 0x0,  0x0,
-        0x0,  0x0,  0x0,  0x0,
-        0x0,  0x0,  0x0,  0x0
-    };
+    uint8_t expected_msg[msg_len] = {0x1C, 0x03, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0};
     assert_memory_equal(msg, expected_msg, msg_len);
 }
 
-static void Test_Abb_Payload(void** state)
+static void Test_Abb_Payload(void **state)
 {
     const size_t msg_len = AVTP_ABB_HEADER_LEN + 8;
     uint8_t msg[msg_len] = {0};
-    Avtp_Abb_t* abb = (Avtp_Abb_t*)msg;
-    uint8_t payload[8] = {0,1,2,3,4,5,6,7};
+    Avtp_Abb_t *abb = (Avtp_Abb_t *)msg;
+    uint8_t payload[8] = {0, 1, 2, 3, 4, 5, 6, 7};
 
     Avtp_Abb_Init(abb);
     Avtp_Abb_SetPayload(abb, payload, sizeof(payload));
@@ -534,12 +402,12 @@ static void Test_Abb_Payload(void** state)
     assert_memory_equal(payload, Avtp_Abb_GetPayload(abb), sizeof(payload));
 }
 
-static void Test_Abb_CreateAcfMessage(void** state)
+static void Test_Abb_CreateAcfMessage(void **state)
 {
     const size_t msg_len = AVTP_ABB_HEADER_LEN + 8;
     uint8_t msg[msg_len] = {0};
-    Avtp_Abb_t* abb = (Avtp_Abb_t*)msg;
-    uint8_t payload[8] = {0,1,2,3,4,5,6,7};
+    Avtp_Abb_t *abb = (Avtp_Abb_t *)msg;
+    uint8_t payload[8] = {0, 1, 2, 3, 4, 5, 6, 7};
 
     Avtp_Abb_CreateAcfMessage(abb, 0x5FF, true, 0xBF, payload, sizeof(payload));
 
@@ -551,12 +419,12 @@ static void Test_Abb_CreateAcfMessage(void** state)
     assert_int_equal(Avtp_Abb_GetPayloadLength(abb), 8);
 }
 
-static void Test_Abb_CreateFromGarbage(void** state)
+static void Test_Abb_CreateFromGarbage(void **state)
 {
     const size_t msg_len = AVTP_ABB_HEADER_LEN + 8;
     uint8_t msg[msg_len];
-    Avtp_Abb_t* abb = (Avtp_Abb_t*)msg;
-    uint8_t payload[8] = {0,1,2,3,4,5,6,7};
+    Avtp_Abb_t *abb = (Avtp_Abb_t *)msg;
+    uint8_t payload[8] = {0, 1, 2, 3, 4, 5, 6, 7};
 
     // CreateAcfMessage must fully initialize the header even on garbage input.
     memset(msg, 0xAA, msg_len);
@@ -573,12 +441,12 @@ static void Test_Abb_CreateFromGarbage(void** state)
     assert_int_equal(Avtp_Abb_IsValid(abb, msg_len), 1);
 }
 
-static void Test_Abb_IsValid(void** state)
+static void Test_Abb_IsValid(void **state)
 {
     const size_t msg_len = AVTP_ABB_HEADER_LEN + 32;
     uint8_t msg[msg_len] = {0};
-    Avtp_Abb_t* abb = (Avtp_Abb_t*)msg;
-    uint8_t payload[8] = {0,1,2,3,4,5,6,7};
+    Avtp_Abb_t *abb = (Avtp_Abb_t *)msg;
+    uint8_t payload[8] = {0, 1, 2, 3, 4, 5, 6, 7};
 
     // An Init-only PDU has AcfMsgLength == 0, so IsValid must reject it.
     Avtp_Abb_Init(abb);
@@ -599,47 +467,45 @@ static void Test_Abb_IsValid(void** state)
 
 int main(void)
 {
-    const struct CMUnitTest tests[] = {
-        cmocka_unit_test(Test_Abb_Init),
-        cmocka_unit_test(Test_Abb_GetAcfMsgType),
-        cmocka_unit_test(Test_Abb_GetAcfMsgLength),
-        cmocka_unit_test(Test_Abb_GetPad),
-        cmocka_unit_test(Test_Abb_IsMtv),
-        cmocka_unit_test(Test_Abb_GetByteBusId),
-        cmocka_unit_test(Test_Abb_GetEvt),
-        cmocka_unit_test(Test_Abb_IsHs),
-        cmocka_unit_test(Test_Abb_IsCs),
-        cmocka_unit_test(Test_Abb_GetTransactionNum),
-        cmocka_unit_test(Test_Abb_IsOp),
-        cmocka_unit_test(Test_Abb_IsRsp),
-        cmocka_unit_test(Test_Abb_IsErr),
-        cmocka_unit_test(Test_Abb_IsMs),
-        cmocka_unit_test(Test_Abb_GetReadSize),
-        cmocka_unit_test(Test_Abb_GetSegmentNum),
-        cmocka_unit_test(Test_Abb_GetPayloadLength),
-        cmocka_unit_test(Test_Abb_GetPayloadLength_NoPadding),
-        cmocka_unit_test(Test_Abb_GetAcfMsgLengthInBytes),
-        cmocka_unit_test(Test_Abb_SetAcfMsgType),
-        cmocka_unit_test(Test_Abb_SetAcfMsgLength),
-        cmocka_unit_test(Test_Abb_SetMtv),
-        cmocka_unit_test(Test_Abb_SetByteBusId),
-        cmocka_unit_test(Test_Abb_SetEvt),
-        cmocka_unit_test(Test_Abb_SetHs),
-        cmocka_unit_test(Test_Abb_SetCs),
-        cmocka_unit_test(Test_Abb_SetTransactionNum),
-        cmocka_unit_test(Test_Abb_SetOp),
-        cmocka_unit_test(Test_Abb_SetRsp),
-        cmocka_unit_test(Test_Abb_SetErr),
-        cmocka_unit_test(Test_Abb_SetMs),
-        cmocka_unit_test(Test_Abb_SetReadSize),
-        cmocka_unit_test(Test_Abb_SetSegmentNum),
-        cmocka_unit_test(Test_Abb_SetPayloadLength),
-        cmocka_unit_test(Test_Abb_SetPayloadLength_NoPadding),
-        cmocka_unit_test(Test_Abb_Payload),
-        cmocka_unit_test(Test_Abb_CreateAcfMessage),
-        cmocka_unit_test(Test_Abb_CreateFromGarbage),
-        cmocka_unit_test(Test_Abb_IsValid)
-    };
+    const struct CMUnitTest tests[] = {cmocka_unit_test(Test_Abb_Init),
+                                       cmocka_unit_test(Test_Abb_GetAcfMsgType),
+                                       cmocka_unit_test(Test_Abb_GetAcfMsgLength),
+                                       cmocka_unit_test(Test_Abb_GetPad),
+                                       cmocka_unit_test(Test_Abb_IsMtv),
+                                       cmocka_unit_test(Test_Abb_GetByteBusId),
+                                       cmocka_unit_test(Test_Abb_GetEvt),
+                                       cmocka_unit_test(Test_Abb_IsHs),
+                                       cmocka_unit_test(Test_Abb_IsCs),
+                                       cmocka_unit_test(Test_Abb_GetTransactionNum),
+                                       cmocka_unit_test(Test_Abb_IsOp),
+                                       cmocka_unit_test(Test_Abb_IsRsp),
+                                       cmocka_unit_test(Test_Abb_IsErr),
+                                       cmocka_unit_test(Test_Abb_IsMs),
+                                       cmocka_unit_test(Test_Abb_GetReadSize),
+                                       cmocka_unit_test(Test_Abb_GetSegmentNum),
+                                       cmocka_unit_test(Test_Abb_GetPayloadLength),
+                                       cmocka_unit_test(Test_Abb_GetPayloadLength_NoPadding),
+                                       cmocka_unit_test(Test_Abb_GetAcfMsgLengthInBytes),
+                                       cmocka_unit_test(Test_Abb_SetAcfMsgType),
+                                       cmocka_unit_test(Test_Abb_SetAcfMsgLength),
+                                       cmocka_unit_test(Test_Abb_SetMtv),
+                                       cmocka_unit_test(Test_Abb_SetByteBusId),
+                                       cmocka_unit_test(Test_Abb_SetEvt),
+                                       cmocka_unit_test(Test_Abb_SetHs),
+                                       cmocka_unit_test(Test_Abb_SetCs),
+                                       cmocka_unit_test(Test_Abb_SetTransactionNum),
+                                       cmocka_unit_test(Test_Abb_SetOp),
+                                       cmocka_unit_test(Test_Abb_SetRsp),
+                                       cmocka_unit_test(Test_Abb_SetErr),
+                                       cmocka_unit_test(Test_Abb_SetMs),
+                                       cmocka_unit_test(Test_Abb_SetReadSize),
+                                       cmocka_unit_test(Test_Abb_SetSegmentNum),
+                                       cmocka_unit_test(Test_Abb_SetPayloadLength),
+                                       cmocka_unit_test(Test_Abb_SetPayloadLength_NoPadding),
+                                       cmocka_unit_test(Test_Abb_Payload),
+                                       cmocka_unit_test(Test_Abb_CreateAcfMessage),
+                                       cmocka_unit_test(Test_Abb_CreateFromGarbage),
+                                       cmocka_unit_test(Test_Abb_IsValid)};
 
     return cmocka_run_group_tests(tests, NULL, NULL);
 }

--- a/unit/test-gbb.c
+++ b/unit/test-gbb.c
@@ -44,10 +44,14 @@ static void Test_Gbb_Init(void** state)
     const size_t msg_len = AVTP_GBB_HEADER_LEN + 4;
     uint8_t msg[msg_len] = {0};
     Avtp_Gbb_t* gbb = (Avtp_Gbb_t*)msg;
+
+    // Check init function while passing in a null pointer
+    Avtp_Gbb_Init(NULL);
+
     Avtp_Gbb_Init(gbb);
 
     uint8_t expected_msg[msg_len] = {
-        0x1A, 0x04, 0x0,  0x0,
+        0x1A, 0x00, 0x0,  0x0,
         0x0,  0x0,  0x0,  0x0,
         0x0,  0x0,  0x0,  0x0,
         0x0,  0x0,  0x0,  0x0,
@@ -55,6 +59,34 @@ static void Test_Gbb_Init(void** state)
     };
 
     assert_memory_equal(msg, expected_msg, msg_len);
+}
+
+static void Test_Gbb_GetAcfMsgType(void** state)
+{
+    const size_t msg_len = AVTP_GBB_HEADER_LEN + 4;
+    uint8_t msg[msg_len] = {
+        0x1A, 0x04, 0x0,  0x0,
+        0x0,  0x0,  0x0,  0x0,
+        0x0,  0x0,  0x0,  0x0,
+        0x0,  0x0,  0x0,  0x0,
+        0x0,  0x0,  0x0,  0x0
+    };
+    Avtp_Gbb_t* gbb = (Avtp_Gbb_t*)msg;
+    assert_int_equal(Avtp_Gbb_GetAcfMsgType(gbb), AVTP_ACF_TYPE_BYTE_BUS);
+}
+
+static void Test_Gbb_GetAcfMsgLength(void** state)
+{
+    const size_t msg_len = AVTP_GBB_HEADER_LEN + 4;
+    uint8_t msg[msg_len] = {
+        0x1A, 0x04, 0x0,  0x0,
+        0x0,  0x0,  0x0,  0x0,
+        0x0,  0x0,  0x0,  0x0,
+        0x0,  0x0,  0x0,  0x0,
+        0x0,  0x0,  0x0,  0x0
+    };
+    Avtp_Gbb_t* gbb = (Avtp_Gbb_t*)msg;
+    assert_int_equal(Avtp_Gbb_GetAcfMsgLength(gbb), 4);
 }
 
 static void Test_Gbb_GetPad(void** state)
@@ -253,7 +285,7 @@ static void Test_Gbb_GetSegmentNum(void** state)
     assert_int_equal(Avtp_Gbb_GetSegmentNum(gbb), 0xBFF);
 }
 
-static void Test_Gbb_GetPayloadLen(void** state)
+static void Test_Gbb_GetPayloadLength(void** state)
 {
     const size_t msg_len = AVTP_GBB_HEADER_LEN + 4;
     uint8_t msg[msg_len] = {
@@ -264,10 +296,10 @@ static void Test_Gbb_GetPayloadLen(void** state)
         0x0,  0x0,  0x0,  0x0
     };
     Avtp_Gbb_t* gbb = (Avtp_Gbb_t*)msg;
-    assert_int_equal(Avtp_Gbb_GetPayloadLen(gbb), 1);
+    assert_int_equal(Avtp_Gbb_GetPayloadLength(gbb), 1);
 }
 
-static void Test_Gbb_GetPayloadLen_NoPadding(void** state)
+static void Test_Gbb_GetPayloadLength_NoPadding(void** state)
 {
     const size_t msg_len = AVTP_GBB_HEADER_LEN + 4;
     uint8_t msg[msg_len] = {
@@ -278,10 +310,10 @@ static void Test_Gbb_GetPayloadLen_NoPadding(void** state)
         0x0,  0x0,  0x0,  0x0
     };
     Avtp_Gbb_t* gbb = (Avtp_Gbb_t*)msg;
-    assert_int_equal(Avtp_Gbb_GetPayloadLen(gbb), 4);
+    assert_int_equal(Avtp_Gbb_GetPayloadLength(gbb), 4);
 }
 
-static void Test_Gbb_GetLen(void** state)
+static void Test_Gbb_GetAcfMsgLengthInBytes(void** state)
 {
     const size_t msg_len = AVTP_GBB_HEADER_LEN + 4;
     uint8_t msg[msg_len] = {
@@ -292,7 +324,28 @@ static void Test_Gbb_GetLen(void** state)
         0x0,  0x0,  0x0,  0x0
     };
     Avtp_Gbb_t* gbb = (Avtp_Gbb_t*)msg;
-    assert_int_equal(Avtp_Gbb_GetLen(gbb), 5 * 4);
+    assert_int_equal(Avtp_Gbb_GetAcfMsgLengthInBytes(gbb), 5 * 4);
+}
+
+static void Test_Gbb_SetAcfMsgType(void** state)
+{
+    const size_t msg_len = AVTP_GBB_HEADER_LEN + 4;
+    uint8_t msg[msg_len] = {0};
+    Avtp_Gbb_t* gbb = (Avtp_Gbb_t*)msg;
+    Avtp_Gbb_Init(gbb);
+    Avtp_Gbb_SetAcfMsgType(gbb, AVTP_ACF_TYPE_BYTE_BUS);
+    assert_int_equal(Avtp_Gbb_GetAcfMsgType(gbb), AVTP_ACF_TYPE_BYTE_BUS);
+}
+
+static void Test_Gbb_SetAcfMsgLength(void** state)
+{
+    const size_t msg_len = AVTP_GBB_HEADER_LEN + 4;
+    uint8_t msg[msg_len] = {0};
+    Avtp_Gbb_t* gbb = (Avtp_Gbb_t*)msg;
+    Avtp_Gbb_Init(gbb);
+    Avtp_Gbb_SetAcfMsgLength(gbb, 5);
+    assert_int_equal(Avtp_Gbb_GetAcfMsgLength(gbb), 5);
+    assert_int_equal(Avtp_Gbb_GetAcfMsgLengthInBytes(gbb), 20);
 }
 
 static void Test_Gbb_SetMtv(void** state)
@@ -304,7 +357,7 @@ static void Test_Gbb_SetMtv(void** state)
     Avtp_Gbb_SetMtv(gbb, true);
 
     uint8_t expected_msg[msg_len] = {
-        0x1A, 0x04, 0x20, 0x0,
+        0x1A, 0x00, 0x20, 0x0,
         0x0,  0x0,  0x0,  0x0,
         0x0,  0x0,  0x0,  0x0,
         0x0,  0x0,  0x0,  0x0,
@@ -322,7 +375,7 @@ static void Test_Gbb_SetByteBusId(void** state)
     Avtp_Gbb_SetByteBusId(gbb, 0x5FF);
 
     uint8_t expected_msg[msg_len] = {
-        0x1A, 0x04, 0x5,  0xFF,
+        0x1A, 0x00, 0x5,  0xFF,
         0x0,  0x0,  0x0,  0x0,
         0x0,  0x0,  0x0,  0x0,
         0x0,  0x0,  0x0,  0x0,
@@ -340,7 +393,7 @@ static void Test_Gbb_SetMessageTimestamp(void** state)
     Avtp_Gbb_SetMessageTimestamp(gbb, 0xBFFFFFFFFFFFFFFFull);
 
     uint8_t expected_msg[msg_len] = {
-        0x1A, 0x04, 0x0,  0x0,
+        0x1A, 0x00, 0x0,  0x0,
         0xBF, 0xFF, 0xFF, 0xFF,
         0xFF, 0xFF, 0xFF, 0xFF,
         0x0,  0x0,  0x0,  0x0,
@@ -358,7 +411,7 @@ static void Test_Gbb_SetEvt(void** state)
     Avtp_Gbb_SetEvt(gbb, 0xB);
 
     uint8_t expected_msg[msg_len] = {
-        0x1A, 0x04, 0x0,  0x0,
+        0x1A, 0x00, 0x0,  0x0,
         0x0,  0x0,  0x0,  0x0,
         0x0,  0x0,  0x0,  0x0,
         0xB0, 0x0,  0x0,  0x0,
@@ -376,7 +429,7 @@ static void Test_Gbb_SetHs(void** state)
     Avtp_Gbb_SetHs(gbb, true);
 
     uint8_t expected_msg[msg_len] = {
-        0x1A, 0x04, 0x0,  0x0,
+        0x1A, 0x00, 0x0,  0x0,
         0x0,  0x0,  0x0,  0x0,
         0x0,  0x0,  0x0,  0x0,
         0x2,  0x0,  0x0,  0x0,
@@ -394,7 +447,7 @@ static void Test_Gbb_SetCs(void** state)
     Avtp_Gbb_SetCs(gbb, true);
 
     uint8_t expected_msg[msg_len] = {
-        0x1A, 0x04, 0x0,  0x0,
+        0x1A, 0x00, 0x0,  0x0,
         0x0,  0x0,  0x0,  0x0,
         0x0,  0x0,  0x0,  0x0,
         0x1,  0x0,  0x0,  0x0,
@@ -412,7 +465,7 @@ static void Test_Gbb_SetTransactionNum(void** state)
     Avtp_Gbb_SetTransactionNum(gbb, 0xBF);
 
     uint8_t expected_msg[msg_len] = {
-        0x1A, 0x04, 0x0,  0x0,
+        0x1A, 0x00, 0x0,  0x0,
         0x0,  0x0,  0x0,  0x0,
         0x0,  0x0,  0x0,  0x0,
         0x0,  0xBF, 0x0,  0x0,
@@ -430,7 +483,7 @@ static void Test_Gbb_SetOp(void** state)
     Avtp_Gbb_SetOp(gbb, true);
 
     uint8_t expected_msg[msg_len] = {
-        0x1A, 0x04, 0x0,  0x0,
+        0x1A, 0x00, 0x0,  0x0,
         0x0,  0x0,  0x0,  0x0,
         0x0,  0x0,  0x0,  0x0,
         0x0,  0x0,  0x80, 0x0,
@@ -448,7 +501,7 @@ static void Test_Gbb_SetRsp(void** state)
     Avtp_Gbb_SetRsp(gbb, true);
 
     uint8_t expected_msg[msg_len] = {
-        0x1A, 0x04, 0x0,  0x0,
+        0x1A, 0x00, 0x0,  0x0,
         0x0,  0x0,  0x0,  0x0,
         0x0,  0x0,  0x0,  0x0,
         0x0,  0x0,  0x40, 0x0,
@@ -466,7 +519,7 @@ static void Test_Gbb_SetErr(void** state)
     Avtp_Gbb_SetErr(gbb, true);
 
     uint8_t expected_msg[msg_len] = {
-        0x1A, 0x04, 0x0,  0x0,
+        0x1A, 0x00, 0x0,  0x0,
         0x0,  0x0,  0x0,  0x0,
         0x0,  0x0,  0x0,  0x0,
         0x0,  0x0,  0x20, 0x0,
@@ -484,7 +537,7 @@ static void Test_Gbb_SetMs(void** state)
     Avtp_Gbb_SetMs(gbb, true);
 
     uint8_t expected_msg[msg_len] = {
-        0x1A, 0x04, 0x0,  0x0,
+        0x1A, 0x00, 0x0,  0x0,
         0x0,  0x0,  0x0,  0x0,
         0x0,  0x0,  0x0,  0x0,
         0x0,  0x0,  0x10, 0x0,
@@ -502,7 +555,7 @@ static void Test_Gbb_SetReadSize(void** state)
     Avtp_Gbb_SetReadSize(gbb, 0xBFF);
 
     uint8_t expected_msg[msg_len] = {
-        0x1A, 0x04, 0x0,  0x0,
+        0x1A, 0x00, 0x0,  0x0,
         0x0,  0x0,  0x0,  0x0,
         0x0,  0x0,  0x0,  0x0,
         0x0,  0x0,  0xB,  0xFF,
@@ -520,7 +573,7 @@ static void Test_Gbb_SetSegmentNum(void** state)
     Avtp_Gbb_SetSegmentNum(gbb, 0xBFF);
 
     uint8_t expected_msg[msg_len] = {
-        0x1A, 0x04, 0x0,  0x0,
+        0x1A, 0x00, 0x0,  0x0,
         0x0,  0x0,  0x0,  0x0,
         0x0,  0x0,  0x0,  0x0,
         0x0,  0x0,  0xB,  0xFF,
@@ -529,13 +582,13 @@ static void Test_Gbb_SetSegmentNum(void** state)
     assert_memory_equal(msg, expected_msg, msg_len);
 }
 
-static void Test_Gbb_SetPayloadLen(void** state)
+static void Test_Gbb_SetPayloadLength(void** state)
 {
     const size_t msg_len = AVTP_GBB_HEADER_LEN + 4;
     uint8_t msg[msg_len] = {0};
     Avtp_Gbb_t* gbb = (Avtp_Gbb_t*)msg;
     Avtp_Gbb_Init(gbb);
-    Avtp_Gbb_SetPayloadLen(gbb, 3);
+    Avtp_Gbb_SetPayloadLength(gbb, 3);
 
     uint8_t expected_msg[msg_len] = {
         0x1A, 0x05, 0x40, 0x0,
@@ -547,13 +600,13 @@ static void Test_Gbb_SetPayloadLen(void** state)
     assert_memory_equal(msg, expected_msg, msg_len);
 }
 
-static void Test_Gbb_SetPayloadLen_NoPadding(void** state)
+static void Test_Gbb_SetPayloadLength_NoPadding(void** state)
 {
     const size_t msg_len = AVTP_GBB_HEADER_LEN + 4;
     uint8_t msg[msg_len] = {0};
     Avtp_Gbb_t* gbb = (Avtp_Gbb_t*)msg;
     Avtp_Gbb_Init(gbb);
-    Avtp_Gbb_SetPayloadLen(gbb, 4);
+    Avtp_Gbb_SetPayloadLength(gbb, 4);
 
     uint8_t expected_msg[msg_len] = {
         0x1A, 0x05, 0x0,  0x0,
@@ -565,10 +618,94 @@ static void Test_Gbb_SetPayloadLen_NoPadding(void** state)
     assert_memory_equal(msg, expected_msg, msg_len);
 }
 
+static void Test_Gbb_Payload(void** state)
+{
+    const size_t msg_len = AVTP_GBB_HEADER_LEN + 8;
+    uint8_t msg[msg_len] = {0};
+    Avtp_Gbb_t* gbb = (Avtp_Gbb_t*)msg;
+    uint8_t payload[8] = {0,1,2,3,4,5,6,7};
+
+    Avtp_Gbb_Init(gbb);
+    Avtp_Gbb_SetPayload(gbb, payload, sizeof(payload));
+
+    assert_ptr_equal(Avtp_Gbb_GetPayload(gbb), msg + AVTP_GBB_HEADER_LEN);
+    assert_memory_equal(payload, Avtp_Gbb_GetPayload(gbb), sizeof(payload));
+}
+
+static void Test_Gbb_CreateAcfMessage(void** state)
+{
+    const size_t msg_len = AVTP_GBB_HEADER_LEN + 8;
+    uint8_t msg[msg_len] = {0};
+    Avtp_Gbb_t* gbb = (Avtp_Gbb_t*)msg;
+    uint8_t payload[8] = {0,1,2,3,4,5,6,7};
+
+    Avtp_Gbb_CreateAcfMessage(gbb, 0x5FF, true, 0xBF, payload, sizeof(payload));
+
+    assert_int_equal(Avtp_Gbb_GetAcfMsgType(gbb), AVTP_ACF_TYPE_BYTE_BUS);
+    assert_int_equal(Avtp_Gbb_GetByteBusId(gbb), 0x5FF);
+    assert_int_equal(Avtp_Gbb_IsOp(gbb), true);
+    assert_int_equal(Avtp_Gbb_GetTransactionNum(gbb), 0xBF);
+    assert_memory_equal(payload, msg + AVTP_GBB_HEADER_LEN, sizeof(payload));
+    assert_int_equal(Avtp_Gbb_GetPayloadLength(gbb), 8);
+
+    // message_timestamp is set by the caller afterwards
+    Avtp_Gbb_SetMessageTimestamp(gbb, 0x123456789ABCDEF0ULL);
+    assert_int_equal(Avtp_Gbb_GetMessageTimestamp(gbb), 0x123456789ABCDEF0ULL);
+}
+
+static void Test_Gbb_CreateFromGarbage(void** state)
+{
+    const size_t msg_len = AVTP_GBB_HEADER_LEN + 8;
+    uint8_t msg[msg_len];
+    Avtp_Gbb_t* gbb = (Avtp_Gbb_t*)msg;
+    uint8_t payload[8] = {0,1,2,3,4,5,6,7};
+
+    // CreateAcfMessage must fully initialize the header even on garbage input.
+    memset(msg, 0xAA, msg_len);
+    Avtp_Gbb_CreateAcfMessage(gbb, 0x5FF, true, 0xBF, payload, sizeof(payload));
+
+    assert_int_equal(Avtp_Gbb_GetAcfMsgType(gbb), AVTP_ACF_TYPE_BYTE_BUS);
+    assert_int_equal(Avtp_Gbb_IsMtv(gbb), false);
+    assert_int_equal(Avtp_Gbb_IsHs(gbb), false);
+    assert_int_equal(Avtp_Gbb_IsCs(gbb), false);
+    assert_int_equal(Avtp_Gbb_IsRsp(gbb), false);
+    assert_int_equal(Avtp_Gbb_IsErr(gbb), false);
+    assert_int_equal(Avtp_Gbb_IsMs(gbb), false);
+    assert_int_equal(Avtp_Gbb_GetMessageTimestamp(gbb), 0);
+    assert_memory_equal(payload, msg + AVTP_GBB_HEADER_LEN, sizeof(payload));
+    assert_int_equal(Avtp_Gbb_IsValid(gbb, msg_len), 1);
+}
+
+static void Test_Gbb_IsValid(void** state)
+{
+    const size_t msg_len = AVTP_GBB_HEADER_LEN + 32;
+    uint8_t msg[msg_len] = {0};
+    Avtp_Gbb_t* gbb = (Avtp_Gbb_t*)msg;
+    uint8_t payload[8] = {0,1,2,3,4,5,6,7};
+
+    // An Init-only PDU has AcfMsgLength == 0, so IsValid must reject it.
+    Avtp_Gbb_Init(gbb);
+    assert_int_equal(Avtp_Gbb_IsValid(gbb, msg_len), 0);
+
+    // A properly-formed frame with an 8-byte payload is valid.
+    Avtp_Gbb_CreateAcfMessage(gbb, 0x5FF, true, 0xBF, payload, sizeof(payload));
+    assert_int_equal(Avtp_Gbb_IsValid(gbb, msg_len), 1);
+
+    // Not a GBB message (zero buffer, AcfMsgType != BYTE_BUS).
+    memset(msg, 0, msg_len);
+    assert_int_equal(Avtp_Gbb_IsValid(gbb, msg_len), 0);
+
+    // Declared length larger than the buffer is invalid.
+    Avtp_Gbb_CreateAcfMessage(gbb, 0x5FF, true, 0xBF, payload, sizeof(payload));
+    assert_int_equal(Avtp_Gbb_IsValid(gbb, AVTP_GBB_HEADER_LEN + 1), 0);
+}
+
 int main(void)
 {
     const struct CMUnitTest tests[] = {
         cmocka_unit_test(Test_Gbb_Init),
+        cmocka_unit_test(Test_Gbb_GetAcfMsgType),
+        cmocka_unit_test(Test_Gbb_GetAcfMsgLength),
         cmocka_unit_test(Test_Gbb_GetPad),
         cmocka_unit_test(Test_Gbb_IsMtv),
         cmocka_unit_test(Test_Gbb_GetByteBusId),
@@ -583,9 +720,11 @@ int main(void)
         cmocka_unit_test(Test_Gbb_IsMs),
         cmocka_unit_test(Test_Gbb_GetReadSize),
         cmocka_unit_test(Test_Gbb_GetSegmentNum),
-        cmocka_unit_test(Test_Gbb_GetPayloadLen),
-        cmocka_unit_test(Test_Gbb_GetPayloadLen_NoPadding),
-        cmocka_unit_test(Test_Gbb_GetLen),
+        cmocka_unit_test(Test_Gbb_GetPayloadLength),
+        cmocka_unit_test(Test_Gbb_GetPayloadLength_NoPadding),
+        cmocka_unit_test(Test_Gbb_GetAcfMsgLengthInBytes),
+        cmocka_unit_test(Test_Gbb_SetAcfMsgType),
+        cmocka_unit_test(Test_Gbb_SetAcfMsgLength),
         cmocka_unit_test(Test_Gbb_SetMtv),
         cmocka_unit_test(Test_Gbb_SetByteBusId),
         cmocka_unit_test(Test_Gbb_SetMessageTimestamp),
@@ -599,8 +738,12 @@ int main(void)
         cmocka_unit_test(Test_Gbb_SetMs),
         cmocka_unit_test(Test_Gbb_SetReadSize),
         cmocka_unit_test(Test_Gbb_SetSegmentNum),
-        cmocka_unit_test(Test_Gbb_SetPayloadLen),
-        cmocka_unit_test(Test_Gbb_SetPayloadLen_NoPadding),
+        cmocka_unit_test(Test_Gbb_SetPayloadLength),
+        cmocka_unit_test(Test_Gbb_SetPayloadLength_NoPadding),
+        cmocka_unit_test(Test_Gbb_Payload),
+        cmocka_unit_test(Test_Gbb_CreateAcfMessage),
+        cmocka_unit_test(Test_Gbb_CreateFromGarbage),
+        cmocka_unit_test(Test_Gbb_IsValid)
     };
 
     return cmocka_run_group_tests(tests, NULL, NULL);

--- a/unit/test-gbb.c
+++ b/unit/test-gbb.c
@@ -39,591 +39,416 @@ extern "C" {
 #include <cmocka.h>
 #include <stdio.h>
 
-static void Test_Gbb_Init(void** state)
+static void Test_Gbb_Init(void **state)
 {
     const size_t msg_len = AVTP_GBB_HEADER_LEN + 4;
     uint8_t msg[msg_len] = {0};
-    Avtp_Gbb_t* gbb = (Avtp_Gbb_t*)msg;
+    Avtp_Gbb_t *gbb = (Avtp_Gbb_t *)msg;
 
     // Check init function while passing in a null pointer
     Avtp_Gbb_Init(NULL);
 
     Avtp_Gbb_Init(gbb);
 
-    uint8_t expected_msg[msg_len] = {
-        0x1A, 0x00, 0x0,  0x0,
-        0x0,  0x0,  0x0,  0x0,
-        0x0,  0x0,  0x0,  0x0,
-        0x0,  0x0,  0x0,  0x0,
-        0x0,  0x0,  0x0,  0x0
-    };
+    uint8_t expected_msg[msg_len] = {0x1A, 0x00, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0,
+                                     0x0,  0x0,  0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0};
 
     assert_memory_equal(msg, expected_msg, msg_len);
 }
 
-static void Test_Gbb_GetAcfMsgType(void** state)
+static void Test_Gbb_GetAcfMsgType(void **state)
 {
     const size_t msg_len = AVTP_GBB_HEADER_LEN + 4;
-    uint8_t msg[msg_len] = {
-        0x1A, 0x04, 0x0,  0x0,
-        0x0,  0x0,  0x0,  0x0,
-        0x0,  0x0,  0x0,  0x0,
-        0x0,  0x0,  0x0,  0x0,
-        0x0,  0x0,  0x0,  0x0
-    };
-    Avtp_Gbb_t* gbb = (Avtp_Gbb_t*)msg;
+    uint8_t msg[msg_len] = {0x1A, 0x04, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0,
+                            0x0,  0x0,  0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0};
+    Avtp_Gbb_t *gbb = (Avtp_Gbb_t *)msg;
     assert_int_equal(Avtp_Gbb_GetAcfMsgType(gbb), AVTP_ACF_TYPE_BYTE_BUS);
 }
 
-static void Test_Gbb_GetAcfMsgLength(void** state)
+static void Test_Gbb_GetAcfMsgLength(void **state)
 {
     const size_t msg_len = AVTP_GBB_HEADER_LEN + 4;
-    uint8_t msg[msg_len] = {
-        0x1A, 0x04, 0x0,  0x0,
-        0x0,  0x0,  0x0,  0x0,
-        0x0,  0x0,  0x0,  0x0,
-        0x0,  0x0,  0x0,  0x0,
-        0x0,  0x0,  0x0,  0x0
-    };
-    Avtp_Gbb_t* gbb = (Avtp_Gbb_t*)msg;
+    uint8_t msg[msg_len] = {0x1A, 0x04, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0,
+                            0x0,  0x0,  0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0};
+    Avtp_Gbb_t *gbb = (Avtp_Gbb_t *)msg;
     assert_int_equal(Avtp_Gbb_GetAcfMsgLength(gbb), 4);
 }
 
-static void Test_Gbb_GetPad(void** state)
+static void Test_Gbb_GetPad(void **state)
 {
     const size_t msg_len = AVTP_GBB_HEADER_LEN + 4;
-    uint8_t msg[msg_len] = {
-        0x1A, 0x04, 0xC0, 0x0,
-        0x0,  0x0,  0x0,  0x0,
-        0x0,  0x0,  0x0,  0x0,
-        0x0,  0x0,  0x0,  0x0,
-        0x0,  0x0,  0x0,  0x0
-    };
-    Avtp_Gbb_t* gbb = (Avtp_Gbb_t*)msg;
+    uint8_t msg[msg_len] = {0x1A, 0x04, 0xC0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0,
+                            0x0,  0x0,  0x0,  0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0};
+    Avtp_Gbb_t *gbb = (Avtp_Gbb_t *)msg;
     assert_int_equal(Avtp_Gbb_GetPad(gbb), 3);
 }
 
-static void Test_Gbb_IsMtv(void** state)
+static void Test_Gbb_IsMtv(void **state)
 {
     const size_t msg_len = AVTP_GBB_HEADER_LEN + 4;
-    uint8_t msg[msg_len] = {
-        0x1A, 0x04, 0x20, 0x0,
-        0x0,  0x0,  0x0,  0x0,
-        0x0,  0x0,  0x0,  0x0,
-        0x0,  0x0,  0x0,  0x0,
-        0x0,  0x0,  0x0,  0x0
-    };
-    Avtp_Gbb_t* gbb = (Avtp_Gbb_t*)msg;
+    uint8_t msg[msg_len] = {0x1A, 0x04, 0x20, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0,
+                            0x0,  0x0,  0x0,  0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0};
+    Avtp_Gbb_t *gbb = (Avtp_Gbb_t *)msg;
     assert_int_equal(Avtp_Gbb_IsMtv(gbb), true);
 }
 
-static void Test_Gbb_GetByteBusId(void** state)
+static void Test_Gbb_GetByteBusId(void **state)
 {
     const size_t msg_len = AVTP_GBB_HEADER_LEN + 4;
-    uint8_t msg[msg_len] = {
-        0x1A, 0x04, 0x05, 0xFF,
-        0x0,  0x0,  0x0,  0x0,
-        0x0,  0x0,  0x0,  0x0,
-        0x0,  0x0,  0x0,  0x0,
-        0x0,  0x0,  0x0,  0x0
-    };
-    Avtp_Gbb_t* gbb = (Avtp_Gbb_t*)msg;
+    uint8_t msg[msg_len] = {0x1A, 0x04, 0x05, 0xFF, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0,
+                            0x0,  0x0,  0x0,  0x0,  0x0, 0x0, 0x0, 0x0, 0x0, 0x0};
+    Avtp_Gbb_t *gbb = (Avtp_Gbb_t *)msg;
     assert_int_equal(Avtp_Gbb_GetByteBusId(gbb), 0x5FF);
 }
 
-static void Test_Gbb_GetMessageTimestamp(void** state)
+static void Test_Gbb_GetMessageTimestamp(void **state)
 {
     const size_t msg_len = AVTP_GBB_HEADER_LEN + 4;
-    uint8_t msg[msg_len] = {
-        0x1A, 0x04, 0x0,  0x0,
-        0xBF, 0xFF, 0xFF, 0xFF,
-        0xFF, 0xFF, 0xFF, 0xFF,
-        0x0,  0x0,  0x0,  0x0,
-        0x0,  0x0,  0x0,  0x0
-    };
-    Avtp_Gbb_t* gbb = (Avtp_Gbb_t*)msg;
+    uint8_t msg[msg_len] = {0x1A, 0x04, 0x0, 0x0, 0xBF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF,
+                            0xFF, 0xFF, 0x0, 0x0, 0x0,  0x0,  0x0,  0x0,  0x0,  0x0};
+    Avtp_Gbb_t *gbb = (Avtp_Gbb_t *)msg;
     assert_int_equal(Avtp_Gbb_GetMessageTimestamp(gbb), 0xBFFFFFFFFFFFFFFFull);
 }
 
-static void Test_Gbb_GetEvt(void** state)
+static void Test_Gbb_GetEvt(void **state)
 {
     const size_t msg_len = AVTP_GBB_HEADER_LEN + 4;
-    uint8_t msg[msg_len] = {
-        0x1A, 0x04, 0x0,  0x0,
-        0x0,  0x0,  0x0,  0x0,
-        0x0,  0x0,  0x0,  0x0,
-        0xB0, 0x0,  0x0,  0x0,
-        0x0,  0x0,  0x0,  0x0
-    };
-    Avtp_Gbb_t* gbb = (Avtp_Gbb_t*)msg;
+    uint8_t msg[msg_len] = {0x1A, 0x04, 0x0,  0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0,
+                            0x0,  0x0,  0xB0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0};
+    Avtp_Gbb_t *gbb = (Avtp_Gbb_t *)msg;
     assert_int_equal(Avtp_Gbb_GetEvt(gbb), 0xB);
 }
 
-static void Test_Gbb_IsHs(void** state)
+static void Test_Gbb_IsHs(void **state)
 {
     const size_t msg_len = AVTP_GBB_HEADER_LEN + 4;
-    uint8_t msg[msg_len] = {
-        0x1A, 0x04, 0x0,  0x0,
-        0x0,  0x0,  0x0,  0x0,
-        0x0,  0x0,  0x0,  0x0,
-        0x2,  0x0,  0x0,  0x0,
-        0x0,  0x0,  0x0,  0x0
-    };
-    Avtp_Gbb_t* gbb = (Avtp_Gbb_t*)msg;
+    uint8_t msg[msg_len] = {0x1A, 0x04, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0,
+                            0x0,  0x0,  0x2, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0};
+    Avtp_Gbb_t *gbb = (Avtp_Gbb_t *)msg;
     assert_int_equal(Avtp_Gbb_IsHs(gbb), true);
 }
 
-static void Test_Gbb_IsCs(void** state)
+static void Test_Gbb_IsCs(void **state)
 {
     const size_t msg_len = AVTP_GBB_HEADER_LEN + 4;
-    uint8_t msg[msg_len] = {
-        0x1A, 0x04, 0x0,  0x0,
-        0x0,  0x0,  0x0,  0x0,
-        0x0,  0x0,  0x0,  0x0,
-        0x1,  0x0,  0x0,  0x0,
-        0x0,  0x0,  0x0,  0x0
-    };
-    Avtp_Gbb_t* gbb = (Avtp_Gbb_t*)msg;
+    uint8_t msg[msg_len] = {0x1A, 0x04, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0,
+                            0x0,  0x0,  0x1, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0};
+    Avtp_Gbb_t *gbb = (Avtp_Gbb_t *)msg;
     assert_int_equal(Avtp_Gbb_IsCs(gbb), true);
 }
 
-static void Test_Gbb_GetTransactionNum(void** state)
+static void Test_Gbb_GetTransactionNum(void **state)
 {
     const size_t msg_len = AVTP_GBB_HEADER_LEN + 4;
-    uint8_t msg[msg_len] = {
-        0x1A, 0x04, 0x0,  0x0,
-        0x0,  0x0,  0x0,  0x0,
-        0x0,  0x0,  0x0,  0x0,
-        0x0,  0xBF, 0x0,  0x0,
-        0x0,  0x0,  0x0,  0x0
-    };
-    Avtp_Gbb_t* gbb = (Avtp_Gbb_t*)msg;
+    uint8_t msg[msg_len] = {0x1A, 0x04, 0x0, 0x0,  0x0, 0x0, 0x0, 0x0, 0x0, 0x0,
+                            0x0,  0x0,  0x0, 0xBF, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0};
+    Avtp_Gbb_t *gbb = (Avtp_Gbb_t *)msg;
     assert_int_equal(Avtp_Gbb_GetTransactionNum(gbb), 0xBF);
 }
 
-static void Test_Gbb_IsOp(void** state)
+static void Test_Gbb_IsOp(void **state)
 {
     const size_t msg_len = AVTP_GBB_HEADER_LEN + 4;
-    uint8_t msg[msg_len] = {
-        0x1A, 0x04, 0x0,  0x0,
-        0x0,  0x0,  0x0,  0x0,
-        0x0,  0x0,  0x0,  0x0,
-        0x0,  0x0,  0x80, 0x0,
-        0x0,  0x0,  0x0,  0x0
-    };
-    Avtp_Gbb_t* gbb = (Avtp_Gbb_t*)msg;
+    uint8_t msg[msg_len] = {0x1A, 0x04, 0x0, 0x0, 0x0,  0x0, 0x0, 0x0, 0x0, 0x0,
+                            0x0,  0x0,  0x0, 0x0, 0x80, 0x0, 0x0, 0x0, 0x0, 0x0};
+    Avtp_Gbb_t *gbb = (Avtp_Gbb_t *)msg;
     assert_int_equal(Avtp_Gbb_IsOp(gbb), true);
 }
 
-static void Test_Gbb_IsRsp(void** state)
+static void Test_Gbb_IsRsp(void **state)
 {
     const size_t msg_len = AVTP_GBB_HEADER_LEN + 4;
-    uint8_t msg[msg_len] = {
-        0x1A, 0x04, 0x0,  0x0,
-        0x0,  0x0,  0x0,  0x0,
-        0x0,  0x0,  0x0,  0x0,
-        0x0,  0x0,  0x40, 0x0,
-        0x0,  0x0,  0x0,  0x0
-    };
-    Avtp_Gbb_t* gbb = (Avtp_Gbb_t*)msg;
+    uint8_t msg[msg_len] = {0x1A, 0x04, 0x0, 0x0, 0x0,  0x0, 0x0, 0x0, 0x0, 0x0,
+                            0x0,  0x0,  0x0, 0x0, 0x40, 0x0, 0x0, 0x0, 0x0, 0x0};
+    Avtp_Gbb_t *gbb = (Avtp_Gbb_t *)msg;
     assert_int_equal(Avtp_Gbb_IsRsp(gbb), true);
 }
 
-static void Test_Gbb_IsErr(void** state)
+static void Test_Gbb_IsErr(void **state)
 {
     const size_t msg_len = AVTP_GBB_HEADER_LEN + 4;
-    uint8_t msg[msg_len] = {
-        0x1A, 0x04, 0x0,  0x0,
-        0x0,  0x0,  0x0,  0x0,
-        0x0,  0x0,  0x0,  0x0,
-        0x0,  0x0,  0x20, 0x0,
-        0x0,  0x0,  0x0,  0x0
-    };
-    Avtp_Gbb_t* gbb = (Avtp_Gbb_t*)msg;
+    uint8_t msg[msg_len] = {0x1A, 0x04, 0x0, 0x0, 0x0,  0x0, 0x0, 0x0, 0x0, 0x0,
+                            0x0,  0x0,  0x0, 0x0, 0x20, 0x0, 0x0, 0x0, 0x0, 0x0};
+    Avtp_Gbb_t *gbb = (Avtp_Gbb_t *)msg;
     assert_int_equal(Avtp_Gbb_IsErr(gbb), true);
 }
 
-static void Test_Gbb_IsMs(void** state)
+static void Test_Gbb_IsMs(void **state)
 {
     const size_t msg_len = AVTP_GBB_HEADER_LEN + 4;
-    uint8_t msg[msg_len] = {
-        0x1A, 0x04, 0x0,  0x0,
-        0x0,  0x0,  0x0,  0x0,
-        0x0,  0x0,  0x0,  0x0,
-        0x0,  0x0,  0x10, 0x0,
-        0x0,  0x0,  0x0,  0x0
-    };
-    Avtp_Gbb_t* gbb = (Avtp_Gbb_t*)msg;
+    uint8_t msg[msg_len] = {0x1A, 0x04, 0x0, 0x0, 0x0,  0x0, 0x0, 0x0, 0x0, 0x0,
+                            0x0,  0x0,  0x0, 0x0, 0x10, 0x0, 0x0, 0x0, 0x0, 0x0};
+    Avtp_Gbb_t *gbb = (Avtp_Gbb_t *)msg;
     assert_int_equal(Avtp_Gbb_IsMs(gbb), true);
 }
 
-static void Test_Gbb_GetReadSize(void** state)
+static void Test_Gbb_GetReadSize(void **state)
 {
     const size_t msg_len = AVTP_GBB_HEADER_LEN + 4;
-    uint8_t msg[msg_len] = {
-        0x1A, 0x04, 0x0,  0x0,
-        0x0,  0x0,  0x0,  0x0,
-        0x0,  0x0,  0x0,  0x0,
-        0x0,  0x0,  0x0B, 0xFF,
-        0x0,  0x0,  0x0,  0x0
-    };
-    Avtp_Gbb_t* gbb = (Avtp_Gbb_t*)msg;
+    uint8_t msg[msg_len] = {0x1A, 0x04, 0x0, 0x0, 0x0,  0x0,  0x0, 0x0, 0x0, 0x0,
+                            0x0,  0x0,  0x0, 0x0, 0x0B, 0xFF, 0x0, 0x0, 0x0, 0x0};
+    Avtp_Gbb_t *gbb = (Avtp_Gbb_t *)msg;
     assert_int_equal(Avtp_Gbb_GetReadSize(gbb), 0xBFF);
 }
 
-static void Test_Gbb_GetSegmentNum(void** state)
+static void Test_Gbb_GetSegmentNum(void **state)
 {
     const size_t msg_len = AVTP_GBB_HEADER_LEN + 4;
-    uint8_t msg[msg_len] = {
-        0x1A, 0x04, 0x0,  0x0,
-        0x0,  0x0,  0x0,  0x0,
-        0x0,  0x0,  0x0,  0x0,
-        0x0,  0x0,  0x0B, 0xFF,
-        0x0,  0x0,  0x0,  0x0
-    };
-    Avtp_Gbb_t* gbb = (Avtp_Gbb_t*)msg;
+    uint8_t msg[msg_len] = {0x1A, 0x04, 0x0, 0x0, 0x0,  0x0,  0x0, 0x0, 0x0, 0x0,
+                            0x0,  0x0,  0x0, 0x0, 0x0B, 0xFF, 0x0, 0x0, 0x0, 0x0};
+    Avtp_Gbb_t *gbb = (Avtp_Gbb_t *)msg;
     assert_int_equal(Avtp_Gbb_GetSegmentNum(gbb), 0xBFF);
 }
 
-static void Test_Gbb_GetPayloadLength(void** state)
+static void Test_Gbb_GetPayloadLength(void **state)
 {
     const size_t msg_len = AVTP_GBB_HEADER_LEN + 4;
-    uint8_t msg[msg_len] = {
-        0x1A, 0x05, 0xC0, 0x0,
-        0x0,  0x0,  0x0,  0x0,
-        0x0,  0x0,  0x0,  0x0,
-        0x0,  0x0,  0x0B, 0xFF,
-        0x0,  0x0,  0x0,  0x0
-    };
-    Avtp_Gbb_t* gbb = (Avtp_Gbb_t*)msg;
+    uint8_t msg[msg_len] = {0x1A, 0x05, 0xC0, 0x0, 0x0,  0x0,  0x0, 0x0, 0x0, 0x0,
+                            0x0,  0x0,  0x0,  0x0, 0x0B, 0xFF, 0x0, 0x0, 0x0, 0x0};
+    Avtp_Gbb_t *gbb = (Avtp_Gbb_t *)msg;
     assert_int_equal(Avtp_Gbb_GetPayloadLength(gbb), 1);
 }
 
-static void Test_Gbb_GetPayloadLength_NoPadding(void** state)
+static void Test_Gbb_GetPayloadLength_NoPadding(void **state)
 {
     const size_t msg_len = AVTP_GBB_HEADER_LEN + 4;
-    uint8_t msg[msg_len] = {
-        0x1A, 0x05, 0x0,  0x0,
-        0x0,  0x0,  0x0,  0x0,
-        0x0,  0x0,  0x0,  0x0,
-        0x0,  0x0,  0x0B, 0xFF,
-        0x0,  0x0,  0x0,  0x0
-    };
-    Avtp_Gbb_t* gbb = (Avtp_Gbb_t*)msg;
+    uint8_t msg[msg_len] = {0x1A, 0x05, 0x0, 0x0, 0x0,  0x0,  0x0, 0x0, 0x0, 0x0,
+                            0x0,  0x0,  0x0, 0x0, 0x0B, 0xFF, 0x0, 0x0, 0x0, 0x0};
+    Avtp_Gbb_t *gbb = (Avtp_Gbb_t *)msg;
     assert_int_equal(Avtp_Gbb_GetPayloadLength(gbb), 4);
 }
 
-static void Test_Gbb_GetAcfMsgLengthInBytes(void** state)
+static void Test_Gbb_GetAcfMsgLengthInBytes(void **state)
 {
     const size_t msg_len = AVTP_GBB_HEADER_LEN + 4;
-    uint8_t msg[msg_len] = {
-        0x1A, 0x05, 0x0,  0x0,
-        0x0,  0x0,  0x0,  0x0,
-        0x0,  0x0,  0x0,  0x0,
-        0x0,  0x0,  0x0B, 0xFF,
-        0x0,  0x0,  0x0,  0x0
-    };
-    Avtp_Gbb_t* gbb = (Avtp_Gbb_t*)msg;
+    uint8_t msg[msg_len] = {0x1A, 0x05, 0x0, 0x0, 0x0,  0x0,  0x0, 0x0, 0x0, 0x0,
+                            0x0,  0x0,  0x0, 0x0, 0x0B, 0xFF, 0x0, 0x0, 0x0, 0x0};
+    Avtp_Gbb_t *gbb = (Avtp_Gbb_t *)msg;
     assert_int_equal(Avtp_Gbb_GetAcfMsgLengthInBytes(gbb), 5 * 4);
 }
 
-static void Test_Gbb_SetAcfMsgType(void** state)
+static void Test_Gbb_SetAcfMsgType(void **state)
 {
     const size_t msg_len = AVTP_GBB_HEADER_LEN + 4;
     uint8_t msg[msg_len] = {0};
-    Avtp_Gbb_t* gbb = (Avtp_Gbb_t*)msg;
+    Avtp_Gbb_t *gbb = (Avtp_Gbb_t *)msg;
     Avtp_Gbb_Init(gbb);
     Avtp_Gbb_SetAcfMsgType(gbb, AVTP_ACF_TYPE_BYTE_BUS);
     assert_int_equal(Avtp_Gbb_GetAcfMsgType(gbb), AVTP_ACF_TYPE_BYTE_BUS);
 }
 
-static void Test_Gbb_SetAcfMsgLength(void** state)
+static void Test_Gbb_SetAcfMsgLength(void **state)
 {
     const size_t msg_len = AVTP_GBB_HEADER_LEN + 4;
     uint8_t msg[msg_len] = {0};
-    Avtp_Gbb_t* gbb = (Avtp_Gbb_t*)msg;
+    Avtp_Gbb_t *gbb = (Avtp_Gbb_t *)msg;
     Avtp_Gbb_Init(gbb);
     Avtp_Gbb_SetAcfMsgLength(gbb, 5);
     assert_int_equal(Avtp_Gbb_GetAcfMsgLength(gbb), 5);
     assert_int_equal(Avtp_Gbb_GetAcfMsgLengthInBytes(gbb), 20);
 }
 
-static void Test_Gbb_SetMtv(void** state)
+static void Test_Gbb_SetMtv(void **state)
 {
     const size_t msg_len = AVTP_GBB_HEADER_LEN + 4;
     uint8_t msg[msg_len] = {0};
-    Avtp_Gbb_t* gbb = (Avtp_Gbb_t*)msg;
+    Avtp_Gbb_t *gbb = (Avtp_Gbb_t *)msg;
     Avtp_Gbb_Init(gbb);
     Avtp_Gbb_SetMtv(gbb, true);
 
-    uint8_t expected_msg[msg_len] = {
-        0x1A, 0x00, 0x20, 0x0,
-        0x0,  0x0,  0x0,  0x0,
-        0x0,  0x0,  0x0,  0x0,
-        0x0,  0x0,  0x0,  0x0,
-        0x0,  0x0,  0x0,  0x0
-    };
+    uint8_t expected_msg[msg_len] = {0x1A, 0x00, 0x20, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0,
+                                     0x0,  0x0,  0x0,  0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0};
     assert_memory_equal(msg, expected_msg, msg_len);
 }
 
-static void Test_Gbb_SetByteBusId(void** state)
+static void Test_Gbb_SetByteBusId(void **state)
 {
     const size_t msg_len = AVTP_GBB_HEADER_LEN + 4;
     uint8_t msg[msg_len] = {0};
-    Avtp_Gbb_t* gbb = (Avtp_Gbb_t*)msg;
+    Avtp_Gbb_t *gbb = (Avtp_Gbb_t *)msg;
     Avtp_Gbb_Init(gbb);
     Avtp_Gbb_SetByteBusId(gbb, 0x5FF);
 
-    uint8_t expected_msg[msg_len] = {
-        0x1A, 0x00, 0x5,  0xFF,
-        0x0,  0x0,  0x0,  0x0,
-        0x0,  0x0,  0x0,  0x0,
-        0x0,  0x0,  0x0,  0x0,
-        0x0,  0x0,  0x0,  0x0
-    };
+    uint8_t expected_msg[msg_len] = {0x1A, 0x00, 0x5, 0xFF, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0,
+                                     0x0,  0x0,  0x0, 0x0,  0x0, 0x0, 0x0, 0x0, 0x0, 0x0};
     assert_memory_equal(msg, expected_msg, msg_len);
 }
 
-static void Test_Gbb_SetMessageTimestamp(void** state)
+static void Test_Gbb_SetMessageTimestamp(void **state)
 {
     const size_t msg_len = AVTP_GBB_HEADER_LEN + 4;
     uint8_t msg[msg_len] = {0};
-    Avtp_Gbb_t* gbb = (Avtp_Gbb_t*)msg;
+    Avtp_Gbb_t *gbb = (Avtp_Gbb_t *)msg;
     Avtp_Gbb_Init(gbb);
     Avtp_Gbb_SetMessageTimestamp(gbb, 0xBFFFFFFFFFFFFFFFull);
 
-    uint8_t expected_msg[msg_len] = {
-        0x1A, 0x00, 0x0,  0x0,
-        0xBF, 0xFF, 0xFF, 0xFF,
-        0xFF, 0xFF, 0xFF, 0xFF,
-        0x0,  0x0,  0x0,  0x0,
-        0x0,  0x0,  0x0,  0x0
-    };
+    uint8_t expected_msg[msg_len] = {0x1A, 0x00, 0x0, 0x0, 0xBF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF,
+                                     0xFF, 0xFF, 0x0, 0x0, 0x0,  0x0,  0x0,  0x0,  0x0,  0x0};
     assert_memory_equal(msg, expected_msg, msg_len);
 }
 
-static void Test_Gbb_SetEvt(void** state)
+static void Test_Gbb_SetEvt(void **state)
 {
     const size_t msg_len = AVTP_GBB_HEADER_LEN + 4;
     uint8_t msg[msg_len] = {0};
-    Avtp_Gbb_t* gbb = (Avtp_Gbb_t*)msg;
+    Avtp_Gbb_t *gbb = (Avtp_Gbb_t *)msg;
     Avtp_Gbb_Init(gbb);
     Avtp_Gbb_SetEvt(gbb, 0xB);
 
-    uint8_t expected_msg[msg_len] = {
-        0x1A, 0x00, 0x0,  0x0,
-        0x0,  0x0,  0x0,  0x0,
-        0x0,  0x0,  0x0,  0x0,
-        0xB0, 0x0,  0x0,  0x0,
-        0x0,  0x0,  0x0,  0x0
-    };
+    uint8_t expected_msg[msg_len] = {0x1A, 0x00, 0x0,  0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0,
+                                     0x0,  0x0,  0xB0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0};
     assert_memory_equal(msg, expected_msg, msg_len);
 }
 
-static void Test_Gbb_SetHs(void** state)
+static void Test_Gbb_SetHs(void **state)
 {
     const size_t msg_len = AVTP_GBB_HEADER_LEN + 4;
     uint8_t msg[msg_len] = {0};
-    Avtp_Gbb_t* gbb = (Avtp_Gbb_t*)msg;
+    Avtp_Gbb_t *gbb = (Avtp_Gbb_t *)msg;
     Avtp_Gbb_Init(gbb);
     Avtp_Gbb_SetHs(gbb, true);
 
-    uint8_t expected_msg[msg_len] = {
-        0x1A, 0x00, 0x0,  0x0,
-        0x0,  0x0,  0x0,  0x0,
-        0x0,  0x0,  0x0,  0x0,
-        0x2,  0x0,  0x0,  0x0,
-        0x0,  0x0,  0x0,  0x0
-    };
+    uint8_t expected_msg[msg_len] = {0x1A, 0x00, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0,
+                                     0x0,  0x0,  0x2, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0};
     assert_memory_equal(msg, expected_msg, msg_len);
 }
 
-static void Test_Gbb_SetCs(void** state)
+static void Test_Gbb_SetCs(void **state)
 {
     const size_t msg_len = AVTP_GBB_HEADER_LEN + 4;
     uint8_t msg[msg_len] = {0};
-    Avtp_Gbb_t* gbb = (Avtp_Gbb_t*)msg;
+    Avtp_Gbb_t *gbb = (Avtp_Gbb_t *)msg;
     Avtp_Gbb_Init(gbb);
     Avtp_Gbb_SetCs(gbb, true);
 
-    uint8_t expected_msg[msg_len] = {
-        0x1A, 0x00, 0x0,  0x0,
-        0x0,  0x0,  0x0,  0x0,
-        0x0,  0x0,  0x0,  0x0,
-        0x1,  0x0,  0x0,  0x0,
-        0x0,  0x0,  0x0,  0x0
-    };
+    uint8_t expected_msg[msg_len] = {0x1A, 0x00, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0,
+                                     0x0,  0x0,  0x1, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0};
     assert_memory_equal(msg, expected_msg, msg_len);
 }
 
-static void Test_Gbb_SetTransactionNum(void** state)
+static void Test_Gbb_SetTransactionNum(void **state)
 {
     const size_t msg_len = AVTP_GBB_HEADER_LEN + 4;
     uint8_t msg[msg_len] = {0};
-    Avtp_Gbb_t* gbb = (Avtp_Gbb_t*)msg;
+    Avtp_Gbb_t *gbb = (Avtp_Gbb_t *)msg;
     Avtp_Gbb_Init(gbb);
     Avtp_Gbb_SetTransactionNum(gbb, 0xBF);
 
-    uint8_t expected_msg[msg_len] = {
-        0x1A, 0x00, 0x0,  0x0,
-        0x0,  0x0,  0x0,  0x0,
-        0x0,  0x0,  0x0,  0x0,
-        0x0,  0xBF, 0x0,  0x0,
-        0x0,  0x0,  0x0,  0x0
-    };
+    uint8_t expected_msg[msg_len] = {0x1A, 0x00, 0x0, 0x0,  0x0, 0x0, 0x0, 0x0, 0x0, 0x0,
+                                     0x0,  0x0,  0x0, 0xBF, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0};
     assert_memory_equal(msg, expected_msg, msg_len);
 }
 
-static void Test_Gbb_SetOp(void** state)
+static void Test_Gbb_SetOp(void **state)
 {
     const size_t msg_len = AVTP_GBB_HEADER_LEN + 4;
     uint8_t msg[msg_len] = {0};
-    Avtp_Gbb_t* gbb = (Avtp_Gbb_t*)msg;
+    Avtp_Gbb_t *gbb = (Avtp_Gbb_t *)msg;
     Avtp_Gbb_Init(gbb);
     Avtp_Gbb_SetOp(gbb, true);
 
-    uint8_t expected_msg[msg_len] = {
-        0x1A, 0x00, 0x0,  0x0,
-        0x0,  0x0,  0x0,  0x0,
-        0x0,  0x0,  0x0,  0x0,
-        0x0,  0x0,  0x80, 0x0,
-        0x0,  0x0,  0x0,  0x0
-    };
+    uint8_t expected_msg[msg_len] = {0x1A, 0x00, 0x0, 0x0, 0x0,  0x0, 0x0, 0x0, 0x0, 0x0,
+                                     0x0,  0x0,  0x0, 0x0, 0x80, 0x0, 0x0, 0x0, 0x0, 0x0};
     assert_memory_equal(msg, expected_msg, msg_len);
 }
 
-static void Test_Gbb_SetRsp(void** state)
+static void Test_Gbb_SetRsp(void **state)
 {
     const size_t msg_len = AVTP_GBB_HEADER_LEN + 4;
     uint8_t msg[msg_len] = {0};
-    Avtp_Gbb_t* gbb = (Avtp_Gbb_t*)msg;
+    Avtp_Gbb_t *gbb = (Avtp_Gbb_t *)msg;
     Avtp_Gbb_Init(gbb);
     Avtp_Gbb_SetRsp(gbb, true);
 
-    uint8_t expected_msg[msg_len] = {
-        0x1A, 0x00, 0x0,  0x0,
-        0x0,  0x0,  0x0,  0x0,
-        0x0,  0x0,  0x0,  0x0,
-        0x0,  0x0,  0x40, 0x0,
-        0x0,  0x0,  0x0,  0x0
-    };
+    uint8_t expected_msg[msg_len] = {0x1A, 0x00, 0x0, 0x0, 0x0,  0x0, 0x0, 0x0, 0x0, 0x0,
+                                     0x0,  0x0,  0x0, 0x0, 0x40, 0x0, 0x0, 0x0, 0x0, 0x0};
     assert_memory_equal(msg, expected_msg, msg_len);
 }
 
-static void Test_Gbb_SetErr(void** state)
+static void Test_Gbb_SetErr(void **state)
 {
     const size_t msg_len = AVTP_GBB_HEADER_LEN + 4;
     uint8_t msg[msg_len] = {0};
-    Avtp_Gbb_t* gbb = (Avtp_Gbb_t*)msg;
+    Avtp_Gbb_t *gbb = (Avtp_Gbb_t *)msg;
     Avtp_Gbb_Init(gbb);
     Avtp_Gbb_SetErr(gbb, true);
 
-    uint8_t expected_msg[msg_len] = {
-        0x1A, 0x00, 0x0,  0x0,
-        0x0,  0x0,  0x0,  0x0,
-        0x0,  0x0,  0x0,  0x0,
-        0x0,  0x0,  0x20, 0x0,
-        0x0,  0x0,  0x0,  0x0
-    };
+    uint8_t expected_msg[msg_len] = {0x1A, 0x00, 0x0, 0x0, 0x0,  0x0, 0x0, 0x0, 0x0, 0x0,
+                                     0x0,  0x0,  0x0, 0x0, 0x20, 0x0, 0x0, 0x0, 0x0, 0x0};
     assert_memory_equal(msg, expected_msg, msg_len);
 }
 
-static void Test_Gbb_SetMs(void** state)
+static void Test_Gbb_SetMs(void **state)
 {
     const size_t msg_len = AVTP_GBB_HEADER_LEN + 4;
     uint8_t msg[msg_len] = {0};
-    Avtp_Gbb_t* gbb = (Avtp_Gbb_t*)msg;
+    Avtp_Gbb_t *gbb = (Avtp_Gbb_t *)msg;
     Avtp_Gbb_Init(gbb);
     Avtp_Gbb_SetMs(gbb, true);
 
-    uint8_t expected_msg[msg_len] = {
-        0x1A, 0x00, 0x0,  0x0,
-        0x0,  0x0,  0x0,  0x0,
-        0x0,  0x0,  0x0,  0x0,
-        0x0,  0x0,  0x10, 0x0,
-        0x0,  0x0,  0x0,  0x0
-    };
+    uint8_t expected_msg[msg_len] = {0x1A, 0x00, 0x0, 0x0, 0x0,  0x0, 0x0, 0x0, 0x0, 0x0,
+                                     0x0,  0x0,  0x0, 0x0, 0x10, 0x0, 0x0, 0x0, 0x0, 0x0};
     assert_memory_equal(msg, expected_msg, msg_len);
 }
 
-static void Test_Gbb_SetReadSize(void** state)
+static void Test_Gbb_SetReadSize(void **state)
 {
     const size_t msg_len = AVTP_GBB_HEADER_LEN + 4;
     uint8_t msg[msg_len] = {0};
-    Avtp_Gbb_t* gbb = (Avtp_Gbb_t*)msg;
+    Avtp_Gbb_t *gbb = (Avtp_Gbb_t *)msg;
     Avtp_Gbb_Init(gbb);
     Avtp_Gbb_SetReadSize(gbb, 0xBFF);
 
-    uint8_t expected_msg[msg_len] = {
-        0x1A, 0x00, 0x0,  0x0,
-        0x0,  0x0,  0x0,  0x0,
-        0x0,  0x0,  0x0,  0x0,
-        0x0,  0x0,  0xB,  0xFF,
-        0x0,  0x0,  0x0,  0x0
-    };
+    uint8_t expected_msg[msg_len] = {0x1A, 0x00, 0x0, 0x0, 0x0, 0x0,  0x0, 0x0, 0x0, 0x0,
+                                     0x0,  0x0,  0x0, 0x0, 0xB, 0xFF, 0x0, 0x0, 0x0, 0x0};
     assert_memory_equal(msg, expected_msg, msg_len);
 }
 
-static void Test_Gbb_SetSegmentNum(void** state)
+static void Test_Gbb_SetSegmentNum(void **state)
 {
     const size_t msg_len = AVTP_GBB_HEADER_LEN + 4;
     uint8_t msg[msg_len] = {0};
-    Avtp_Gbb_t* gbb = (Avtp_Gbb_t*)msg;
+    Avtp_Gbb_t *gbb = (Avtp_Gbb_t *)msg;
     Avtp_Gbb_Init(gbb);
     Avtp_Gbb_SetSegmentNum(gbb, 0xBFF);
 
-    uint8_t expected_msg[msg_len] = {
-        0x1A, 0x00, 0x0,  0x0,
-        0x0,  0x0,  0x0,  0x0,
-        0x0,  0x0,  0x0,  0x0,
-        0x0,  0x0,  0xB,  0xFF,
-        0x0,  0x0,  0x0,  0x0
-    };
+    uint8_t expected_msg[msg_len] = {0x1A, 0x00, 0x0, 0x0, 0x0, 0x0,  0x0, 0x0, 0x0, 0x0,
+                                     0x0,  0x0,  0x0, 0x0, 0xB, 0xFF, 0x0, 0x0, 0x0, 0x0};
     assert_memory_equal(msg, expected_msg, msg_len);
 }
 
-static void Test_Gbb_SetPayloadLength(void** state)
+static void Test_Gbb_SetPayloadLength(void **state)
 {
     const size_t msg_len = AVTP_GBB_HEADER_LEN + 4;
     uint8_t msg[msg_len] = {0};
-    Avtp_Gbb_t* gbb = (Avtp_Gbb_t*)msg;
+    Avtp_Gbb_t *gbb = (Avtp_Gbb_t *)msg;
     Avtp_Gbb_Init(gbb);
     Avtp_Gbb_SetPayloadLength(gbb, 3);
 
-    uint8_t expected_msg[msg_len] = {
-        0x1A, 0x05, 0x40, 0x0,
-        0x0,  0x0,  0x0,  0x0,
-        0x0,  0x0,  0x0,  0x0,
-        0x0,  0x0,  0x0,  0x0,
-        0x0,  0x0,  0x0,  0x0
-    };
+    uint8_t expected_msg[msg_len] = {0x1A, 0x05, 0x40, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0,
+                                     0x0,  0x0,  0x0,  0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0};
     assert_memory_equal(msg, expected_msg, msg_len);
 }
 
-static void Test_Gbb_SetPayloadLength_NoPadding(void** state)
+static void Test_Gbb_SetPayloadLength_NoPadding(void **state)
 {
     const size_t msg_len = AVTP_GBB_HEADER_LEN + 4;
     uint8_t msg[msg_len] = {0};
-    Avtp_Gbb_t* gbb = (Avtp_Gbb_t*)msg;
+    Avtp_Gbb_t *gbb = (Avtp_Gbb_t *)msg;
     Avtp_Gbb_Init(gbb);
     Avtp_Gbb_SetPayloadLength(gbb, 4);
 
-    uint8_t expected_msg[msg_len] = {
-        0x1A, 0x05, 0x0,  0x0,
-        0x0,  0x0,  0x0,  0x0,
-        0x0,  0x0,  0x0,  0x0,
-        0x0,  0x0,  0x0,  0x0,
-        0x0,  0x0,  0x0,  0x0
-    };
+    uint8_t expected_msg[msg_len] = {0x1A, 0x05, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0,
+                                     0x0,  0x0,  0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0};
     assert_memory_equal(msg, expected_msg, msg_len);
 }
 
-static void Test_Gbb_Payload(void** state)
+static void Test_Gbb_Payload(void **state)
 {
     const size_t msg_len = AVTP_GBB_HEADER_LEN + 8;
     uint8_t msg[msg_len] = {0};
-    Avtp_Gbb_t* gbb = (Avtp_Gbb_t*)msg;
-    uint8_t payload[8] = {0,1,2,3,4,5,6,7};
+    Avtp_Gbb_t *gbb = (Avtp_Gbb_t *)msg;
+    uint8_t payload[8] = {0, 1, 2, 3, 4, 5, 6, 7};
 
     Avtp_Gbb_Init(gbb);
     Avtp_Gbb_SetPayload(gbb, payload, sizeof(payload));
@@ -632,12 +457,12 @@ static void Test_Gbb_Payload(void** state)
     assert_memory_equal(payload, Avtp_Gbb_GetPayload(gbb), sizeof(payload));
 }
 
-static void Test_Gbb_CreateAcfMessage(void** state)
+static void Test_Gbb_CreateAcfMessage(void **state)
 {
     const size_t msg_len = AVTP_GBB_HEADER_LEN + 8;
     uint8_t msg[msg_len] = {0};
-    Avtp_Gbb_t* gbb = (Avtp_Gbb_t*)msg;
-    uint8_t payload[8] = {0,1,2,3,4,5,6,7};
+    Avtp_Gbb_t *gbb = (Avtp_Gbb_t *)msg;
+    uint8_t payload[8] = {0, 1, 2, 3, 4, 5, 6, 7};
 
     Avtp_Gbb_CreateAcfMessage(gbb, 0x5FF, true, 0xBF, payload, sizeof(payload));
 
@@ -653,12 +478,12 @@ static void Test_Gbb_CreateAcfMessage(void** state)
     assert_int_equal(Avtp_Gbb_GetMessageTimestamp(gbb), 0x123456789ABCDEF0ULL);
 }
 
-static void Test_Gbb_CreateFromGarbage(void** state)
+static void Test_Gbb_CreateFromGarbage(void **state)
 {
     const size_t msg_len = AVTP_GBB_HEADER_LEN + 8;
     uint8_t msg[msg_len];
-    Avtp_Gbb_t* gbb = (Avtp_Gbb_t*)msg;
-    uint8_t payload[8] = {0,1,2,3,4,5,6,7};
+    Avtp_Gbb_t *gbb = (Avtp_Gbb_t *)msg;
+    uint8_t payload[8] = {0, 1, 2, 3, 4, 5, 6, 7};
 
     // CreateAcfMessage must fully initialize the header even on garbage input.
     memset(msg, 0xAA, msg_len);
@@ -676,12 +501,12 @@ static void Test_Gbb_CreateFromGarbage(void** state)
     assert_int_equal(Avtp_Gbb_IsValid(gbb, msg_len), 1);
 }
 
-static void Test_Gbb_IsValid(void** state)
+static void Test_Gbb_IsValid(void **state)
 {
     const size_t msg_len = AVTP_GBB_HEADER_LEN + 32;
     uint8_t msg[msg_len] = {0};
-    Avtp_Gbb_t* gbb = (Avtp_Gbb_t*)msg;
-    uint8_t payload[8] = {0,1,2,3,4,5,6,7};
+    Avtp_Gbb_t *gbb = (Avtp_Gbb_t *)msg;
+    uint8_t payload[8] = {0, 1, 2, 3, 4, 5, 6, 7};
 
     // An Init-only PDU has AcfMsgLength == 0, so IsValid must reject it.
     Avtp_Gbb_Init(gbb);
@@ -702,49 +527,47 @@ static void Test_Gbb_IsValid(void** state)
 
 int main(void)
 {
-    const struct CMUnitTest tests[] = {
-        cmocka_unit_test(Test_Gbb_Init),
-        cmocka_unit_test(Test_Gbb_GetAcfMsgType),
-        cmocka_unit_test(Test_Gbb_GetAcfMsgLength),
-        cmocka_unit_test(Test_Gbb_GetPad),
-        cmocka_unit_test(Test_Gbb_IsMtv),
-        cmocka_unit_test(Test_Gbb_GetByteBusId),
-        cmocka_unit_test(Test_Gbb_GetMessageTimestamp),
-        cmocka_unit_test(Test_Gbb_GetEvt),
-        cmocka_unit_test(Test_Gbb_IsHs),
-        cmocka_unit_test(Test_Gbb_IsCs),
-        cmocka_unit_test(Test_Gbb_GetTransactionNum),
-        cmocka_unit_test(Test_Gbb_IsOp),
-        cmocka_unit_test(Test_Gbb_IsRsp),
-        cmocka_unit_test(Test_Gbb_IsErr),
-        cmocka_unit_test(Test_Gbb_IsMs),
-        cmocka_unit_test(Test_Gbb_GetReadSize),
-        cmocka_unit_test(Test_Gbb_GetSegmentNum),
-        cmocka_unit_test(Test_Gbb_GetPayloadLength),
-        cmocka_unit_test(Test_Gbb_GetPayloadLength_NoPadding),
-        cmocka_unit_test(Test_Gbb_GetAcfMsgLengthInBytes),
-        cmocka_unit_test(Test_Gbb_SetAcfMsgType),
-        cmocka_unit_test(Test_Gbb_SetAcfMsgLength),
-        cmocka_unit_test(Test_Gbb_SetMtv),
-        cmocka_unit_test(Test_Gbb_SetByteBusId),
-        cmocka_unit_test(Test_Gbb_SetMessageTimestamp),
-        cmocka_unit_test(Test_Gbb_SetEvt),
-        cmocka_unit_test(Test_Gbb_SetHs),
-        cmocka_unit_test(Test_Gbb_SetCs),
-        cmocka_unit_test(Test_Gbb_SetTransactionNum),
-        cmocka_unit_test(Test_Gbb_SetOp),
-        cmocka_unit_test(Test_Gbb_SetRsp),
-        cmocka_unit_test(Test_Gbb_SetErr),
-        cmocka_unit_test(Test_Gbb_SetMs),
-        cmocka_unit_test(Test_Gbb_SetReadSize),
-        cmocka_unit_test(Test_Gbb_SetSegmentNum),
-        cmocka_unit_test(Test_Gbb_SetPayloadLength),
-        cmocka_unit_test(Test_Gbb_SetPayloadLength_NoPadding),
-        cmocka_unit_test(Test_Gbb_Payload),
-        cmocka_unit_test(Test_Gbb_CreateAcfMessage),
-        cmocka_unit_test(Test_Gbb_CreateFromGarbage),
-        cmocka_unit_test(Test_Gbb_IsValid)
-    };
+    const struct CMUnitTest tests[] = {cmocka_unit_test(Test_Gbb_Init),
+                                       cmocka_unit_test(Test_Gbb_GetAcfMsgType),
+                                       cmocka_unit_test(Test_Gbb_GetAcfMsgLength),
+                                       cmocka_unit_test(Test_Gbb_GetPad),
+                                       cmocka_unit_test(Test_Gbb_IsMtv),
+                                       cmocka_unit_test(Test_Gbb_GetByteBusId),
+                                       cmocka_unit_test(Test_Gbb_GetMessageTimestamp),
+                                       cmocka_unit_test(Test_Gbb_GetEvt),
+                                       cmocka_unit_test(Test_Gbb_IsHs),
+                                       cmocka_unit_test(Test_Gbb_IsCs),
+                                       cmocka_unit_test(Test_Gbb_GetTransactionNum),
+                                       cmocka_unit_test(Test_Gbb_IsOp),
+                                       cmocka_unit_test(Test_Gbb_IsRsp),
+                                       cmocka_unit_test(Test_Gbb_IsErr),
+                                       cmocka_unit_test(Test_Gbb_IsMs),
+                                       cmocka_unit_test(Test_Gbb_GetReadSize),
+                                       cmocka_unit_test(Test_Gbb_GetSegmentNum),
+                                       cmocka_unit_test(Test_Gbb_GetPayloadLength),
+                                       cmocka_unit_test(Test_Gbb_GetPayloadLength_NoPadding),
+                                       cmocka_unit_test(Test_Gbb_GetAcfMsgLengthInBytes),
+                                       cmocka_unit_test(Test_Gbb_SetAcfMsgType),
+                                       cmocka_unit_test(Test_Gbb_SetAcfMsgLength),
+                                       cmocka_unit_test(Test_Gbb_SetMtv),
+                                       cmocka_unit_test(Test_Gbb_SetByteBusId),
+                                       cmocka_unit_test(Test_Gbb_SetMessageTimestamp),
+                                       cmocka_unit_test(Test_Gbb_SetEvt),
+                                       cmocka_unit_test(Test_Gbb_SetHs),
+                                       cmocka_unit_test(Test_Gbb_SetCs),
+                                       cmocka_unit_test(Test_Gbb_SetTransactionNum),
+                                       cmocka_unit_test(Test_Gbb_SetOp),
+                                       cmocka_unit_test(Test_Gbb_SetRsp),
+                                       cmocka_unit_test(Test_Gbb_SetErr),
+                                       cmocka_unit_test(Test_Gbb_SetMs),
+                                       cmocka_unit_test(Test_Gbb_SetReadSize),
+                                       cmocka_unit_test(Test_Gbb_SetSegmentNum),
+                                       cmocka_unit_test(Test_Gbb_SetPayloadLength),
+                                       cmocka_unit_test(Test_Gbb_SetPayloadLength_NoPadding),
+                                       cmocka_unit_test(Test_Gbb_Payload),
+                                       cmocka_unit_test(Test_Gbb_CreateAcfMessage),
+                                       cmocka_unit_test(Test_Gbb_CreateFromGarbage),
+                                       cmocka_unit_test(Test_Gbb_IsValid)};
 
     return cmocka_run_group_tests(tests, NULL, NULL);
 }


### PR DESCRIPTION
- packed structs 
- renamed Avtp_GbbField_t→Avtp_GbbFields_t, __AVTP_GBB_FIELDS→Avtp_GbbFieldDesc, __Avtp_Gbb_GetField/SetField→GET_GBB_FIELD/SET_GBB_FIELD, msg→pdu; added Get/SetAcfMsgType, Get/SetAcfMsgLength, GetAcfMsgLengthInBytes, GetPayload, SetPayload, SetPad; renamed GetLen→GetAcfMsgLengthInBytes, GetPayloadLen→GetPayloadLength (uint8_t), SetPayloadLen→SetPayloadLength (pad-zeroing);  Same for ABB
- added inline CreateAcfMessage (byte_bus_id + op + transaction_num + payload) and structural-only IsValid; 
- unit/test-gbb.c, test.abb.c: Updated