### PR TITLE
GISF apply API guidelines

### DIFF
--- a/include/avtp/acf/Gisf.h
+++ b/include/avtp/acf/Gisf.h
@@ -44,9 +44,14 @@ extern "C" {
 #include <stdbool.h>
 #include <string.h>
 
+#include "avtp/Utils.h"
 #include "avtp/Defines.h"
 #include "avtp/acf/AcfCommon.h"
-#include "avtp/Utils.h"
+
+#define GET_GISF_FIELD(field)                                                                      \
+    (Avtp_GetField(Avtp_GisfFieldDesc, AVTP_GISF_FIELD_MAX, (uint8_t *)pdu, field))
+#define SET_GISF_FIELD(field, value)                                                               \
+    (Avtp_SetField(Avtp_GisfFieldDesc, AVTP_GISF_FIELD_MAX, (uint8_t *)pdu, field, value))
 
 /**
  * Length of ACF_GISF message header in bytes.
@@ -60,7 +65,7 @@ extern "C" {
 typedef struct {
     uint8_t header[AVTP_GISF_HEADER_LEN];
     uint8_t payload[0];
-} Avtp_Gisf_t;
+} __attribute__((packed)) Avtp_Gisf_t;
 
 /**
  * Fields encoded in the ACF_GISF header.
@@ -85,12 +90,12 @@ typedef enum {
     AVTP_GISF_FIELD_LINE_NUMBER,
     /* Count number of fields for bound checks */
     AVTP_GISF_FIELD_MAX
-} Avtp_GisfField_t;
+} Avtp_GisfFields_t;
 
 /**
  * This table describes all the offsets of the ACF_GISF header fields.
  */
-static const Avtp_FieldDescriptor_t __AVTP_GISF_FIELDS[AVTP_GISF_FIELD_MAX] =
+static const Avtp_FieldDescriptor_t Avtp_GisfFieldDesc[AVTP_GISF_FIELD_MAX] =
 {
     /* ACF common header fields */
     [AVTP_GISF_FIELD_ACF_MSG_TYPE]      = { .quadlet = 0, .offset =  0, .bits =  7 },
@@ -112,333 +117,460 @@ static const Avtp_FieldDescriptor_t __AVTP_GISF_FIELDS[AVTP_GISF_FIELD_MAX] =
 };
 
 /**
- * Macro to get the value of a field from an ACF_GISF message header.
- * 
- * @note This macro should not be used directly, instead use the field specific
- * getter functions defined below.
- */
-#define __Avtp_Gisf_GetField(field) \
-        (Avtp_GetField(__AVTP_GISF_FIELDS, AVTP_GISF_FIELD_MAX, (uint8_t*)msg, field))
-
-/**
- * Macro to set the value of a field in an ACF_GISF message header.
- * 
- * @note This macro should not be used directly, instead use the field specific
- * setter functions defined below.
- */
-#define __Avtp_Gisf_SetField(field, value) \
-        (Avtp_SetField(__AVTP_GISF_FIELDS, AVTP_GISF_FIELD_MAX, (uint8_t*)msg, field, value))
-
-/**
- * Initializes an ACF_GISF message with default values for the header fields
- * including acf_msg_type and acf_msg_length.
+ * Return the value of the ACF message type field as specified in the IEEE 1722 Specification.
  *
- * @param msg Pointer to the ACF_GISF message to initialize.
+ * @param pdu Pointer to the first bit of a 1722 ACF GISF PDU.
+ * @returns Value of the ACF message type field.
  */
-OPEN1722_INLINE void Avtp_Gisf_Init(Avtp_Gisf_t* msg) {
-    memset(msg, 0, sizeof(Avtp_Gisf_t));
-    __Avtp_Gisf_SetField(AVTP_GISF_FIELD_ACF_MSG_TYPE, AVTP_ACF_TYPE_GISF);
-    __Avtp_Gisf_SetField(AVTP_GISF_FIELD_ACF_MSG_LENGTH, AVTP_GISF_HEADER_LEN / AVTP_QUADLET_SIZE);
+OPEN1722_INLINE uint8_t Avtp_Gisf_GetAcfMsgType(const Avtp_Gisf_t* const pdu) {
+    return (uint8_t) GET_GISF_FIELD(AVTP_GISF_FIELD_ACF_MSG_TYPE);
+}
+
+/**
+ * Return the value of the ACF message length field as specified in the IEEE 1722 Specification.
+ * This returns the length in Quadlets as specified in the IEEE 1722 Specification.
+ *
+ * You can use Avtp_Gisf_GetPayloadLength to get the length in bytes without padding.
+ *
+ * @param pdu Pointer to the first bit of a 1722 ACF GISF PDU.
+ * @returns Value of the ACF message length field.
+ */
+OPEN1722_INLINE uint16_t Avtp_Gisf_GetAcfMsgLength(const Avtp_Gisf_t* const pdu) {
+    return (uint16_t) GET_GISF_FIELD(AVTP_GISF_FIELD_ACF_MSG_LENGTH);
+}
+
+/**
+ * Return the ACF message length in bytes.
+ *
+ * @param pdu Pointer to the first bit of a 1722 ACF GISF PDU.
+ * @returns Length of the ACF message in bytes.
+ */
+OPEN1722_INLINE uint16_t Avtp_Gisf_GetAcfMsgLengthInBytes(const Avtp_Gisf_t* const pdu) {
+    return (uint16_t) GET_GISF_FIELD(AVTP_GISF_FIELD_ACF_MSG_LENGTH) * 4;
+}
+
+/**
+ * Set the value of the ACF message type field as specified in the IEEE 1722 Specification.
+ *
+ * @param pdu Pointer to the first bit of a 1722 ACF GISF PDU.
+ * @param value Value to set the ACF message type field to.
+ */
+OPEN1722_INLINE void Avtp_Gisf_SetAcfMsgType(Avtp_Gisf_t* pdu, uint8_t value) {
+    SET_GISF_FIELD(AVTP_GISF_FIELD_ACF_MSG_TYPE, value);
+}
+
+/**
+ * Set the value of the ACF message length field as specified in the IEEE 1722 Specification.
+ * Note: the size is in Quadlets as specified in the IEEE 1722 Specification.
+ * You can use Avtp_Gisf_SetPayloadLength to set length in bytes and automatically set the
+ * correct padding.
+ *
+ * @param pdu Pointer to the first bit of a 1722 ACF GISF PDU.
+ * @param value Value to set the ACF message length field to.
+ */
+OPEN1722_INLINE void Avtp_Gisf_SetAcfMsgLength(Avtp_Gisf_t* pdu, uint16_t value) {
+    SET_GISF_FIELD(AVTP_GISF_FIELD_ACF_MSG_LENGTH, value);
 }
 
 /**
  * Returns the pad field from an ACF_GISF message header.
- * 
- * @param msg Pointer to an ACF_GISF message.
+ *
+ * @param pdu Pointer to an ACF_GISF message.
  * @returns The value of the pad field.
  */
-OPEN1722_INLINE uint8_t Avtp_Gisf_GetPad(const Avtp_Gisf_t* msg) {
-    return (uint8_t) __Avtp_Gisf_GetField(AVTP_GISF_FIELD_PAD);
+OPEN1722_INLINE uint8_t Avtp_Gisf_GetPad(const Avtp_Gisf_t* const pdu) {
+    return (uint8_t) GET_GISF_FIELD(AVTP_GISF_FIELD_PAD);
 }
 
 /**
- * Returns the message timestamp valid flag (mtv) from an ACF_GISF message
- * header.
- * 
- * @param msg Pointer to an ACF_GISF message.
+ * Sets the pad field in an ACF_GISF message header.
+ *
+ * @param pdu Pointer to an ACF_GISF message.
+ * @param pad The value to set.
+ */
+OPEN1722_INLINE void Avtp_Gisf_SetPad(Avtp_Gisf_t* pdu, uint8_t pad) {
+    SET_GISF_FIELD(AVTP_GISF_FIELD_PAD, pad);
+}
+
+/**
+ * Returns the message timestamp valid flag (mtv) from an ACF_GISF message header.
+ *
+ * @param pdu Pointer to an ACF_GISF message.
  * @returns The value of the mtv flag.
  */
-OPEN1722_INLINE bool Avtp_Gisf_IsMtv(const Avtp_Gisf_t* msg) {
-    return (bool) __Avtp_Gisf_GetField(AVTP_GISF_FIELD_MTV);
+OPEN1722_INLINE bool Avtp_Gisf_IsMtv(const Avtp_Gisf_t* const pdu) {
+    return (bool) GET_GISF_FIELD(AVTP_GISF_FIELD_MTV);
 }
 
 /**
- * Returns the value of the image_sensor_id field from an ACF_GISF message
- * header.
- * 
- * @param msg Pointer to an ACF_GISF message.
+ * Returns the value of the image_sensor_id field from an ACF_GISF message header.
+ *
+ * @param pdu Pointer to an ACF_GISF message.
  * @returns The value of the image_sensor_id field.
  */
-OPEN1722_INLINE uint16_t Avtp_Gisf_GetImageSensorId(const Avtp_Gisf_t* msg) {
-    return (uint16_t) __Avtp_Gisf_GetField(AVTP_GISF_FIELD_IMAGE_SENSOR_ID);
+OPEN1722_INLINE uint16_t Avtp_Gisf_GetImageSensorId(const Avtp_Gisf_t* const pdu) {
+    return (uint16_t) GET_GISF_FIELD(AVTP_GISF_FIELD_IMAGE_SENSOR_ID);
 }
 
 /**
- * Returns the value of the message_timestamp field from an ACF_GISF message
- * header.
- * 
- * @param msg Pointer to an ACF_GISF message.
+ * Returns the value of the message_timestamp field from an ACF_GISF message header.
+ *
+ * @param pdu Pointer to an ACF_GISF message.
  * @returns The value of the message_timestamp field.
  */
-OPEN1722_INLINE uint64_t Avtp_Gisf_GetMessageTimestamp(const Avtp_Gisf_t* msg) {
-    return (uint64_t) __Avtp_Gisf_GetField(AVTP_GISF_FIELD_MESSAGE_TIMESTAMP);
+OPEN1722_INLINE uint64_t Avtp_Gisf_GetMessageTimestamp(const Avtp_Gisf_t* const pdu) {
+    return (uint64_t) GET_GISF_FIELD(AVTP_GISF_FIELD_MESSAGE_TIMESTAMP);
 }
 
 /**
  * Returns the value of the el (end line) flag from an ACF_GISF message header.
- * 
- * @param msg Pointer to an ACF_GISF message.
+ *
+ * @param pdu Pointer to an ACF_GISF message.
  * @returns The value of the el flag.
  */
-OPEN1722_INLINE bool Avtp_Gisf_IsEl(const Avtp_Gisf_t* msg) {
-    return (bool) __Avtp_Gisf_GetField(AVTP_GISF_FIELD_EL);
+OPEN1722_INLINE bool Avtp_Gisf_IsEl(const Avtp_Gisf_t* const pdu) {
+    return (bool) GET_GISF_FIELD(AVTP_GISF_FIELD_EL);
 }
 
 /**
- * Returns the value of the tl (timestamp line) flag from an ACF_GISF message
- * header.
- * 
- * @param msg Pointer to an ACF_GISF message.
+ * Returns the value of the tl (timestamp line) flag from an ACF_GISF message header.
+ *
+ * @param pdu Pointer to an ACF_GISF message.
  * @returns The value of the tl flag.
  */
-OPEN1722_INLINE bool Avtp_Gisf_IsTl(const Avtp_Gisf_t* msg) {
-    return (bool) __Avtp_Gisf_GetField(AVTP_GISF_FIELD_TL);
+OPEN1722_INLINE bool Avtp_Gisf_IsTl(const Avtp_Gisf_t* const pdu) {
+    return (bool) GET_GISF_FIELD(AVTP_GISF_FIELD_TL);
 }
 
 /**
- * Returns the value of the ef (end frame) flag from an ACF_GISF message
- * header.
- * 
- * @param msg Pointer to an ACF_GISF message.
+ * Returns the value of the ef (end frame) flag from an ACF_GISF message header.
+ *
+ * @param pdu Pointer to an ACF_GISF message.
  * @returns The value of the ef flag.
  */
-OPEN1722_INLINE bool Avtp_Gisf_IsEf(const Avtp_Gisf_t* msg) {
-    return (bool) __Avtp_Gisf_GetField(AVTP_GISF_FIELD_EF);
+OPEN1722_INLINE bool Avtp_Gisf_IsEf(const Avtp_Gisf_t* const pdu) {
+    return (bool) GET_GISF_FIELD(AVTP_GISF_FIELD_EF);
 }
 
 /**
  * Returns the value of the evt (event) field from an ACF_GISF message header.
- * 
- * @param msg Pointer to an ACF_GISF message.
+ *
+ * @param pdu Pointer to an ACF_GISF message.
  * @returns The value of the evt field.
  */
-OPEN1722_INLINE uint8_t Avtp_Gisf_GetEvt(const Avtp_Gisf_t* msg) {
-    return (uint8_t) __Avtp_Gisf_GetField(AVTP_GISF_FIELD_EVT);
+OPEN1722_INLINE uint8_t Avtp_Gisf_GetEvt(const Avtp_Gisf_t* const pdu) {
+    return (uint8_t) GET_GISF_FIELD(AVTP_GISF_FIELD_EVT);
 }
 
 /**
- * Returns the value of the bf (begin frame) flag from an ACF_GISF message
- * header.
- * 
- * @param msg Pointer to an ACF_GISF message.
+ * Returns the value of the bf (begin frame) flag from an ACF_GISF message header.
+ *
+ * @param pdu Pointer to an ACF_GISF message.
  * @returns The value of the bf flag.
  */
-OPEN1722_INLINE bool Avtp_Gisf_IsBf(const Avtp_Gisf_t* msg) {
-    return (bool) __Avtp_Gisf_GetField(AVTP_GISF_FIELD_BF);
+OPEN1722_INLINE bool Avtp_Gisf_IsBf(const Avtp_Gisf_t* const pdu) {
+    return (bool) GET_GISF_FIELD(AVTP_GISF_FIELD_BF);
 }
 
 /**
  * Returns the value of the line_type_id field from an ACF_GISF message header.
- * 
- * @param msg Pointer to an ACF_GISF message.
+ *
+ * @param pdu Pointer to an ACF_GISF message.
  * @returns The value of the line_type_id value.
  */
-OPEN1722_INLINE uint8_t Avtp_Gisf_GetLineTypeId(const Avtp_Gisf_t* msg) {
-    return (uint8_t) __Avtp_Gisf_GetField(AVTP_GISF_FIELD_LINE_TYPE_ID);
+OPEN1722_INLINE uint8_t Avtp_Gisf_GetLineTypeId(const Avtp_Gisf_t* const pdu) {
+    return (uint8_t) GET_GISF_FIELD(AVTP_GISF_FIELD_LINE_TYPE_ID);
 }
 
 /**
- * Returns the value of the evt2 (event 2) field from an ACF_GISF message
- * header.
- * 
- * @param msg Pointer to an ACF_GISF message.
+ * Returns the value of the evt2 (event 2) field from an ACF_GISF message header.
+ *
+ * @param pdu Pointer to an ACF_GISF message.
  * @returns The value of the evt2 field.
  */
-OPEN1722_INLINE uint8_t Avtp_Gisf_GetEvt2(const Avtp_Gisf_t* msg) {
-    return (uint8_t) __Avtp_Gisf_GetField(AVTP_GISF_FIELD_EVT2);
+OPEN1722_INLINE uint8_t Avtp_Gisf_GetEvt2(const Avtp_Gisf_t* const pdu) {
+    return (uint8_t) GET_GISF_FIELD(AVTP_GISF_FIELD_EVT2);
 }
 
 /**
- * Returns the value of the i_seq_num (intra line sequence number) field from
- * an ACF_GISF message header.
- * 
- * @param msg Pointer to an ACF_GISF message.
+ * Returns the value of the i_seq_num (intra line sequence number) field from an ACF_GISF message header.
+ *
+ * @param pdu Pointer to an ACF_GISF message.
  * @returns The value of the i_seq_num field.
  */
-OPEN1722_INLINE uint8_t Avtp_Gisf_GetISeqNum(const Avtp_Gisf_t* msg) {
-    return (uint8_t) __Avtp_Gisf_GetField(AVTP_GISF_FIELD_I_SEQ_NUM);
+OPEN1722_INLINE uint8_t Avtp_Gisf_GetISeqNum(const Avtp_Gisf_t* const pdu) {
+    return (uint8_t) GET_GISF_FIELD(AVTP_GISF_FIELD_I_SEQ_NUM);
 }
 
 /**
  * Returns the value of the line_number field from an ACF_GISF message header.
- * 
- * @param msg Pointer to an ACF_GISF message.
+ *
+ * @param pdu Pointer to an ACF_GISF message.
  * @returns The value of the line_number field.
  */
-OPEN1722_INLINE uint16_t Avtp_Gisf_GetLineNumber(const Avtp_Gisf_t* msg) {
-    return (uint16_t) __Avtp_Gisf_GetField(AVTP_GISF_FIELD_LINE_NUMBER);
-}
-
-/**
- * Returns the paload length from an ACF_GISF message (in bytes). This is
- * calculated based on the value of the acf_msg_length field in the header
- * as well as the value of the pad field.
- * 
- * @param msg Pointer to an ACF_GISF message.
- * @returns The payload length in bytes.
- */
-OPEN1722_INLINE uint16_t Avtp_Gisf_GetPayloadLen(const Avtp_Gisf_t* msg) {
-    return (uint16_t) (__Avtp_Gisf_GetField(AVTP_GISF_FIELD_ACF_MSG_LENGTH) * AVTP_QUADLET_SIZE
-           - AVTP_GISF_HEADER_LEN
-           - __Avtp_Gisf_GetField(AVTP_GISF_FIELD_PAD));
-}
-
-/**
- * Returns the total message length from an ACF_GISF message (in bytes)
- * including header and payload section.
- * 
- * @param msg Pointer to an ACF_GISF message.
- * @returns The total message length in bytes.
- */
-OPEN1722_INLINE uint16_t Avtp_Gisf_GetLen(const Avtp_Gisf_t* msg) {
-    return (uint16_t) (__Avtp_Gisf_GetField(AVTP_GISF_FIELD_ACF_MSG_LENGTH) * AVTP_QUADLET_SIZE);
+OPEN1722_INLINE uint16_t Avtp_Gisf_GetLineNumber(const Avtp_Gisf_t* const pdu) {
+    return (uint16_t) GET_GISF_FIELD(AVTP_GISF_FIELD_LINE_NUMBER);
 }
 
 /**
  * Sets the value of the mtv flag in an ACF_GISF message header.
- * 
- * @param msg Pointer to an ACF_GISF message.
+ *
+ * @param pdu Pointer to an ACF_GISF message.
  * @param mtv The value to set.
  */
-OPEN1722_INLINE void Avtp_Gisf_SetMtv(Avtp_Gisf_t* msg, bool mtv) {
-    __Avtp_Gisf_SetField(AVTP_GISF_FIELD_MTV, mtv);
+OPEN1722_INLINE void Avtp_Gisf_SetMtv(Avtp_Gisf_t* pdu, bool mtv) {
+    SET_GISF_FIELD(AVTP_GISF_FIELD_MTV, mtv);
 }
 
 /**
  * Sets the value of the image_sensor_id field in an ACF_GISF message header.
- * 
- * @param msg Pointer to an ACF_GISF message.
- * @param byteBusId The value to set.
+ *
+ * @param pdu Pointer to an ACF_GISF message.
+ * @param imageSensorId The value to set.
  */
-OPEN1722_INLINE void Avtp_Gisf_SetImageSensorId(Avtp_Gisf_t* msg, uint16_t imageSensorId) {
-    __Avtp_Gisf_SetField(AVTP_GISF_FIELD_IMAGE_SENSOR_ID, imageSensorId);
+OPEN1722_INLINE void Avtp_Gisf_SetImageSensorId(Avtp_Gisf_t* pdu, uint16_t imageSensorId) {
+    SET_GISF_FIELD(AVTP_GISF_FIELD_IMAGE_SENSOR_ID, imageSensorId);
 }
 
 /**
  * Sets the value of the message_timestamp field in an ACF_GISF message header.
- * 
- * @param msg Pointer to an ACF_GISF message.
+ *
+ * @param pdu Pointer to an ACF_GISF message.
  * @param messageTimestamp The value to set.
  */
-OPEN1722_INLINE void Avtp_Gisf_SetMessageTimestamp(Avtp_Gisf_t* msg, uint64_t messageTimestamp) {
-    __Avtp_Gisf_SetField(AVTP_GISF_FIELD_MESSAGE_TIMESTAMP, messageTimestamp);
+OPEN1722_INLINE void Avtp_Gisf_SetMessageTimestamp(Avtp_Gisf_t* pdu, uint64_t messageTimestamp) {
+    SET_GISF_FIELD(AVTP_GISF_FIELD_MESSAGE_TIMESTAMP, messageTimestamp);
 }
 
 /**
  * Sets the value of the end line (el) flag in an ACF_GISF message header.
- * 
- * @param msg Pointer to an ACF_GISF message.
- * @param hs The value to set.
+ *
+ * @param pdu Pointer to an ACF_GISF message.
+ * @param el The value to set.
  */
-OPEN1722_INLINE void Avtp_Gisf_SetEl(Avtp_Gisf_t* msg, bool el) {
-    __Avtp_Gisf_SetField(AVTP_GISF_FIELD_EL, el);
+OPEN1722_INLINE void Avtp_Gisf_SetEl(Avtp_Gisf_t* pdu, bool el) {
+    SET_GISF_FIELD(AVTP_GISF_FIELD_EL, el);
 }
 
 /**
- * Sets the value of the timestamp line (tl) flag in an ACF_GISF message
- * header.
- * 
- * @param msg Pointer to an ACF_GISF message.
- * @param cs The value to set.
+ * Sets the value of the timestamp line (tl) flag in an ACF_GISF message header.
+ *
+ * @param pdu Pointer to an ACF_GISF message.
+ * @param tl The value to set.
  */
-OPEN1722_INLINE void Avtp_Gisf_SetTl(Avtp_Gisf_t* msg, bool tl) {
-    __Avtp_Gisf_SetField(AVTP_GISF_FIELD_TL, tl);
+OPEN1722_INLINE void Avtp_Gisf_SetTl(Avtp_Gisf_t* pdu, bool tl) {
+    SET_GISF_FIELD(AVTP_GISF_FIELD_TL, tl);
 }
 
 /**
  * Sets the value of the end frame (ef) flag in an ACF_GISF message header.
- * 
- * @param msg Pointer to an ACF_GISF message.
- * @param transactionNum The value to set.
+ *
+ * @param pdu Pointer to an ACF_GISF message.
+ * @param ef The value to set.
  */
-OPEN1722_INLINE void Avtp_Gisf_SetEf(Avtp_Gisf_t* msg, bool ef) {
-    __Avtp_Gisf_SetField(AVTP_GISF_FIELD_EF, ef);
+OPEN1722_INLINE void Avtp_Gisf_SetEf(Avtp_Gisf_t* pdu, bool ef) {
+    SET_GISF_FIELD(AVTP_GISF_FIELD_EF, ef);
 }
 
 /**
  * Sets the value of the event field in an ACF_GISF message header.
- * 
- * @param msg Pointer to an ACF_GISF message.
- * @param op The value to set.
+ *
+ * @param pdu Pointer to an ACF_GISF message.
+ * @param evt The value to set.
  */
-OPEN1722_INLINE void Avtp_Gisf_SetEvt(Avtp_Gisf_t* msg, uint8_t evt) {
-    __Avtp_Gisf_SetField(AVTP_GISF_FIELD_EVT, evt);
+OPEN1722_INLINE void Avtp_Gisf_SetEvt(Avtp_Gisf_t* pdu, uint8_t evt) {
+    SET_GISF_FIELD(AVTP_GISF_FIELD_EVT, evt);
 }
 
 /**
  * Sets the value of the begin frame (bf) flag in an ACF_GISF message header.
- * 
- * @param msg Pointer to an ACF_GISF message.
- * @param rsp The value to set.
+ *
+ * @param pdu Pointer to an ACF_GISF message.
+ * @param bf The value to set.
  */
-OPEN1722_INLINE void Avtp_Gisf_SetBf(Avtp_Gisf_t* msg, bool bf) {
-    __Avtp_Gisf_SetField(AVTP_GISF_FIELD_BF, bf);
+OPEN1722_INLINE void Avtp_Gisf_SetBf(Avtp_Gisf_t* pdu, bool bf) {
+    SET_GISF_FIELD(AVTP_GISF_FIELD_BF, bf);
 }
 
 /**
  * Sets the value of the line_type_id field in an ACF_GISF message header.
- * 
- * @param msg Pointer to an ACF_GISF message.
- * @param err The value to set.
+ *
+ * @param pdu Pointer to an ACF_GISF message.
+ * @param lineTypeId The value to set.
  */
-OPEN1722_INLINE void Avtp_Gisf_SetLineTypeId(Avtp_Gisf_t* msg, uint8_t lineTypeId) {
-    __Avtp_Gisf_SetField(AVTP_GISF_FIELD_LINE_TYPE_ID, lineTypeId);
+OPEN1722_INLINE void Avtp_Gisf_SetLineTypeId(Avtp_Gisf_t* pdu, uint8_t lineTypeId) {
+    SET_GISF_FIELD(AVTP_GISF_FIELD_LINE_TYPE_ID, lineTypeId);
 }
 
 /**
  * Sets the value of the event_2 field in an ACF_GISF message header.
- * 
- * @param msg Pointer to an ACF_GISF message.
- * @param ms The value to set.
+ *
+ * @param pdu Pointer to an ACF_GISF message.
+ * @param evt2 The value to set.
  */
-OPEN1722_INLINE void Avtp_Gisf_SetEvt2(Avtp_Gisf_t* msg, uint8_t evt2) {
-    __Avtp_Gisf_SetField(AVTP_GISF_FIELD_EVT2, evt2);
+OPEN1722_INLINE void Avtp_Gisf_SetEvt2(Avtp_Gisf_t* pdu, uint8_t evt2) {
+    SET_GISF_FIELD(AVTP_GISF_FIELD_EVT2, evt2);
 }
 
 /**
  * Sets the value of the i_seq_num field in an ACF_GISF message header.
- * 
- * @param msg Pointer to an ACF_GISF message.
- * @param readSize The value to set.
+ *
+ * @param pdu Pointer to an ACF_GISF message.
+ * @param iSeqNum The value to set.
  */
-OPEN1722_INLINE void Avtp_Gisf_SetISeqNum(Avtp_Gisf_t* msg, uint8_t iSeqNum) {
-    __Avtp_Gisf_SetField(AVTP_GISF_FIELD_I_SEQ_NUM, iSeqNum);
+OPEN1722_INLINE void Avtp_Gisf_SetISeqNum(Avtp_Gisf_t* pdu, uint8_t iSeqNum) {
+    SET_GISF_FIELD(AVTP_GISF_FIELD_I_SEQ_NUM, iSeqNum);
 }
 
 /**
- * Sets the value of the read_size/segment_num field in an ACF_GISF message header.
- * 
- * @param msg Pointer to an ACF_GISF message.
- * @param segmentNum The value to set.
+ * Sets the value of the line_number field in an ACF_GISF message header.
+ *
+ * @param pdu Pointer to an ACF_GISF message.
+ * @param lineNumber The value to set.
  */
-OPEN1722_INLINE void Avtp_Gisf_SetLineNumber(Avtp_Gisf_t* msg, uint16_t lineNumber) {
-    __Avtp_Gisf_SetField(AVTP_GISF_FIELD_LINE_NUMBER, lineNumber);
+OPEN1722_INLINE void Avtp_Gisf_SetLineNumber(Avtp_Gisf_t* pdu, uint16_t lineNumber) {
+    SET_GISF_FIELD(AVTP_GISF_FIELD_LINE_NUMBER, lineNumber);
 }
 
 /**
- * Sets the value of the acf_msg_length field in an ACF_GISF message header
- * based on the given payload length. This function also calculates the
- * required padding and sets the value of the pad field accordingly.
- * 
- * @param msg Pointer to an ACF_GISF message.
- * @param payloadLen The length of the payload in bytes.
+ * Returns pointer to payload of an ACF GISF frame.
+ *
+ * @param pdu Pointer to the first bit of a 1722 ACF GISF PDU.
+ * @return Pointer to ACF GISF frame payload
  */
-OPEN1722_INLINE void Avtp_Gisf_SetPayloadLen(Avtp_Gisf_t* msg, uint16_t payloadLen) {
-    uint16_t msgLenBytes = AVTP_GISF_HEADER_LEN + payloadLen;
-    uint8_t pad = (uint8_t) (4 - (msgLenBytes % 4)) % 4;
-    uint16_t msgLenQuadlets = (uint16_t) ((msgLenBytes + pad) / 4);
-    __Avtp_Gisf_SetField(AVTP_GISF_FIELD_ACF_MSG_LENGTH, msgLenQuadlets);
-    __Avtp_Gisf_SetField(AVTP_GISF_FIELD_PAD, pad);
+OPEN1722_INLINE const uint8_t *Avtp_Gisf_GetPayload(const Avtp_Gisf_t* const pdu)
+{
+    return pdu->payload;
+}
+
+/**
+ * Sets the payload in an ACF GISF frame.
+ *
+ * @param pdu Pointer to the first bit of a 1722 ACF GISF PDU.
+ * @param payload Pointer to the payload byte array
+ * @param payload_length Length of the payload
+ */
+OPEN1722_INLINE void Avtp_Gisf_SetPayload(Avtp_Gisf_t *pdu, uint8_t *payload,
+                                          uint16_t payload_length)
+{
+    memcpy(pdu->payload, payload, payload_length);
+}
+
+/**
+ * Finalizes the ACF GISF frame. This function will set the
+ * length and pad fields while inserting the padded bytes. This will also
+ * set padding bytes to zero if the payload length is not a multiple of 4.
+ * to avoid leaking information
+ *
+ * @param pdu Pointer to the first bit of a 1722 ACF GISF PDU.
+ * @param payload_length Length of the frame payload.
+ */
+OPEN1722_INLINE void Avtp_Gisf_SetPayloadLength(Avtp_Gisf_t *pdu, uint16_t payload_length)
+{
+    uint16_t msgLenBytes = AVTP_GISF_HEADER_LEN + payload_length;
+    uint8_t pad = (uint8_t)(4 - (msgLenBytes % 4)) % 4;
+    if (pad > 0) {
+        memset(pdu->payload + payload_length, 0, pad);
+    }
+    uint16_t msgLenQuadlets = (uint16_t)((msgLenBytes + pad) / 4);
+    Avtp_Gisf_SetPad(pdu, pad);
+    Avtp_Gisf_SetAcfMsgLength(pdu, msgLenQuadlets);
+}
+
+/**
+ * Returns the length of the payload without the padding bytes and the
+ * header length of the encapsulating ACF Frame.
+ *
+ * Precondition: the caller must have validated the PDU with
+ * Avtp_Gisf_IsValid(). This function performs no further bounds checking
+ * and assumes those invariants already hold.
+ *
+ * @param pdu Pointer to the first bit of a 1722 ACF GISF PDU.
+ * @return  Length of payload in bytes
+ */
+OPEN1722_INLINE uint16_t Avtp_Gisf_GetPayloadLength(const Avtp_Gisf_t* const pdu)
+{
+    uint8_t pad_length = Avtp_Gisf_GetPad(pdu);
+    uint16_t acf_length_bytes = Avtp_Gisf_GetAcfMsgLengthInBytes(pdu);
+    return (uint16_t)(acf_length_bytes - AVTP_GISF_HEADER_LEN - pad_length);
+}
+
+/**
+ * Initializes an ACF_GISF message header as specified in the IEEE 1722 Specification.
+ *
+ * @param pdu Pointer to the first bit of a 1722 ACF GISF PDU.
+ */
+OPEN1722_INLINE void Avtp_Gisf_Init(Avtp_Gisf_t* pdu)
+{
+    if (pdu != NULL) {
+        memset(pdu, 0, sizeof(Avtp_Gisf_t));
+        Avtp_Gisf_SetAcfMsgType(pdu, AVTP_ACF_TYPE_GISF);
+    }
+}
+
+/**
+ * Copies the payload data and image sensor ID into the ACF GISF frame. This
+ * function will also set the length and pad fields while inserting the padded
+ * bytes.
+ *
+ * @param pdu Pointer to the first bit of a 1722 ACF GISF PDU.
+ * @param image_sensor_id Image sensor ID
+ * @param payload Pointer to the payload byte array
+ * @param payload_length Length of the payload.
+ */
+OPEN1722_INLINE void Avtp_Gisf_CreateAcfMessage(Avtp_Gisf_t *pdu, uint16_t image_sensor_id,
+                                                uint8_t *payload, uint16_t payload_length)
+{
+    // Initialize the ACF GISF header
+    Avtp_Gisf_Init(pdu);
+
+    // Set the image sensor ID
+    Avtp_Gisf_SetImageSensorId(pdu, image_sensor_id);
+
+    // Copy the payload into the GISF PDU
+    Avtp_Gisf_SetPayload(pdu, payload, payload_length);
+
+    // Finalize the AVTP GISF Frame
+    Avtp_Gisf_SetPayloadLength(pdu, payload_length);
+}
+
+/**
+ * Checks if the ACF GISF frame is valid by checking:
+ *     1) if the length field of AVTP/ACF messages contains a value larger than the actual size of
+ * the buffer that contains the AVTP message. 2) if other format specific invariants are not upheld
+ * @param pdu Pointer to the first bit of a 1722 ACF GISF PDU.
+ * @param bufferSize Size of the buffer containing the ACF GISF frame.
+ * @return true if the ACF GISF frame is valid, false otherwise.
+ */
+OPEN1722_INLINE bool Avtp_Gisf_IsValid(const Avtp_Gisf_t* const pdu, size_t bufferSize)
+{
+    if (pdu == NULL) {
+        return false;
+    }
+
+    if (bufferSize < AVTP_GISF_HEADER_LEN) {
+        return false;
+    }
+
+    if (Avtp_Gisf_GetAcfMsgType(pdu) != AVTP_ACF_TYPE_GISF) {
+        return false;
+    }
+
+    // Avtp_Gisf_GetAcfMsgLength returns quadlets. Convert the length field to octets.
+    uint16_t msg_length_bytes = (uint16_t)Avtp_Gisf_GetAcfMsgLength(pdu) * 4;
+    if (msg_length_bytes > bufferSize) {
+        return false;
+    }
+
+    /* The encoded message length must accommodate header + declared padding
+     * so the payload computation in Avtp_Gisf_GetPayloadLength() doesn't
+     * underflow. */
+    uint8_t pad_length = Avtp_Gisf_GetPad(pdu);
+    uint16_t header_and_pad = (uint16_t)AVTP_GISF_HEADER_LEN + pad_length;
+    if (msg_length_bytes < header_and_pad) {
+        return false;
+    }
+    return true;
 }
 
 #ifdef __cplusplus

--- a/include/avtp/acf/Gisf.h
+++ b/include/avtp/acf/Gisf.h
@@ -95,25 +95,24 @@ typedef enum {
 /**
  * This table describes all the offsets of the ACF_GISF header fields.
  */
-static const Avtp_FieldDescriptor_t Avtp_GisfFieldDesc[AVTP_GISF_FIELD_MAX] =
-{
+static const Avtp_FieldDescriptor_t Avtp_GisfFieldDesc[AVTP_GISF_FIELD_MAX] = {
     /* ACF common header fields */
-    [AVTP_GISF_FIELD_ACF_MSG_TYPE]      = { .quadlet = 0, .offset =  0, .bits =  7 },
-    [AVTP_GISF_FIELD_ACF_MSG_LENGTH]    = { .quadlet = 0, .offset =  7, .bits =  9 },
+    [AVTP_GISF_FIELD_ACF_MSG_TYPE] = {.quadlet = 0, .offset = 0, .bits = 7},
+    [AVTP_GISF_FIELD_ACF_MSG_LENGTH] = {.quadlet = 0, .offset = 7, .bits = 9},
     /* ACF GISF header fields */
-    [AVTP_GISF_FIELD_PAD]               = { .quadlet = 0, .offset = 16, .bits =  2 },
-    [AVTP_GISF_FIELD_MTV]               = { .quadlet = 0, .offset = 18, .bits =  1 },
-    [AVTP_GISF_FIELD_IMAGE_SENSOR_ID]   = { .quadlet = 0, .offset = 21, .bits = 11 },
-    [AVTP_GISF_FIELD_MESSAGE_TIMESTAMP] = { .quadlet = 1, .offset =  0, .bits = 64 },
-    [AVTP_GISF_FIELD_EL]                = { .quadlet = 3, .offset = 17, .bits =  1 },
-    [AVTP_GISF_FIELD_TL]                = { .quadlet = 3, .offset = 18, .bits =  1 },
-    [AVTP_GISF_FIELD_EF]                = { .quadlet = 3, .offset = 19, .bits =  1 },
-    [AVTP_GISF_FIELD_EVT]               = { .quadlet = 3, .offset = 20, .bits =  4 },
-    [AVTP_GISF_FIELD_BF]                = { .quadlet = 3, .offset = 26, .bits =  1 },
-    [AVTP_GISF_FIELD_LINE_TYPE_ID]      = { .quadlet = 3, .offset = 27, .bits =  5 },
-    [AVTP_GISF_FIELD_EVT2]              = { .quadlet = 4, .offset =  0, .bits =  8 },
-    [AVTP_GISF_FIELD_I_SEQ_NUM]         = { .quadlet = 4, .offset =  8, .bits =  8 },
-    [AVTP_GISF_FIELD_LINE_NUMBER]       = { .quadlet = 4, .offset = 16, .bits = 16 },
+    [AVTP_GISF_FIELD_PAD] = {.quadlet = 0, .offset = 16, .bits = 2},
+    [AVTP_GISF_FIELD_MTV] = {.quadlet = 0, .offset = 18, .bits = 1},
+    [AVTP_GISF_FIELD_IMAGE_SENSOR_ID] = {.quadlet = 0, .offset = 21, .bits = 11},
+    [AVTP_GISF_FIELD_MESSAGE_TIMESTAMP] = {.quadlet = 1, .offset = 0, .bits = 64},
+    [AVTP_GISF_FIELD_EL] = {.quadlet = 3, .offset = 17, .bits = 1},
+    [AVTP_GISF_FIELD_TL] = {.quadlet = 3, .offset = 18, .bits = 1},
+    [AVTP_GISF_FIELD_EF] = {.quadlet = 3, .offset = 19, .bits = 1},
+    [AVTP_GISF_FIELD_EVT] = {.quadlet = 3, .offset = 20, .bits = 4},
+    [AVTP_GISF_FIELD_BF] = {.quadlet = 3, .offset = 26, .bits = 1},
+    [AVTP_GISF_FIELD_LINE_TYPE_ID] = {.quadlet = 3, .offset = 27, .bits = 5},
+    [AVTP_GISF_FIELD_EVT2] = {.quadlet = 4, .offset = 0, .bits = 8},
+    [AVTP_GISF_FIELD_I_SEQ_NUM] = {.quadlet = 4, .offset = 8, .bits = 8},
+    [AVTP_GISF_FIELD_LINE_NUMBER] = {.quadlet = 4, .offset = 16, .bits = 16},
 };
 
 /**
@@ -122,8 +121,9 @@ static const Avtp_FieldDescriptor_t Avtp_GisfFieldDesc[AVTP_GISF_FIELD_MAX] =
  * @param pdu Pointer to the first bit of a 1722 ACF GISF PDU.
  * @returns Value of the ACF message type field.
  */
-OPEN1722_INLINE uint8_t Avtp_Gisf_GetAcfMsgType(const Avtp_Gisf_t* const pdu) {
-    return (uint8_t) GET_GISF_FIELD(AVTP_GISF_FIELD_ACF_MSG_TYPE);
+OPEN1722_INLINE uint8_t Avtp_Gisf_GetAcfMsgType(const Avtp_Gisf_t *const pdu)
+{
+    return (uint8_t)GET_GISF_FIELD(AVTP_GISF_FIELD_ACF_MSG_TYPE);
 }
 
 /**
@@ -135,8 +135,9 @@ OPEN1722_INLINE uint8_t Avtp_Gisf_GetAcfMsgType(const Avtp_Gisf_t* const pdu) {
  * @param pdu Pointer to the first bit of a 1722 ACF GISF PDU.
  * @returns Value of the ACF message length field.
  */
-OPEN1722_INLINE uint16_t Avtp_Gisf_GetAcfMsgLength(const Avtp_Gisf_t* const pdu) {
-    return (uint16_t) GET_GISF_FIELD(AVTP_GISF_FIELD_ACF_MSG_LENGTH);
+OPEN1722_INLINE uint16_t Avtp_Gisf_GetAcfMsgLength(const Avtp_Gisf_t *const pdu)
+{
+    return (uint16_t)GET_GISF_FIELD(AVTP_GISF_FIELD_ACF_MSG_LENGTH);
 }
 
 /**
@@ -145,8 +146,9 @@ OPEN1722_INLINE uint16_t Avtp_Gisf_GetAcfMsgLength(const Avtp_Gisf_t* const pdu)
  * @param pdu Pointer to the first bit of a 1722 ACF GISF PDU.
  * @returns Length of the ACF message in bytes.
  */
-OPEN1722_INLINE uint16_t Avtp_Gisf_GetAcfMsgLengthInBytes(const Avtp_Gisf_t* const pdu) {
-    return (uint16_t) GET_GISF_FIELD(AVTP_GISF_FIELD_ACF_MSG_LENGTH) * 4;
+OPEN1722_INLINE uint16_t Avtp_Gisf_GetAcfMsgLengthInBytes(const Avtp_Gisf_t *const pdu)
+{
+    return (uint16_t)GET_GISF_FIELD(AVTP_GISF_FIELD_ACF_MSG_LENGTH) * 4;
 }
 
 /**
@@ -155,7 +157,8 @@ OPEN1722_INLINE uint16_t Avtp_Gisf_GetAcfMsgLengthInBytes(const Avtp_Gisf_t* con
  * @param pdu Pointer to the first bit of a 1722 ACF GISF PDU.
  * @param value Value to set the ACF message type field to.
  */
-OPEN1722_INLINE void Avtp_Gisf_SetAcfMsgType(Avtp_Gisf_t* pdu, uint8_t value) {
+OPEN1722_INLINE void Avtp_Gisf_SetAcfMsgType(Avtp_Gisf_t *pdu, uint8_t value)
+{
     SET_GISF_FIELD(AVTP_GISF_FIELD_ACF_MSG_TYPE, value);
 }
 
@@ -168,7 +171,8 @@ OPEN1722_INLINE void Avtp_Gisf_SetAcfMsgType(Avtp_Gisf_t* pdu, uint8_t value) {
  * @param pdu Pointer to the first bit of a 1722 ACF GISF PDU.
  * @param value Value to set the ACF message length field to.
  */
-OPEN1722_INLINE void Avtp_Gisf_SetAcfMsgLength(Avtp_Gisf_t* pdu, uint16_t value) {
+OPEN1722_INLINE void Avtp_Gisf_SetAcfMsgLength(Avtp_Gisf_t *pdu, uint16_t value)
+{
     SET_GISF_FIELD(AVTP_GISF_FIELD_ACF_MSG_LENGTH, value);
 }
 
@@ -178,8 +182,9 @@ OPEN1722_INLINE void Avtp_Gisf_SetAcfMsgLength(Avtp_Gisf_t* pdu, uint16_t value)
  * @param pdu Pointer to an ACF_GISF message.
  * @returns The value of the pad field.
  */
-OPEN1722_INLINE uint8_t Avtp_Gisf_GetPad(const Avtp_Gisf_t* const pdu) {
-    return (uint8_t) GET_GISF_FIELD(AVTP_GISF_FIELD_PAD);
+OPEN1722_INLINE uint8_t Avtp_Gisf_GetPad(const Avtp_Gisf_t *const pdu)
+{
+    return (uint8_t)GET_GISF_FIELD(AVTP_GISF_FIELD_PAD);
 }
 
 /**
@@ -188,7 +193,8 @@ OPEN1722_INLINE uint8_t Avtp_Gisf_GetPad(const Avtp_Gisf_t* const pdu) {
  * @param pdu Pointer to an ACF_GISF message.
  * @param pad The value to set.
  */
-OPEN1722_INLINE void Avtp_Gisf_SetPad(Avtp_Gisf_t* pdu, uint8_t pad) {
+OPEN1722_INLINE void Avtp_Gisf_SetPad(Avtp_Gisf_t *pdu, uint8_t pad)
+{
     SET_GISF_FIELD(AVTP_GISF_FIELD_PAD, pad);
 }
 
@@ -198,8 +204,9 @@ OPEN1722_INLINE void Avtp_Gisf_SetPad(Avtp_Gisf_t* pdu, uint8_t pad) {
  * @param pdu Pointer to an ACF_GISF message.
  * @returns The value of the mtv flag.
  */
-OPEN1722_INLINE bool Avtp_Gisf_IsMtv(const Avtp_Gisf_t* const pdu) {
-    return (bool) GET_GISF_FIELD(AVTP_GISF_FIELD_MTV);
+OPEN1722_INLINE bool Avtp_Gisf_IsMtv(const Avtp_Gisf_t *const pdu)
+{
+    return (bool)GET_GISF_FIELD(AVTP_GISF_FIELD_MTV);
 }
 
 /**
@@ -208,8 +215,9 @@ OPEN1722_INLINE bool Avtp_Gisf_IsMtv(const Avtp_Gisf_t* const pdu) {
  * @param pdu Pointer to an ACF_GISF message.
  * @returns The value of the image_sensor_id field.
  */
-OPEN1722_INLINE uint16_t Avtp_Gisf_GetImageSensorId(const Avtp_Gisf_t* const pdu) {
-    return (uint16_t) GET_GISF_FIELD(AVTP_GISF_FIELD_IMAGE_SENSOR_ID);
+OPEN1722_INLINE uint16_t Avtp_Gisf_GetImageSensorId(const Avtp_Gisf_t *const pdu)
+{
+    return (uint16_t)GET_GISF_FIELD(AVTP_GISF_FIELD_IMAGE_SENSOR_ID);
 }
 
 /**
@@ -218,8 +226,9 @@ OPEN1722_INLINE uint16_t Avtp_Gisf_GetImageSensorId(const Avtp_Gisf_t* const pdu
  * @param pdu Pointer to an ACF_GISF message.
  * @returns The value of the message_timestamp field.
  */
-OPEN1722_INLINE uint64_t Avtp_Gisf_GetMessageTimestamp(const Avtp_Gisf_t* const pdu) {
-    return (uint64_t) GET_GISF_FIELD(AVTP_GISF_FIELD_MESSAGE_TIMESTAMP);
+OPEN1722_INLINE uint64_t Avtp_Gisf_GetMessageTimestamp(const Avtp_Gisf_t *const pdu)
+{
+    return (uint64_t)GET_GISF_FIELD(AVTP_GISF_FIELD_MESSAGE_TIMESTAMP);
 }
 
 /**
@@ -228,8 +237,9 @@ OPEN1722_INLINE uint64_t Avtp_Gisf_GetMessageTimestamp(const Avtp_Gisf_t* const 
  * @param pdu Pointer to an ACF_GISF message.
  * @returns The value of the el flag.
  */
-OPEN1722_INLINE bool Avtp_Gisf_IsEl(const Avtp_Gisf_t* const pdu) {
-    return (bool) GET_GISF_FIELD(AVTP_GISF_FIELD_EL);
+OPEN1722_INLINE bool Avtp_Gisf_IsEl(const Avtp_Gisf_t *const pdu)
+{
+    return (bool)GET_GISF_FIELD(AVTP_GISF_FIELD_EL);
 }
 
 /**
@@ -238,8 +248,9 @@ OPEN1722_INLINE bool Avtp_Gisf_IsEl(const Avtp_Gisf_t* const pdu) {
  * @param pdu Pointer to an ACF_GISF message.
  * @returns The value of the tl flag.
  */
-OPEN1722_INLINE bool Avtp_Gisf_IsTl(const Avtp_Gisf_t* const pdu) {
-    return (bool) GET_GISF_FIELD(AVTP_GISF_FIELD_TL);
+OPEN1722_INLINE bool Avtp_Gisf_IsTl(const Avtp_Gisf_t *const pdu)
+{
+    return (bool)GET_GISF_FIELD(AVTP_GISF_FIELD_TL);
 }
 
 /**
@@ -248,8 +259,9 @@ OPEN1722_INLINE bool Avtp_Gisf_IsTl(const Avtp_Gisf_t* const pdu) {
  * @param pdu Pointer to an ACF_GISF message.
  * @returns The value of the ef flag.
  */
-OPEN1722_INLINE bool Avtp_Gisf_IsEf(const Avtp_Gisf_t* const pdu) {
-    return (bool) GET_GISF_FIELD(AVTP_GISF_FIELD_EF);
+OPEN1722_INLINE bool Avtp_Gisf_IsEf(const Avtp_Gisf_t *const pdu)
+{
+    return (bool)GET_GISF_FIELD(AVTP_GISF_FIELD_EF);
 }
 
 /**
@@ -258,8 +270,9 @@ OPEN1722_INLINE bool Avtp_Gisf_IsEf(const Avtp_Gisf_t* const pdu) {
  * @param pdu Pointer to an ACF_GISF message.
  * @returns The value of the evt field.
  */
-OPEN1722_INLINE uint8_t Avtp_Gisf_GetEvt(const Avtp_Gisf_t* const pdu) {
-    return (uint8_t) GET_GISF_FIELD(AVTP_GISF_FIELD_EVT);
+OPEN1722_INLINE uint8_t Avtp_Gisf_GetEvt(const Avtp_Gisf_t *const pdu)
+{
+    return (uint8_t)GET_GISF_FIELD(AVTP_GISF_FIELD_EVT);
 }
 
 /**
@@ -268,8 +281,9 @@ OPEN1722_INLINE uint8_t Avtp_Gisf_GetEvt(const Avtp_Gisf_t* const pdu) {
  * @param pdu Pointer to an ACF_GISF message.
  * @returns The value of the bf flag.
  */
-OPEN1722_INLINE bool Avtp_Gisf_IsBf(const Avtp_Gisf_t* const pdu) {
-    return (bool) GET_GISF_FIELD(AVTP_GISF_FIELD_BF);
+OPEN1722_INLINE bool Avtp_Gisf_IsBf(const Avtp_Gisf_t *const pdu)
+{
+    return (bool)GET_GISF_FIELD(AVTP_GISF_FIELD_BF);
 }
 
 /**
@@ -278,8 +292,9 @@ OPEN1722_INLINE bool Avtp_Gisf_IsBf(const Avtp_Gisf_t* const pdu) {
  * @param pdu Pointer to an ACF_GISF message.
  * @returns The value of the line_type_id value.
  */
-OPEN1722_INLINE uint8_t Avtp_Gisf_GetLineTypeId(const Avtp_Gisf_t* const pdu) {
-    return (uint8_t) GET_GISF_FIELD(AVTP_GISF_FIELD_LINE_TYPE_ID);
+OPEN1722_INLINE uint8_t Avtp_Gisf_GetLineTypeId(const Avtp_Gisf_t *const pdu)
+{
+    return (uint8_t)GET_GISF_FIELD(AVTP_GISF_FIELD_LINE_TYPE_ID);
 }
 
 /**
@@ -288,18 +303,21 @@ OPEN1722_INLINE uint8_t Avtp_Gisf_GetLineTypeId(const Avtp_Gisf_t* const pdu) {
  * @param pdu Pointer to an ACF_GISF message.
  * @returns The value of the evt2 field.
  */
-OPEN1722_INLINE uint8_t Avtp_Gisf_GetEvt2(const Avtp_Gisf_t* const pdu) {
-    return (uint8_t) GET_GISF_FIELD(AVTP_GISF_FIELD_EVT2);
+OPEN1722_INLINE uint8_t Avtp_Gisf_GetEvt2(const Avtp_Gisf_t *const pdu)
+{
+    return (uint8_t)GET_GISF_FIELD(AVTP_GISF_FIELD_EVT2);
 }
 
 /**
- * Returns the value of the i_seq_num (intra line sequence number) field from an ACF_GISF message header.
+ * Returns the value of the i_seq_num (intra line sequence number) field from an ACF_GISF message
+ * header.
  *
  * @param pdu Pointer to an ACF_GISF message.
  * @returns The value of the i_seq_num field.
  */
-OPEN1722_INLINE uint8_t Avtp_Gisf_GetISeqNum(const Avtp_Gisf_t* const pdu) {
-    return (uint8_t) GET_GISF_FIELD(AVTP_GISF_FIELD_I_SEQ_NUM);
+OPEN1722_INLINE uint8_t Avtp_Gisf_GetISeqNum(const Avtp_Gisf_t *const pdu)
+{
+    return (uint8_t)GET_GISF_FIELD(AVTP_GISF_FIELD_I_SEQ_NUM);
 }
 
 /**
@@ -308,8 +326,9 @@ OPEN1722_INLINE uint8_t Avtp_Gisf_GetISeqNum(const Avtp_Gisf_t* const pdu) {
  * @param pdu Pointer to an ACF_GISF message.
  * @returns The value of the line_number field.
  */
-OPEN1722_INLINE uint16_t Avtp_Gisf_GetLineNumber(const Avtp_Gisf_t* const pdu) {
-    return (uint16_t) GET_GISF_FIELD(AVTP_GISF_FIELD_LINE_NUMBER);
+OPEN1722_INLINE uint16_t Avtp_Gisf_GetLineNumber(const Avtp_Gisf_t *const pdu)
+{
+    return (uint16_t)GET_GISF_FIELD(AVTP_GISF_FIELD_LINE_NUMBER);
 }
 
 /**
@@ -318,7 +337,8 @@ OPEN1722_INLINE uint16_t Avtp_Gisf_GetLineNumber(const Avtp_Gisf_t* const pdu) {
  * @param pdu Pointer to an ACF_GISF message.
  * @param mtv The value to set.
  */
-OPEN1722_INLINE void Avtp_Gisf_SetMtv(Avtp_Gisf_t* pdu, bool mtv) {
+OPEN1722_INLINE void Avtp_Gisf_SetMtv(Avtp_Gisf_t *pdu, bool mtv)
+{
     SET_GISF_FIELD(AVTP_GISF_FIELD_MTV, mtv);
 }
 
@@ -328,7 +348,8 @@ OPEN1722_INLINE void Avtp_Gisf_SetMtv(Avtp_Gisf_t* pdu, bool mtv) {
  * @param pdu Pointer to an ACF_GISF message.
  * @param imageSensorId The value to set.
  */
-OPEN1722_INLINE void Avtp_Gisf_SetImageSensorId(Avtp_Gisf_t* pdu, uint16_t imageSensorId) {
+OPEN1722_INLINE void Avtp_Gisf_SetImageSensorId(Avtp_Gisf_t *pdu, uint16_t imageSensorId)
+{
     SET_GISF_FIELD(AVTP_GISF_FIELD_IMAGE_SENSOR_ID, imageSensorId);
 }
 
@@ -338,7 +359,8 @@ OPEN1722_INLINE void Avtp_Gisf_SetImageSensorId(Avtp_Gisf_t* pdu, uint16_t image
  * @param pdu Pointer to an ACF_GISF message.
  * @param messageTimestamp The value to set.
  */
-OPEN1722_INLINE void Avtp_Gisf_SetMessageTimestamp(Avtp_Gisf_t* pdu, uint64_t messageTimestamp) {
+OPEN1722_INLINE void Avtp_Gisf_SetMessageTimestamp(Avtp_Gisf_t *pdu, uint64_t messageTimestamp)
+{
     SET_GISF_FIELD(AVTP_GISF_FIELD_MESSAGE_TIMESTAMP, messageTimestamp);
 }
 
@@ -348,7 +370,8 @@ OPEN1722_INLINE void Avtp_Gisf_SetMessageTimestamp(Avtp_Gisf_t* pdu, uint64_t me
  * @param pdu Pointer to an ACF_GISF message.
  * @param el The value to set.
  */
-OPEN1722_INLINE void Avtp_Gisf_SetEl(Avtp_Gisf_t* pdu, bool el) {
+OPEN1722_INLINE void Avtp_Gisf_SetEl(Avtp_Gisf_t *pdu, bool el)
+{
     SET_GISF_FIELD(AVTP_GISF_FIELD_EL, el);
 }
 
@@ -358,7 +381,8 @@ OPEN1722_INLINE void Avtp_Gisf_SetEl(Avtp_Gisf_t* pdu, bool el) {
  * @param pdu Pointer to an ACF_GISF message.
  * @param tl The value to set.
  */
-OPEN1722_INLINE void Avtp_Gisf_SetTl(Avtp_Gisf_t* pdu, bool tl) {
+OPEN1722_INLINE void Avtp_Gisf_SetTl(Avtp_Gisf_t *pdu, bool tl)
+{
     SET_GISF_FIELD(AVTP_GISF_FIELD_TL, tl);
 }
 
@@ -368,7 +392,8 @@ OPEN1722_INLINE void Avtp_Gisf_SetTl(Avtp_Gisf_t* pdu, bool tl) {
  * @param pdu Pointer to an ACF_GISF message.
  * @param ef The value to set.
  */
-OPEN1722_INLINE void Avtp_Gisf_SetEf(Avtp_Gisf_t* pdu, bool ef) {
+OPEN1722_INLINE void Avtp_Gisf_SetEf(Avtp_Gisf_t *pdu, bool ef)
+{
     SET_GISF_FIELD(AVTP_GISF_FIELD_EF, ef);
 }
 
@@ -378,7 +403,8 @@ OPEN1722_INLINE void Avtp_Gisf_SetEf(Avtp_Gisf_t* pdu, bool ef) {
  * @param pdu Pointer to an ACF_GISF message.
  * @param evt The value to set.
  */
-OPEN1722_INLINE void Avtp_Gisf_SetEvt(Avtp_Gisf_t* pdu, uint8_t evt) {
+OPEN1722_INLINE void Avtp_Gisf_SetEvt(Avtp_Gisf_t *pdu, uint8_t evt)
+{
     SET_GISF_FIELD(AVTP_GISF_FIELD_EVT, evt);
 }
 
@@ -388,7 +414,8 @@ OPEN1722_INLINE void Avtp_Gisf_SetEvt(Avtp_Gisf_t* pdu, uint8_t evt) {
  * @param pdu Pointer to an ACF_GISF message.
  * @param bf The value to set.
  */
-OPEN1722_INLINE void Avtp_Gisf_SetBf(Avtp_Gisf_t* pdu, bool bf) {
+OPEN1722_INLINE void Avtp_Gisf_SetBf(Avtp_Gisf_t *pdu, bool bf)
+{
     SET_GISF_FIELD(AVTP_GISF_FIELD_BF, bf);
 }
 
@@ -398,7 +425,8 @@ OPEN1722_INLINE void Avtp_Gisf_SetBf(Avtp_Gisf_t* pdu, bool bf) {
  * @param pdu Pointer to an ACF_GISF message.
  * @param lineTypeId The value to set.
  */
-OPEN1722_INLINE void Avtp_Gisf_SetLineTypeId(Avtp_Gisf_t* pdu, uint8_t lineTypeId) {
+OPEN1722_INLINE void Avtp_Gisf_SetLineTypeId(Avtp_Gisf_t *pdu, uint8_t lineTypeId)
+{
     SET_GISF_FIELD(AVTP_GISF_FIELD_LINE_TYPE_ID, lineTypeId);
 }
 
@@ -408,7 +436,8 @@ OPEN1722_INLINE void Avtp_Gisf_SetLineTypeId(Avtp_Gisf_t* pdu, uint8_t lineTypeI
  * @param pdu Pointer to an ACF_GISF message.
  * @param evt2 The value to set.
  */
-OPEN1722_INLINE void Avtp_Gisf_SetEvt2(Avtp_Gisf_t* pdu, uint8_t evt2) {
+OPEN1722_INLINE void Avtp_Gisf_SetEvt2(Avtp_Gisf_t *pdu, uint8_t evt2)
+{
     SET_GISF_FIELD(AVTP_GISF_FIELD_EVT2, evt2);
 }
 
@@ -418,7 +447,8 @@ OPEN1722_INLINE void Avtp_Gisf_SetEvt2(Avtp_Gisf_t* pdu, uint8_t evt2) {
  * @param pdu Pointer to an ACF_GISF message.
  * @param iSeqNum The value to set.
  */
-OPEN1722_INLINE void Avtp_Gisf_SetISeqNum(Avtp_Gisf_t* pdu, uint8_t iSeqNum) {
+OPEN1722_INLINE void Avtp_Gisf_SetISeqNum(Avtp_Gisf_t *pdu, uint8_t iSeqNum)
+{
     SET_GISF_FIELD(AVTP_GISF_FIELD_I_SEQ_NUM, iSeqNum);
 }
 
@@ -428,7 +458,8 @@ OPEN1722_INLINE void Avtp_Gisf_SetISeqNum(Avtp_Gisf_t* pdu, uint8_t iSeqNum) {
  * @param pdu Pointer to an ACF_GISF message.
  * @param lineNumber The value to set.
  */
-OPEN1722_INLINE void Avtp_Gisf_SetLineNumber(Avtp_Gisf_t* pdu, uint16_t lineNumber) {
+OPEN1722_INLINE void Avtp_Gisf_SetLineNumber(Avtp_Gisf_t *pdu, uint16_t lineNumber)
+{
     SET_GISF_FIELD(AVTP_GISF_FIELD_LINE_NUMBER, lineNumber);
 }
 
@@ -438,7 +469,7 @@ OPEN1722_INLINE void Avtp_Gisf_SetLineNumber(Avtp_Gisf_t* pdu, uint16_t lineNumb
  * @param pdu Pointer to the first bit of a 1722 ACF GISF PDU.
  * @return Pointer to ACF GISF frame payload
  */
-OPEN1722_INLINE const uint8_t *Avtp_Gisf_GetPayload(const Avtp_Gisf_t* const pdu)
+OPEN1722_INLINE const uint8_t *Avtp_Gisf_GetPayload(const Avtp_Gisf_t *const pdu)
 {
     return pdu->payload;
 }
@@ -488,7 +519,7 @@ OPEN1722_INLINE void Avtp_Gisf_SetPayloadLength(Avtp_Gisf_t *pdu, uint16_t paylo
  * @param pdu Pointer to the first bit of a 1722 ACF GISF PDU.
  * @return  Length of payload in bytes
  */
-OPEN1722_INLINE uint16_t Avtp_Gisf_GetPayloadLength(const Avtp_Gisf_t* const pdu)
+OPEN1722_INLINE uint16_t Avtp_Gisf_GetPayloadLength(const Avtp_Gisf_t *const pdu)
 {
     uint8_t pad_length = Avtp_Gisf_GetPad(pdu);
     uint16_t acf_length_bytes = Avtp_Gisf_GetAcfMsgLengthInBytes(pdu);
@@ -500,7 +531,7 @@ OPEN1722_INLINE uint16_t Avtp_Gisf_GetPayloadLength(const Avtp_Gisf_t* const pdu
  *
  * @param pdu Pointer to the first bit of a 1722 ACF GISF PDU.
  */
-OPEN1722_INLINE void Avtp_Gisf_Init(Avtp_Gisf_t* pdu)
+OPEN1722_INLINE void Avtp_Gisf_Init(Avtp_Gisf_t *pdu)
 {
     if (pdu != NULL) {
         memset(pdu, 0, sizeof(Avtp_Gisf_t));
@@ -542,7 +573,7 @@ OPEN1722_INLINE void Avtp_Gisf_CreateAcfMessage(Avtp_Gisf_t *pdu, uint16_t image
  * @param bufferSize Size of the buffer containing the ACF GISF frame.
  * @return true if the ACF GISF frame is valid, false otherwise.
  */
-OPEN1722_INLINE bool Avtp_Gisf_IsValid(const Avtp_Gisf_t* const pdu, size_t bufferSize)
+OPEN1722_INLINE bool Avtp_Gisf_IsValid(const Avtp_Gisf_t *const pdu, size_t bufferSize)
 {
     if (pdu == NULL) {
         return false;

--- a/unit/test-gisf.c
+++ b/unit/test-gisf.c
@@ -38,593 +38,437 @@ extern "C" {
 #include <cmocka.h>
 #include <stdio.h>
 
-static void Test_Gisf_Init(void** state)
+static void Test_Gisf_Init(void **state)
 {
     const size_t msg_len = AVTP_GISF_HEADER_LEN + 4;
     uint8_t msg[msg_len] = {0};
-    Avtp_Gisf_t* gisf = (Avtp_Gisf_t*)msg;
+    Avtp_Gisf_t *gisf = (Avtp_Gisf_t *)msg;
 
     // Check init function while passing in a null pointer
     Avtp_Gisf_Init(NULL);
 
     Avtp_Gisf_Init(gisf);
 
-    uint8_t expected_msg[msg_len] = {
-        0x18, 0x00, 0x0,  0x0,
-        0x0,  0x0,  0x0,  0x0,
-        0x0,  0x0,  0x0,  0x0,
-        0x0,  0x0,  0x0,  0x0,
-        0x0,  0x0,  0x0,  0x0,
-        0x0,  0x0,  0x0,  0x0
-    };
+    uint8_t expected_msg[msg_len] = {0x18, 0x00, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0,
+                                     0x0,  0x0,  0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0};
 
     assert_memory_equal(msg, expected_msg, msg_len);
 }
 
-static void Test_Gisf_GetAcfMsgType(void** state)
+static void Test_Gisf_GetAcfMsgType(void **state)
 {
     const size_t msg_len = AVTP_GISF_HEADER_LEN + 4;
     uint8_t msg[msg_len] = {
-        0x18, 0x05, 0x0,  0x0,
-        0x0,  0x0,  0x0,  0x0,
-        0x0,  0x0,  0x0,  0x0,
-        0x0,  0x0,  0x0,  0x0,
-        0x0,  0x0,  0x0,  0x0,
-        0x0,  0x0,  0x0,  0x0,
+        0x18, 0x05, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0,
+        0x0,  0x0,  0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0,
     };
-    Avtp_Gisf_t* gisf = (Avtp_Gisf_t*)msg;
+    Avtp_Gisf_t *gisf = (Avtp_Gisf_t *)msg;
     assert_int_equal(Avtp_Gisf_GetAcfMsgType(gisf), AVTP_ACF_TYPE_GISF);
 }
 
-static void Test_Gisf_GetAcfMsgLength(void** state)
+static void Test_Gisf_GetAcfMsgLength(void **state)
 {
     const size_t msg_len = AVTP_GISF_HEADER_LEN + 4;
     uint8_t msg[msg_len] = {
-        0x18, 0x05, 0x0,  0x0,
-        0x0,  0x0,  0x0,  0x0,
-        0x0,  0x0,  0x0,  0x0,
-        0x0,  0x0,  0x0,  0x0,
-        0x0,  0x0,  0x0,  0x0,
-        0x0,  0x0,  0x0,  0x0,
+        0x18, 0x05, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0,
+        0x0,  0x0,  0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0,
     };
-    Avtp_Gisf_t* gisf = (Avtp_Gisf_t*)msg;
+    Avtp_Gisf_t *gisf = (Avtp_Gisf_t *)msg;
     assert_int_equal(Avtp_Gisf_GetAcfMsgLength(gisf), 5);
 }
 
-static void Test_Gisf_GetPad(void** state)
+static void Test_Gisf_GetPad(void **state)
 {
     const size_t msg_len = AVTP_GISF_HEADER_LEN + 4;
     uint8_t msg[msg_len] = {
-        0x18, 0x06, 0xC0, 0x0,
-        0x0,  0x0,  0x0,  0x0,
-        0x0,  0x0,  0x0,  0x0,
-        0x0,  0x0,  0x0,  0x0,
-        0x0,  0x0,  0x0,  0x0,
-        0x0,  0x0,  0x0,  0x0,
+        0x18, 0x06, 0xC0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0,
+        0x0,  0x0,  0x0,  0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0,
     };
-    Avtp_Gisf_t* gisf = (Avtp_Gisf_t*)msg;
+    Avtp_Gisf_t *gisf = (Avtp_Gisf_t *)msg;
     assert_int_equal(Avtp_Gisf_GetPad(gisf), 3);
 }
 
-static void Test_Gisf_IsMtv(void** state)
+static void Test_Gisf_IsMtv(void **state)
 {
     const size_t msg_len = AVTP_GISF_HEADER_LEN + 4;
     uint8_t msg[msg_len] = {
-        0x18, 0x05, 0x20, 0x0,
-        0x0,  0x0,  0x0,  0x0,
-        0x0,  0x0,  0x0,  0x0,
-        0x0,  0x0,  0x0,  0x0,
-        0x0,  0x0,  0x0,  0x0,
-        0x0,  0x0,  0x0,  0x0,
+        0x18, 0x05, 0x20, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0,
+        0x0,  0x0,  0x0,  0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0,
     };
-    Avtp_Gisf_t* gisf = (Avtp_Gisf_t*)msg;
+    Avtp_Gisf_t *gisf = (Avtp_Gisf_t *)msg;
     assert_int_equal(Avtp_Gisf_IsMtv(gisf), true);
 }
 
-static void Test_Gisf_GetImageSensorId(void** state)
+static void Test_Gisf_GetImageSensorId(void **state)
 {
     const size_t msg_len = AVTP_GISF_HEADER_LEN + 4;
     uint8_t msg[msg_len] = {
-        0x18, 0x05, 0x5,  0xFF,
-        0x0,  0x0,  0x0,  0x0,
-        0x0,  0x0,  0x0,  0x0,
-        0x0,  0x0,  0x0,  0x0,
-        0x0,  0x0,  0x0,  0x0,
-        0x0,  0x0,  0x0,  0x0,
+        0x18, 0x05, 0x5, 0xFF, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0,
+        0x0,  0x0,  0x0, 0x0,  0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0,
     };
-    Avtp_Gisf_t* gisf = (Avtp_Gisf_t*)msg;
+    Avtp_Gisf_t *gisf = (Avtp_Gisf_t *)msg;
     assert_int_equal(Avtp_Gisf_GetImageSensorId(gisf), 0x5FF);
 }
 
-static void Test_Gisf_GetMessageTimestamp(void** state)
+static void Test_Gisf_GetMessageTimestamp(void **state)
 {
     const size_t msg_len = AVTP_GISF_HEADER_LEN + 4;
     uint8_t msg[msg_len] = {
-        0x18, 0x05, 0x0,  0x0,
-        0xBF, 0xFF, 0xFF, 0xFF,
-        0xFF, 0xFF, 0xFF, 0xFF,
-        0x0,  0x0,  0x0,  0x0,
-        0x0,  0x0,  0x0,  0x0,
-        0x0,  0x0,  0x0,  0x0,
+        0x18, 0x05, 0x0, 0x0, 0xBF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF,
+        0x0,  0x0,  0x0, 0x0, 0x0,  0x0,  0x0,  0x0,  0x0,  0x0,  0x0,  0x0,
     };
-    Avtp_Gisf_t* gisf = (Avtp_Gisf_t*)msg;
+    Avtp_Gisf_t *gisf = (Avtp_Gisf_t *)msg;
     assert_int_equal(Avtp_Gisf_GetMessageTimestamp(gisf), 0xBFFFFFFFFFFFFFFFull);
 }
 
-static void Test_Gisf_IsEl(void** state)
+static void Test_Gisf_IsEl(void **state)
 {
     const size_t msg_len = AVTP_GISF_HEADER_LEN + 4;
     uint8_t msg[msg_len] = {
-        0x18, 0x05, 0x0,  0x0,
-        0x0,  0x0,  0x0,  0x0,
-        0x0,  0x0,  0x0,  0x0,
-        0x0,  0x0,  0x40, 0x0,
-        0x0,  0x0,  0x0,  0x0,
-        0x0,  0x0,  0x0,  0x0,
+        0x18, 0x05, 0x0,  0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0,
+        0x0,  0x0,  0x40, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0,
     };
-    Avtp_Gisf_t* gisf = (Avtp_Gisf_t*)msg;
+    Avtp_Gisf_t *gisf = (Avtp_Gisf_t *)msg;
     assert_int_equal(Avtp_Gisf_IsEl(gisf), true);
 }
 
-static void Test_Gisf_IsTl(void** state)
+static void Test_Gisf_IsTl(void **state)
 {
     const size_t msg_len = AVTP_GISF_HEADER_LEN + 4;
     uint8_t msg[msg_len] = {
-        0x18, 0x05, 0x0,  0x0,
-        0x0,  0x0,  0x0,  0x0,
-        0x0,  0x0,  0x0,  0x0,
-        0x0,  0x0,  0x20, 0x0,
-        0x0,  0x0,  0x0,  0x0,
-        0x0,  0x0,  0x0,  0x0,
+        0x18, 0x05, 0x0,  0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0,
+        0x0,  0x0,  0x20, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0,
     };
-    Avtp_Gisf_t* gisf = (Avtp_Gisf_t*)msg;
+    Avtp_Gisf_t *gisf = (Avtp_Gisf_t *)msg;
     assert_int_equal(Avtp_Gisf_IsTl(gisf), true);
 }
 
-static void Test_Gisf_IsEf(void** state)
+static void Test_Gisf_IsEf(void **state)
 {
     const size_t msg_len = AVTP_GISF_HEADER_LEN + 4;
     uint8_t msg[msg_len] = {
-        0x18, 0x05, 0x0,  0x0,
-        0x0,  0x0,  0x0,  0x0,
-        0x0,  0x0,  0x0,  0x0,
-        0x0,  0x0,  0x10, 0x0,
-        0x0,  0x0,  0x0,  0x0,
-        0x0,  0x0,  0x0,  0x0,
+        0x18, 0x05, 0x0,  0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0,
+        0x0,  0x0,  0x10, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0,
     };
-    Avtp_Gisf_t* gisf = (Avtp_Gisf_t*)msg;
+    Avtp_Gisf_t *gisf = (Avtp_Gisf_t *)msg;
     assert_int_equal(Avtp_Gisf_IsEf(gisf), true);
 }
 
-static void Test_Gisf_GetEvt(void** state)
+static void Test_Gisf_GetEvt(void **state)
 {
     const size_t msg_len = AVTP_GISF_HEADER_LEN + 4;
     uint8_t msg[msg_len] = {
-        0x18, 0x05, 0x0,  0x0,
-        0x0,  0x0,  0x0,  0x0,
-        0x0,  0x0,  0x0,  0x0,
-        0x0,  0x0,  0xB,  0x0,
-        0x0,  0x0,  0x0,  0x0,
-        0x0,  0x0,  0x0,  0x0,
+        0x18, 0x05, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0,
+        0x0,  0x0,  0xB, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0,
     };
-    Avtp_Gisf_t* gisf = (Avtp_Gisf_t*)msg;
+    Avtp_Gisf_t *gisf = (Avtp_Gisf_t *)msg;
     assert_int_equal(Avtp_Gisf_GetEvt(gisf), 0xB);
 }
 
-static void Test_Gisf_IsBf(void** state)
+static void Test_Gisf_IsBf(void **state)
 {
     const size_t msg_len = AVTP_GISF_HEADER_LEN + 4;
     uint8_t msg[msg_len] = {
-        0x18, 0x05, 0x0,  0x0,
-        0x0,  0x0,  0x0,  0x0,
-        0x0,  0x0,  0x0,  0x0,
-        0x0,  0x0,  0x0,  0x20,
-        0x0,  0x0,  0x0,  0x0,
-        0x0,  0x0,  0x0,  0x0,
+        0x18, 0x05, 0x0, 0x0,  0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0,
+        0x0,  0x0,  0x0, 0x20, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0,
     };
-    Avtp_Gisf_t* gisf = (Avtp_Gisf_t*)msg;
+    Avtp_Gisf_t *gisf = (Avtp_Gisf_t *)msg;
     assert_int_equal(Avtp_Gisf_IsBf(gisf), true);
 }
 
-static void Test_Gisf_GetLineTypeId(void** state)
+static void Test_Gisf_GetLineTypeId(void **state)
 {
     const size_t msg_len = AVTP_GISF_HEADER_LEN + 4;
     uint8_t msg[msg_len] = {
-        0x18, 0x05, 0x0,  0x0,
-        0x0,  0x0,  0x0,  0x0,
-        0x0,  0x0,  0x0,  0x0,
-        0x0,  0x0,  0x0,  0x17,
-        0x0,  0x0,  0x0,  0x0,
-        0x0,  0x0,  0x0,  0x0,
+        0x18, 0x05, 0x0, 0x0,  0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0,
+        0x0,  0x0,  0x0, 0x17, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0,
     };
-    Avtp_Gisf_t* gisf = (Avtp_Gisf_t*)msg;
+    Avtp_Gisf_t *gisf = (Avtp_Gisf_t *)msg;
     assert_int_equal(Avtp_Gisf_GetLineTypeId(gisf), 0x17);
 }
 
-static void Test_Gisf_GetEvt2(void** state)
+static void Test_Gisf_GetEvt2(void **state)
 {
     const size_t msg_len = AVTP_GISF_HEADER_LEN + 4;
     uint8_t msg[msg_len] = {
-        0x18, 0x05, 0x0,  0x0,
-        0x0,  0x0,  0x0,  0x0,
-        0x0,  0x0,  0x0,  0x0,
-        0x0,  0x0,  0x0,  0x0,
-        0xBF, 0x0,  0x0,  0x0,
-        0x0,  0x0,  0x0,  0x0,
+        0x18, 0x05, 0x0, 0x0, 0x0,  0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0,
+        0x0,  0x0,  0x0, 0x0, 0xBF, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0,
     };
-    Avtp_Gisf_t* gisf = (Avtp_Gisf_t*)msg;
+    Avtp_Gisf_t *gisf = (Avtp_Gisf_t *)msg;
     assert_int_equal(Avtp_Gisf_GetEvt2(gisf), 0xBF);
 }
 
-static void Test_Gisf_GetISeqNum(void** state)
+static void Test_Gisf_GetISeqNum(void **state)
 {
     const size_t msg_len = AVTP_GISF_HEADER_LEN + 4;
     uint8_t msg[msg_len] = {
-        0x18, 0x05, 0x0,  0x0,
-        0x0,  0x0,  0x0,  0x0,
-        0x0,  0x0,  0x0,  0x0,
-        0x0,  0x0,  0x0,  0x0,
-        0x0,  0xBF, 0x0,  0x0,
-        0x0,  0x0,  0x0,  0x0,
+        0x18, 0x05, 0x0, 0x0, 0x0, 0x0,  0x0, 0x0, 0x0, 0x0, 0x0, 0x0,
+        0x0,  0x0,  0x0, 0x0, 0x0, 0xBF, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0,
     };
-    Avtp_Gisf_t* gisf = (Avtp_Gisf_t*)msg;
+    Avtp_Gisf_t *gisf = (Avtp_Gisf_t *)msg;
     assert_int_equal(Avtp_Gisf_GetISeqNum(gisf), 0xBF);
 }
 
-static void Test_Gisf_GetLineNumber(void** state)
+static void Test_Gisf_GetLineNumber(void **state)
 {
     const size_t msg_len = AVTP_GISF_HEADER_LEN + 4;
     uint8_t msg[msg_len] = {
-        0x18, 0x05, 0x0,  0x0,
-        0x0,  0x0,  0x0,  0x0,
-        0x0,  0x0,  0x0,  0x0,
-        0x0,  0x0,  0x0,  0x0,
-        0x0,  0x0,  0xBF, 0xFF,
-        0x0,  0x0,  0x0,  0x0,
+        0x18, 0x05, 0x0, 0x0, 0x0, 0x0, 0x0,  0x0,  0x0, 0x0, 0x0, 0x0,
+        0x0,  0x0,  0x0, 0x0, 0x0, 0x0, 0xBF, 0xFF, 0x0, 0x0, 0x0, 0x0,
     };
-    Avtp_Gisf_t* gisf = (Avtp_Gisf_t*)msg;
+    Avtp_Gisf_t *gisf = (Avtp_Gisf_t *)msg;
     assert_int_equal(Avtp_Gisf_GetLineNumber(gisf), 0xBFFFul);
 }
 
-static void Test_Gisf_GetPayloadLength(void** state)
+static void Test_Gisf_GetPayloadLength(void **state)
 {
     const size_t msg_len = AVTP_GISF_HEADER_LEN + 4;
     uint8_t msg[msg_len] = {
-        0x18, 0x06, 0xC0, 0x0,
-        0x0,  0x0,  0x0,  0x0,
-        0x0,  0x0,  0x0,  0x0,
-        0x0,  0x0,  0x0,  0x0,
-        0x0,  0x0,  0xBF, 0xFF,
-        0x0,  0x0,  0x0,  0x0,
+        0x18, 0x06, 0xC0, 0x0, 0x0, 0x0, 0x0,  0x0,  0x0, 0x0, 0x0, 0x0,
+        0x0,  0x0,  0x0,  0x0, 0x0, 0x0, 0xBF, 0xFF, 0x0, 0x0, 0x0, 0x0,
     };
-    Avtp_Gisf_t* gisf = (Avtp_Gisf_t*)msg;
+    Avtp_Gisf_t *gisf = (Avtp_Gisf_t *)msg;
     assert_int_equal(Avtp_Gisf_GetPayloadLength(gisf), 1);
 }
 
-static void Test_Gisf_GetPayloadLength_NoPadding(void** state)
+static void Test_Gisf_GetPayloadLength_NoPadding(void **state)
 {
     const size_t msg_len = AVTP_GISF_HEADER_LEN + 4;
     uint8_t msg[msg_len] = {
-        0x18, 0x06, 0x0,  0x0,
-        0x0,  0x0,  0x0,  0x0,
-        0x0,  0x0,  0x0,  0x0,
-        0x0,  0x0,  0x0,  0x0,
-        0x0,  0x0,  0xBF, 0xFF,
-        0x0,  0x0,  0x0,  0x0,
+        0x18, 0x06, 0x0, 0x0, 0x0, 0x0, 0x0,  0x0,  0x0, 0x0, 0x0, 0x0,
+        0x0,  0x0,  0x0, 0x0, 0x0, 0x0, 0xBF, 0xFF, 0x0, 0x0, 0x0, 0x0,
     };
-    Avtp_Gisf_t* gisf = (Avtp_Gisf_t*)msg;
+    Avtp_Gisf_t *gisf = (Avtp_Gisf_t *)msg;
     assert_int_equal(Avtp_Gisf_GetPayloadLength(gisf), 4);
 }
 
-static void Test_Gisf_GetAcfMsgLengthInBytes(void** state)
+static void Test_Gisf_GetAcfMsgLengthInBytes(void **state)
 {
     const size_t msg_len = AVTP_GISF_HEADER_LEN + 4;
     uint8_t msg[msg_len] = {
-        0x18, 0x06, 0xC0, 0x0,
-        0x0,  0x0,  0x0,  0x0,
-        0x0,  0x0,  0x0,  0x0,
-        0x0,  0x0,  0x0,  0x0,
-        0x0,  0x0,  0xBF, 0xFF,
-        0x0,  0x0,  0x0,  0x0,
+        0x18, 0x06, 0xC0, 0x0, 0x0, 0x0, 0x0,  0x0,  0x0, 0x0, 0x0, 0x0,
+        0x0,  0x0,  0x0,  0x0, 0x0, 0x0, 0xBF, 0xFF, 0x0, 0x0, 0x0, 0x0,
     };
-    Avtp_Gisf_t* gisf = (Avtp_Gisf_t*)msg;
+    Avtp_Gisf_t *gisf = (Avtp_Gisf_t *)msg;
     assert_int_equal(Avtp_Gisf_GetAcfMsgLengthInBytes(gisf), 6 * 4);
 }
 
-static void Test_Gisf_SetAcfMsgType(void** state)
+static void Test_Gisf_SetAcfMsgType(void **state)
 {
     const size_t msg_len = AVTP_GISF_HEADER_LEN + 4;
     uint8_t msg[msg_len] = {0};
-    Avtp_Gisf_t* gisf = (Avtp_Gisf_t*)msg;
+    Avtp_Gisf_t *gisf = (Avtp_Gisf_t *)msg;
     Avtp_Gisf_Init(gisf);
     Avtp_Gisf_SetAcfMsgType(gisf, AVTP_ACF_TYPE_GISF);
     assert_int_equal(Avtp_Gisf_GetAcfMsgType(gisf), AVTP_ACF_TYPE_GISF);
 }
 
-static void Test_Gisf_SetAcfMsgLength(void** state)
+static void Test_Gisf_SetAcfMsgLength(void **state)
 {
     const size_t msg_len = AVTP_GISF_HEADER_LEN + 4;
     uint8_t msg[msg_len] = {0};
-    Avtp_Gisf_t* gisf = (Avtp_Gisf_t*)msg;
+    Avtp_Gisf_t *gisf = (Avtp_Gisf_t *)msg;
     Avtp_Gisf_Init(gisf);
     Avtp_Gisf_SetAcfMsgLength(gisf, 5);
     assert_int_equal(Avtp_Gisf_GetAcfMsgLength(gisf), 5);
     assert_int_equal(Avtp_Gisf_GetAcfMsgLengthInBytes(gisf), 20);
 }
 
-static void Test_Gisf_SetMtv(void** state)
+static void Test_Gisf_SetMtv(void **state)
 {
     const size_t msg_len = AVTP_GISF_HEADER_LEN + 4;
     uint8_t msg[msg_len] = {0};
-    Avtp_Gisf_t* gisf = (Avtp_Gisf_t*)msg;
+    Avtp_Gisf_t *gisf = (Avtp_Gisf_t *)msg;
     Avtp_Gisf_Init(gisf);
     Avtp_Gisf_SetMtv(gisf, true);
 
-    uint8_t expected_msg[msg_len] = {
-        0x18, 0x00, 0x20, 0x0,
-        0x0,  0x0,  0x0,  0x0,
-        0x0,  0x0,  0x0,  0x0,
-        0x0,  0x0,  0x0,  0x0,
-        0x0,  0x0,  0x0,  0x0,
-        0x0,  0x0,  0x0,  0x0
-    };
+    uint8_t expected_msg[msg_len] = {0x18, 0x00, 0x20, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0,
+                                     0x0,  0x0,  0x0,  0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0};
     assert_memory_equal(msg, expected_msg, msg_len);
 }
 
-static void Test_Gisf_SetImageSensorId(void** state)
+static void Test_Gisf_SetImageSensorId(void **state)
 {
     const size_t msg_len = AVTP_GISF_HEADER_LEN + 4;
     uint8_t msg[msg_len] = {0};
-    Avtp_Gisf_t* gisf = (Avtp_Gisf_t*)msg;
+    Avtp_Gisf_t *gisf = (Avtp_Gisf_t *)msg;
     Avtp_Gisf_Init(gisf);
     Avtp_Gisf_SetImageSensorId(gisf, 0x5FF);
 
-    uint8_t expected_msg[msg_len] = {
-        0x18, 0x00, 0x5,  0xFF,
-        0x0,  0x0,  0x0,  0x0,
-        0x0,  0x0,  0x0,  0x0,
-        0x0,  0x0,  0x0,  0x0,
-        0x0,  0x0,  0x0,  0x0,
-        0x0,  0x0,  0x0,  0x0
-    };
+    uint8_t expected_msg[msg_len] = {0x18, 0x00, 0x5, 0xFF, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0,
+                                     0x0,  0x0,  0x0, 0x0,  0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0};
     assert_memory_equal(msg, expected_msg, msg_len);
 }
 
-static void Test_Gisf_SetMessageTimestamp(void** state)
+static void Test_Gisf_SetMessageTimestamp(void **state)
 {
     const size_t msg_len = AVTP_GISF_HEADER_LEN + 4;
     uint8_t msg[msg_len] = {0};
-    Avtp_Gisf_t* gisf = (Avtp_Gisf_t*)msg;
+    Avtp_Gisf_t *gisf = (Avtp_Gisf_t *)msg;
     Avtp_Gisf_Init(gisf);
     Avtp_Gisf_SetMessageTimestamp(gisf, 0xBFFFFFFFFFFFFFFFull);
 
-    uint8_t expected_msg[msg_len] = {
-        0x18, 0x00, 0x0,  0x0,
-        0xBF, 0xFF, 0xFF, 0xFF,
-        0xFF, 0xFF, 0xFF, 0xFF,
-        0x0,  0x0,  0x0,  0x0,
-        0x0,  0x0,  0x0,  0x0,
-        0x0,  0x0,  0x0,  0x0
-    };
+    uint8_t expected_msg[msg_len] = {0x18, 0x00, 0x0,  0x0,  0xBF, 0xFF, 0xFF, 0xFF,
+                                     0xFF, 0xFF, 0xFF, 0xFF, 0x0,  0x0,  0x0,  0x0,
+                                     0x0,  0x0,  0x0,  0x0,  0x0,  0x0,  0x0,  0x0};
 
     assert_memory_equal(msg, expected_msg, msg_len);
 }
 
-static void Test_Gisf_SetEl(void** state)
+static void Test_Gisf_SetEl(void **state)
 {
     const size_t msg_len = AVTP_GISF_HEADER_LEN + 4;
     uint8_t msg[msg_len] = {0};
-    Avtp_Gisf_t* gisf = (Avtp_Gisf_t*)msg;
+    Avtp_Gisf_t *gisf = (Avtp_Gisf_t *)msg;
     Avtp_Gisf_Init(gisf);
     Avtp_Gisf_SetEl(gisf, true);
 
-    uint8_t expected_msg[msg_len] = {
-        0x18, 0x00, 0x0,  0x0,
-        0x0,  0x0,  0x0,  0x0,
-        0x0,  0x0,  0x0,  0x0,
-        0x0,  0x0,  0x40,  0x0,
-        0x0,  0x0,  0x0,  0x0,
-        0x0,  0x0,  0x0,  0x0
-    };
+    uint8_t expected_msg[msg_len] = {0x18, 0x00, 0x0,  0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0,
+                                     0x0,  0x0,  0x40, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0};
     assert_memory_equal(msg, expected_msg, msg_len);
 }
 
-static void Test_Gisf_SetTl(void** state)
+static void Test_Gisf_SetTl(void **state)
 {
     const size_t msg_len = AVTP_GISF_HEADER_LEN + 4;
     uint8_t msg[msg_len] = {0};
-    Avtp_Gisf_t* gisf = (Avtp_Gisf_t*)msg;
+    Avtp_Gisf_t *gisf = (Avtp_Gisf_t *)msg;
     Avtp_Gisf_Init(gisf);
     Avtp_Gisf_SetTl(gisf, true);
 
-    uint8_t expected_msg[msg_len] = {
-        0x18, 0x00, 0x0,  0x0,
-        0x0,  0x0,  0x0,  0x0,
-        0x0,  0x0,  0x0,  0x0,
-        0x0,  0x0,  0x20,  0x0,
-        0x0,  0x0,  0x0,  0x0,
-        0x0,  0x0,  0x0,  0x0
-    };
+    uint8_t expected_msg[msg_len] = {0x18, 0x00, 0x0,  0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0,
+                                     0x0,  0x0,  0x20, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0};
     assert_memory_equal(msg, expected_msg, msg_len);
 }
 
-static void Test_Gisf_SetEf(void** state)
+static void Test_Gisf_SetEf(void **state)
 {
     const size_t msg_len = AVTP_GISF_HEADER_LEN + 4;
     uint8_t msg[msg_len] = {0};
-    Avtp_Gisf_t* gisf = (Avtp_Gisf_t*)msg;
+    Avtp_Gisf_t *gisf = (Avtp_Gisf_t *)msg;
     Avtp_Gisf_Init(gisf);
     Avtp_Gisf_SetEf(gisf, true);
 
-    uint8_t expected_msg[msg_len] = {
-        0x18, 0x00, 0x0,  0x0,
-        0x0,  0x0,  0x0,  0x0,
-        0x0,  0x0,  0x0,  0x0,
-        0x0,  0x0,  0x10,  0x0,
-        0x0,  0x0,  0x0,  0x0,
-        0x0,  0x0,  0x0,  0x0
-    };
+    uint8_t expected_msg[msg_len] = {0x18, 0x00, 0x0,  0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0,
+                                     0x0,  0x0,  0x10, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0};
     assert_memory_equal(msg, expected_msg, msg_len);
 }
 
-static void Test_Gisf_SetEvt(void** state)
+static void Test_Gisf_SetEvt(void **state)
 {
     const size_t msg_len = AVTP_GISF_HEADER_LEN + 4;
     uint8_t msg[msg_len] = {0};
-    Avtp_Gisf_t* gisf = (Avtp_Gisf_t*)msg;
+    Avtp_Gisf_t *gisf = (Avtp_Gisf_t *)msg;
     Avtp_Gisf_Init(gisf);
     Avtp_Gisf_SetEvt(gisf, 0xB);
 
-    uint8_t expected_msg[msg_len] = {
-        0x18, 0x00, 0x0,  0x0,
-        0x0,  0x0,  0x0,  0x0,
-        0x0,  0x0,  0x0,  0x0,
-        0x0,  0x0,  0xB,  0x0,
-        0x0,  0x0,  0x0,  0x0,
-        0x0,  0x0,  0x0,  0x0
-    };
+    uint8_t expected_msg[msg_len] = {0x18, 0x00, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0,
+                                     0x0,  0x0,  0xB, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0};
     assert_memory_equal(msg, expected_msg, msg_len);
 }
 
-static void Test_Gisf_SetBf(void** state)
+static void Test_Gisf_SetBf(void **state)
 {
     const size_t msg_len = AVTP_GISF_HEADER_LEN + 4;
     uint8_t msg[msg_len] = {0};
-    Avtp_Gisf_t* gisf = (Avtp_Gisf_t*)msg;
+    Avtp_Gisf_t *gisf = (Avtp_Gisf_t *)msg;
     Avtp_Gisf_Init(gisf);
     Avtp_Gisf_SetBf(gisf, true);
 
-    uint8_t expected_msg[msg_len] = {
-        0x18, 0x00, 0x0,  0x0,
-        0x0,  0x0,  0x0,  0x0,
-        0x0,  0x0,  0x0,  0x0,
-        0x0,  0x0,  0x0,  0x20,
-        0x0,  0x0,  0x0,  0x0,
-        0x0,  0x0,  0x0,  0x0
-    };
+    uint8_t expected_msg[msg_len] = {0x18, 0x00, 0x0, 0x0,  0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0,
+                                     0x0,  0x0,  0x0, 0x20, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0};
     assert_memory_equal(msg, expected_msg, msg_len);
 }
 
-static void Test_Gisf_SetLineTypeId(void** state)
+static void Test_Gisf_SetLineTypeId(void **state)
 {
     const size_t msg_len = AVTP_GISF_HEADER_LEN + 4;
     uint8_t msg[msg_len] = {0};
-    Avtp_Gisf_t* gisf = (Avtp_Gisf_t*)msg;
+    Avtp_Gisf_t *gisf = (Avtp_Gisf_t *)msg;
     Avtp_Gisf_Init(gisf);
     Avtp_Gisf_SetLineTypeId(gisf, 0x17);
 
-    uint8_t expected_msg[msg_len] = {
-        0x18, 0x00, 0x0,  0x0,
-        0x0,  0x0,  0x0,  0x0,
-        0x0,  0x0,  0x0,  0x0,
-        0x0,  0x0,  0x0,  0x17,
-        0x0,  0x0,  0x0,  0x0,
-        0x0,  0x0,  0x0,  0x0
-    };
+    uint8_t expected_msg[msg_len] = {0x18, 0x00, 0x0, 0x0,  0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0,
+                                     0x0,  0x0,  0x0, 0x17, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0};
     assert_memory_equal(msg, expected_msg, msg_len);
 }
 
-static void Test_Gisf_SetEvt2(void** state)
+static void Test_Gisf_SetEvt2(void **state)
 {
     const size_t msg_len = AVTP_GISF_HEADER_LEN + 4;
     uint8_t msg[msg_len] = {0};
-    Avtp_Gisf_t* gisf = (Avtp_Gisf_t*)msg;
+    Avtp_Gisf_t *gisf = (Avtp_Gisf_t *)msg;
     Avtp_Gisf_Init(gisf);
     Avtp_Gisf_SetEvt2(gisf, 0xBF);
 
-    uint8_t expected_msg[msg_len] = {
-        0x18, 0x00, 0x0,  0x0,
-        0x0,  0x0,  0x0,  0x0,
-        0x0,  0x0,  0x0,  0x0,
-        0x0,  0x0,  0x0,  0x0,
-        0xBF, 0x0,  0x0,  0x0,
-        0x0,  0x0,  0x0,  0x0
-    };
+    uint8_t expected_msg[msg_len] = {0x18, 0x00, 0x0, 0x0, 0x0,  0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0,
+                                     0x0,  0x0,  0x0, 0x0, 0xBF, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0};
     assert_memory_equal(msg, expected_msg, msg_len);
 }
 
-static void Test_Gisf_SetISeqNum(void** state)
+static void Test_Gisf_SetISeqNum(void **state)
 {
     const size_t msg_len = AVTP_GISF_HEADER_LEN + 4;
     uint8_t msg[msg_len] = {0};
-    Avtp_Gisf_t* gisf = (Avtp_Gisf_t*)msg;
+    Avtp_Gisf_t *gisf = (Avtp_Gisf_t *)msg;
     Avtp_Gisf_Init(gisf);
     Avtp_Gisf_SetISeqNum(gisf, 0xBF);
 
-    uint8_t expected_msg[msg_len] = {
-        0x18, 0x00, 0x0,  0x0,
-        0x0,  0x0,  0x0,  0x0,
-        0x0,  0x0,  0x0,  0x0,
-        0x0,  0x0,  0x0,  0x0,
-        0x0,  0xBF, 0x0,  0x0,
-        0x0,  0x0,  0x0,  0x0
-    };
+    uint8_t expected_msg[msg_len] = {0x18, 0x00, 0x0, 0x0, 0x0, 0x0,  0x0, 0x0, 0x0, 0x0, 0x0, 0x0,
+                                     0x0,  0x0,  0x0, 0x0, 0x0, 0xBF, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0};
     assert_memory_equal(msg, expected_msg, msg_len);
 }
 
-static void Test_Gisf_SetLineNumber(void** state)
+static void Test_Gisf_SetLineNumber(void **state)
 {
     const size_t msg_len = AVTP_GISF_HEADER_LEN + 4;
     uint8_t msg[msg_len] = {0};
-    Avtp_Gisf_t* gisf = (Avtp_Gisf_t*)msg;
+    Avtp_Gisf_t *gisf = (Avtp_Gisf_t *)msg;
     Avtp_Gisf_Init(gisf);
     Avtp_Gisf_SetLineNumber(gisf, 0xBFFF);
 
-    uint8_t expected_msg[msg_len] = {
-        0x18, 0x00, 0x0,  0x0,
-        0x0,  0x0,  0x0,  0x0,
-        0x0,  0x0,  0x0,  0x0,
-        0x0,  0x0,  0x0,  0x0,
-        0x0,  0x0,  0xBF, 0xFF,
-        0x0,  0x0,  0x0,  0x0
-    };
+    uint8_t expected_msg[msg_len] = {0x18, 0x00, 0x0,  0x0,  0x0, 0x0, 0x0, 0x0,
+                                     0x0,  0x0,  0x0,  0x0,  0x0, 0x0, 0x0, 0x0,
+                                     0x0,  0x0,  0xBF, 0xFF, 0x0, 0x0, 0x0, 0x0};
     assert_memory_equal(msg, expected_msg, msg_len);
 }
 
-static void Test_Gisf_SetPayloadLength(void** state)
+static void Test_Gisf_SetPayloadLength(void **state)
 {
     const size_t msg_len = AVTP_GISF_HEADER_LEN + 4;
     uint8_t msg[msg_len] = {0};
-    Avtp_Gisf_t* gisf = (Avtp_Gisf_t*)msg;
+    Avtp_Gisf_t *gisf = (Avtp_Gisf_t *)msg;
     Avtp_Gisf_Init(gisf);
     Avtp_Gisf_SetPayloadLength(gisf, 3);
 
     uint8_t expected_msg[msg_len] = {
-        0x18, 0x06, 0x40, 0x0,
-        0x0,  0x0,  0x0,  0x0,
-        0x0,  0x0,  0x0,  0x0,
-        0x0,  0x0,  0x0,  0x0,
-        0x0,  0x0,  0x0,  0x0,
-        0x0,  0x0,  0x0,  0x0,
+        0x18, 0x06, 0x40, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0,
+        0x0,  0x0,  0x0,  0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0,
     };
     assert_memory_equal(msg, expected_msg, msg_len);
 }
 
-static void Test_Gisf_SetPayloadLength_NoPadding(void** state)
+static void Test_Gisf_SetPayloadLength_NoPadding(void **state)
 {
     const size_t msg_len = AVTP_GISF_HEADER_LEN + 4;
     uint8_t msg[msg_len] = {0};
-    Avtp_Gisf_t* gisf = (Avtp_Gisf_t*)msg;
+    Avtp_Gisf_t *gisf = (Avtp_Gisf_t *)msg;
     Avtp_Gisf_Init(gisf);
     Avtp_Gisf_SetPayloadLength(gisf, 4);
 
     uint8_t expected_msg[msg_len] = {
-        0x18, 0x06, 0x0,  0x0,
-        0x0,  0x0,  0x0,  0x0,
-        0x0,  0x0,  0x0,  0x0,
-        0x0,  0x0,  0x0,  0x0,
-        0x0,  0x0,  0x0,  0x0,
-        0x0,  0x0,  0x0,  0x0,
+        0x18, 0x06, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0,
+        0x0,  0x0,  0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0,
     };
     assert_memory_equal(msg, expected_msg, msg_len);
 }
 
-static void Test_Gisf_Payload(void** state)
+static void Test_Gisf_Payload(void **state)
 {
     const size_t msg_len = AVTP_GISF_HEADER_LEN + 8;
     uint8_t msg[msg_len] = {0};
-    Avtp_Gisf_t* gisf = (Avtp_Gisf_t*)msg;
-    uint8_t payload[8] = {0,1,2,3,4,5,6,7};
+    Avtp_Gisf_t *gisf = (Avtp_Gisf_t *)msg;
+    uint8_t payload[8] = {0, 1, 2, 3, 4, 5, 6, 7};
 
     Avtp_Gisf_Init(gisf);
     Avtp_Gisf_SetPayload(gisf, payload, sizeof(payload));
@@ -633,12 +477,12 @@ static void Test_Gisf_Payload(void** state)
     assert_memory_equal(payload, Avtp_Gisf_GetPayload(gisf), sizeof(payload));
 }
 
-static void Test_Gisf_CreateAcfMessage(void** state)
+static void Test_Gisf_CreateAcfMessage(void **state)
 {
     const size_t msg_len = AVTP_GISF_HEADER_LEN + 8;
     uint8_t msg[msg_len] = {0};
-    Avtp_Gisf_t* gisf = (Avtp_Gisf_t*)msg;
-    uint8_t payload[8] = {0,1,2,3,4,5,6,7};
+    Avtp_Gisf_t *gisf = (Avtp_Gisf_t *)msg;
+    uint8_t payload[8] = {0, 1, 2, 3, 4, 5, 6, 7};
 
     Avtp_Gisf_CreateAcfMessage(gisf, 0x5FF, payload, sizeof(payload));
 
@@ -649,12 +493,12 @@ static void Test_Gisf_CreateAcfMessage(void** state)
     assert_int_equal(Avtp_Gisf_IsValid(gisf, msg_len), 1);
 }
 
-static void Test_Gisf_CreateFromGarbage(void** state)
+static void Test_Gisf_CreateFromGarbage(void **state)
 {
     const size_t msg_len = AVTP_GISF_HEADER_LEN + 8;
     uint8_t msg[msg_len];
-    Avtp_Gisf_t* gisf = (Avtp_Gisf_t*)msg;
-    uint8_t payload[8] = {0,1,2,3,4,5,6,7};
+    Avtp_Gisf_t *gisf = (Avtp_Gisf_t *)msg;
+    uint8_t payload[8] = {0, 1, 2, 3, 4, 5, 6, 7};
 
     // CreateAcfMessage must fully initialize the header even on garbage input.
     memset(msg, 0xAA, msg_len);
@@ -671,12 +515,12 @@ static void Test_Gisf_CreateFromGarbage(void** state)
     assert_int_equal(Avtp_Gisf_IsValid(gisf, msg_len), 1);
 }
 
-static void Test_Gisf_IsValid(void** state)
+static void Test_Gisf_IsValid(void **state)
 {
     const size_t msg_len = AVTP_GISF_HEADER_LEN + 32;
     uint8_t msg[msg_len] = {0};
-    Avtp_Gisf_t* gisf = (Avtp_Gisf_t*)msg;
-    uint8_t payload[8] = {0,1,2,3,4,5,6,7};
+    Avtp_Gisf_t *gisf = (Avtp_Gisf_t *)msg;
+    uint8_t payload[8] = {0, 1, 2, 3, 4, 5, 6, 7};
 
     // An Init-only PDU has AcfMsgLength == 0, so IsValid must reject it.
     Avtp_Gisf_Init(gisf);
@@ -697,47 +541,45 @@ static void Test_Gisf_IsValid(void** state)
 
 int main(void)
 {
-    const struct CMUnitTest tests[] = {
-        cmocka_unit_test(Test_Gisf_Init),
-        cmocka_unit_test(Test_Gisf_GetAcfMsgType),
-        cmocka_unit_test(Test_Gisf_GetAcfMsgLength),
-        cmocka_unit_test(Test_Gisf_GetPad),
-        cmocka_unit_test(Test_Gisf_IsMtv),
-        cmocka_unit_test(Test_Gisf_GetImageSensorId),
-        cmocka_unit_test(Test_Gisf_GetMessageTimestamp),
-        cmocka_unit_test(Test_Gisf_IsEl),
-        cmocka_unit_test(Test_Gisf_IsTl),
-        cmocka_unit_test(Test_Gisf_IsEf),
-        cmocka_unit_test(Test_Gisf_GetEvt),
-        cmocka_unit_test(Test_Gisf_IsBf),
-        cmocka_unit_test(Test_Gisf_GetLineTypeId),
-        cmocka_unit_test(Test_Gisf_GetEvt2),
-        cmocka_unit_test(Test_Gisf_GetISeqNum),
-        cmocka_unit_test(Test_Gisf_GetLineNumber),
-        cmocka_unit_test(Test_Gisf_GetPayloadLength),
-        cmocka_unit_test(Test_Gisf_GetPayloadLength_NoPadding),
-        cmocka_unit_test(Test_Gisf_GetAcfMsgLengthInBytes),
-        cmocka_unit_test(Test_Gisf_SetAcfMsgType),
-        cmocka_unit_test(Test_Gisf_SetAcfMsgLength),
-        cmocka_unit_test(Test_Gisf_SetMtv),
-        cmocka_unit_test(Test_Gisf_SetImageSensorId),
-        cmocka_unit_test(Test_Gisf_SetMessageTimestamp),
-        cmocka_unit_test(Test_Gisf_SetEl),
-        cmocka_unit_test(Test_Gisf_SetTl),
-        cmocka_unit_test(Test_Gisf_SetEf),
-        cmocka_unit_test(Test_Gisf_SetEvt),
-        cmocka_unit_test(Test_Gisf_SetBf),
-        cmocka_unit_test(Test_Gisf_SetLineTypeId),
-        cmocka_unit_test(Test_Gisf_SetEvt2),
-        cmocka_unit_test(Test_Gisf_SetISeqNum),
-        cmocka_unit_test(Test_Gisf_SetLineNumber),
-        cmocka_unit_test(Test_Gisf_SetPayloadLength),
-        cmocka_unit_test(Test_Gisf_SetPayloadLength_NoPadding),
-        cmocka_unit_test(Test_Gisf_Payload),
-        cmocka_unit_test(Test_Gisf_CreateAcfMessage),
-        cmocka_unit_test(Test_Gisf_CreateFromGarbage),
-        cmocka_unit_test(Test_Gisf_IsValid)
-    };
+    const struct CMUnitTest tests[] = {cmocka_unit_test(Test_Gisf_Init),
+                                       cmocka_unit_test(Test_Gisf_GetAcfMsgType),
+                                       cmocka_unit_test(Test_Gisf_GetAcfMsgLength),
+                                       cmocka_unit_test(Test_Gisf_GetPad),
+                                       cmocka_unit_test(Test_Gisf_IsMtv),
+                                       cmocka_unit_test(Test_Gisf_GetImageSensorId),
+                                       cmocka_unit_test(Test_Gisf_GetMessageTimestamp),
+                                       cmocka_unit_test(Test_Gisf_IsEl),
+                                       cmocka_unit_test(Test_Gisf_IsTl),
+                                       cmocka_unit_test(Test_Gisf_IsEf),
+                                       cmocka_unit_test(Test_Gisf_GetEvt),
+                                       cmocka_unit_test(Test_Gisf_IsBf),
+                                       cmocka_unit_test(Test_Gisf_GetLineTypeId),
+                                       cmocka_unit_test(Test_Gisf_GetEvt2),
+                                       cmocka_unit_test(Test_Gisf_GetISeqNum),
+                                       cmocka_unit_test(Test_Gisf_GetLineNumber),
+                                       cmocka_unit_test(Test_Gisf_GetPayloadLength),
+                                       cmocka_unit_test(Test_Gisf_GetPayloadLength_NoPadding),
+                                       cmocka_unit_test(Test_Gisf_GetAcfMsgLengthInBytes),
+                                       cmocka_unit_test(Test_Gisf_SetAcfMsgType),
+                                       cmocka_unit_test(Test_Gisf_SetAcfMsgLength),
+                                       cmocka_unit_test(Test_Gisf_SetMtv),
+                                       cmocka_unit_test(Test_Gisf_SetImageSensorId),
+                                       cmocka_unit_test(Test_Gisf_SetMessageTimestamp),
+                                       cmocka_unit_test(Test_Gisf_SetEl),
+                                       cmocka_unit_test(Test_Gisf_SetTl),
+                                       cmocka_unit_test(Test_Gisf_SetEf),
+                                       cmocka_unit_test(Test_Gisf_SetEvt),
+                                       cmocka_unit_test(Test_Gisf_SetBf),
+                                       cmocka_unit_test(Test_Gisf_SetLineTypeId),
+                                       cmocka_unit_test(Test_Gisf_SetEvt2),
+                                       cmocka_unit_test(Test_Gisf_SetISeqNum),
+                                       cmocka_unit_test(Test_Gisf_SetLineNumber),
+                                       cmocka_unit_test(Test_Gisf_SetPayloadLength),
+                                       cmocka_unit_test(Test_Gisf_SetPayloadLength_NoPadding),
+                                       cmocka_unit_test(Test_Gisf_Payload),
+                                       cmocka_unit_test(Test_Gisf_CreateAcfMessage),
+                                       cmocka_unit_test(Test_Gisf_CreateFromGarbage),
+                                       cmocka_unit_test(Test_Gisf_IsValid)};
 
     return cmocka_run_group_tests(tests, NULL, NULL);
 }

--- a/unit/test-gisf.c
+++ b/unit/test-gisf.c
@@ -30,7 +30,7 @@
 #ifdef __cplusplus
 extern "C" {
 #endif
-    
+
 #include "avtp/acf/Gisf.h"
 #include <stdarg.h>
 #include <stddef.h>
@@ -43,10 +43,14 @@ static void Test_Gisf_Init(void** state)
     const size_t msg_len = AVTP_GISF_HEADER_LEN + 4;
     uint8_t msg[msg_len] = {0};
     Avtp_Gisf_t* gisf = (Avtp_Gisf_t*)msg;
+
+    // Check init function while passing in a null pointer
+    Avtp_Gisf_Init(NULL);
+
     Avtp_Gisf_Init(gisf);
 
     uint8_t expected_msg[msg_len] = {
-        0x18, 0x05, 0x0,  0x0,
+        0x18, 0x00, 0x0,  0x0,
         0x0,  0x0,  0x0,  0x0,
         0x0,  0x0,  0x0,  0x0,
         0x0,  0x0,  0x0,  0x0,
@@ -55,6 +59,36 @@ static void Test_Gisf_Init(void** state)
     };
 
     assert_memory_equal(msg, expected_msg, msg_len);
+}
+
+static void Test_Gisf_GetAcfMsgType(void** state)
+{
+    const size_t msg_len = AVTP_GISF_HEADER_LEN + 4;
+    uint8_t msg[msg_len] = {
+        0x18, 0x05, 0x0,  0x0,
+        0x0,  0x0,  0x0,  0x0,
+        0x0,  0x0,  0x0,  0x0,
+        0x0,  0x0,  0x0,  0x0,
+        0x0,  0x0,  0x0,  0x0,
+        0x0,  0x0,  0x0,  0x0,
+    };
+    Avtp_Gisf_t* gisf = (Avtp_Gisf_t*)msg;
+    assert_int_equal(Avtp_Gisf_GetAcfMsgType(gisf), AVTP_ACF_TYPE_GISF);
+}
+
+static void Test_Gisf_GetAcfMsgLength(void** state)
+{
+    const size_t msg_len = AVTP_GISF_HEADER_LEN + 4;
+    uint8_t msg[msg_len] = {
+        0x18, 0x05, 0x0,  0x0,
+        0x0,  0x0,  0x0,  0x0,
+        0x0,  0x0,  0x0,  0x0,
+        0x0,  0x0,  0x0,  0x0,
+        0x0,  0x0,  0x0,  0x0,
+        0x0,  0x0,  0x0,  0x0,
+    };
+    Avtp_Gisf_t* gisf = (Avtp_Gisf_t*)msg;
+    assert_int_equal(Avtp_Gisf_GetAcfMsgLength(gisf), 5);
 }
 
 static void Test_Gisf_GetPad(void** state)
@@ -252,7 +286,7 @@ static void Test_Gisf_GetLineNumber(void** state)
     assert_int_equal(Avtp_Gisf_GetLineNumber(gisf), 0xBFFFul);
 }
 
-static void Test_Gisf_GetPayloadLen(void** state)
+static void Test_Gisf_GetPayloadLength(void** state)
 {
     const size_t msg_len = AVTP_GISF_HEADER_LEN + 4;
     uint8_t msg[msg_len] = {
@@ -264,10 +298,10 @@ static void Test_Gisf_GetPayloadLen(void** state)
         0x0,  0x0,  0x0,  0x0,
     };
     Avtp_Gisf_t* gisf = (Avtp_Gisf_t*)msg;
-    assert_int_equal(Avtp_Gisf_GetPayloadLen(gisf), 1);
+    assert_int_equal(Avtp_Gisf_GetPayloadLength(gisf), 1);
 }
 
-static void Test_Gisf_GetPayloadLen_NoPadding(void** state)
+static void Test_Gisf_GetPayloadLength_NoPadding(void** state)
 {
     const size_t msg_len = AVTP_GISF_HEADER_LEN + 4;
     uint8_t msg[msg_len] = {
@@ -279,10 +313,10 @@ static void Test_Gisf_GetPayloadLen_NoPadding(void** state)
         0x0,  0x0,  0x0,  0x0,
     };
     Avtp_Gisf_t* gisf = (Avtp_Gisf_t*)msg;
-    assert_int_equal(Avtp_Gisf_GetPayloadLen(gisf), 4);
+    assert_int_equal(Avtp_Gisf_GetPayloadLength(gisf), 4);
 }
 
-static void Test_Gisf_GetLen(void** state)
+static void Test_Gisf_GetAcfMsgLengthInBytes(void** state)
 {
     const size_t msg_len = AVTP_GISF_HEADER_LEN + 4;
     uint8_t msg[msg_len] = {
@@ -294,7 +328,28 @@ static void Test_Gisf_GetLen(void** state)
         0x0,  0x0,  0x0,  0x0,
     };
     Avtp_Gisf_t* gisf = (Avtp_Gisf_t*)msg;
-    assert_int_equal(Avtp_Gisf_GetLen(gisf), 6 * 4);
+    assert_int_equal(Avtp_Gisf_GetAcfMsgLengthInBytes(gisf), 6 * 4);
+}
+
+static void Test_Gisf_SetAcfMsgType(void** state)
+{
+    const size_t msg_len = AVTP_GISF_HEADER_LEN + 4;
+    uint8_t msg[msg_len] = {0};
+    Avtp_Gisf_t* gisf = (Avtp_Gisf_t*)msg;
+    Avtp_Gisf_Init(gisf);
+    Avtp_Gisf_SetAcfMsgType(gisf, AVTP_ACF_TYPE_GISF);
+    assert_int_equal(Avtp_Gisf_GetAcfMsgType(gisf), AVTP_ACF_TYPE_GISF);
+}
+
+static void Test_Gisf_SetAcfMsgLength(void** state)
+{
+    const size_t msg_len = AVTP_GISF_HEADER_LEN + 4;
+    uint8_t msg[msg_len] = {0};
+    Avtp_Gisf_t* gisf = (Avtp_Gisf_t*)msg;
+    Avtp_Gisf_Init(gisf);
+    Avtp_Gisf_SetAcfMsgLength(gisf, 5);
+    assert_int_equal(Avtp_Gisf_GetAcfMsgLength(gisf), 5);
+    assert_int_equal(Avtp_Gisf_GetAcfMsgLengthInBytes(gisf), 20);
 }
 
 static void Test_Gisf_SetMtv(void** state)
@@ -306,7 +361,7 @@ static void Test_Gisf_SetMtv(void** state)
     Avtp_Gisf_SetMtv(gisf, true);
 
     uint8_t expected_msg[msg_len] = {
-        0x18, 0x05, 0x20, 0x0,
+        0x18, 0x00, 0x20, 0x0,
         0x0,  0x0,  0x0,  0x0,
         0x0,  0x0,  0x0,  0x0,
         0x0,  0x0,  0x0,  0x0,
@@ -325,7 +380,7 @@ static void Test_Gisf_SetImageSensorId(void** state)
     Avtp_Gisf_SetImageSensorId(gisf, 0x5FF);
 
     uint8_t expected_msg[msg_len] = {
-        0x18, 0x05, 0x5,  0xFF,
+        0x18, 0x00, 0x5,  0xFF,
         0x0,  0x0,  0x0,  0x0,
         0x0,  0x0,  0x0,  0x0,
         0x0,  0x0,  0x0,  0x0,
@@ -344,7 +399,7 @@ static void Test_Gisf_SetMessageTimestamp(void** state)
     Avtp_Gisf_SetMessageTimestamp(gisf, 0xBFFFFFFFFFFFFFFFull);
 
     uint8_t expected_msg[msg_len] = {
-        0x18, 0x05, 0x0,  0x0,
+        0x18, 0x00, 0x0,  0x0,
         0xBF, 0xFF, 0xFF, 0xFF,
         0xFF, 0xFF, 0xFF, 0xFF,
         0x0,  0x0,  0x0,  0x0,
@@ -364,7 +419,7 @@ static void Test_Gisf_SetEl(void** state)
     Avtp_Gisf_SetEl(gisf, true);
 
     uint8_t expected_msg[msg_len] = {
-        0x18, 0x05, 0x0,  0x0,
+        0x18, 0x00, 0x0,  0x0,
         0x0,  0x0,  0x0,  0x0,
         0x0,  0x0,  0x0,  0x0,
         0x0,  0x0,  0x40,  0x0,
@@ -383,7 +438,7 @@ static void Test_Gisf_SetTl(void** state)
     Avtp_Gisf_SetTl(gisf, true);
 
     uint8_t expected_msg[msg_len] = {
-        0x18, 0x05, 0x0,  0x0,
+        0x18, 0x00, 0x0,  0x0,
         0x0,  0x0,  0x0,  0x0,
         0x0,  0x0,  0x0,  0x0,
         0x0,  0x0,  0x20,  0x0,
@@ -402,7 +457,7 @@ static void Test_Gisf_SetEf(void** state)
     Avtp_Gisf_SetEf(gisf, true);
 
     uint8_t expected_msg[msg_len] = {
-        0x18, 0x05, 0x0,  0x0,
+        0x18, 0x00, 0x0,  0x0,
         0x0,  0x0,  0x0,  0x0,
         0x0,  0x0,  0x0,  0x0,
         0x0,  0x0,  0x10,  0x0,
@@ -421,7 +476,7 @@ static void Test_Gisf_SetEvt(void** state)
     Avtp_Gisf_SetEvt(gisf, 0xB);
 
     uint8_t expected_msg[msg_len] = {
-        0x18, 0x05, 0x0,  0x0,
+        0x18, 0x00, 0x0,  0x0,
         0x0,  0x0,  0x0,  0x0,
         0x0,  0x0,  0x0,  0x0,
         0x0,  0x0,  0xB,  0x0,
@@ -440,7 +495,7 @@ static void Test_Gisf_SetBf(void** state)
     Avtp_Gisf_SetBf(gisf, true);
 
     uint8_t expected_msg[msg_len] = {
-        0x18, 0x05, 0x0,  0x0,
+        0x18, 0x00, 0x0,  0x0,
         0x0,  0x0,  0x0,  0x0,
         0x0,  0x0,  0x0,  0x0,
         0x0,  0x0,  0x0,  0x20,
@@ -459,7 +514,7 @@ static void Test_Gisf_SetLineTypeId(void** state)
     Avtp_Gisf_SetLineTypeId(gisf, 0x17);
 
     uint8_t expected_msg[msg_len] = {
-        0x18, 0x05, 0x0,  0x0,
+        0x18, 0x00, 0x0,  0x0,
         0x0,  0x0,  0x0,  0x0,
         0x0,  0x0,  0x0,  0x0,
         0x0,  0x0,  0x0,  0x17,
@@ -478,7 +533,7 @@ static void Test_Gisf_SetEvt2(void** state)
     Avtp_Gisf_SetEvt2(gisf, 0xBF);
 
     uint8_t expected_msg[msg_len] = {
-        0x18, 0x05, 0x0,  0x0,
+        0x18, 0x00, 0x0,  0x0,
         0x0,  0x0,  0x0,  0x0,
         0x0,  0x0,  0x0,  0x0,
         0x0,  0x0,  0x0,  0x0,
@@ -497,7 +552,7 @@ static void Test_Gisf_SetISeqNum(void** state)
     Avtp_Gisf_SetISeqNum(gisf, 0xBF);
 
     uint8_t expected_msg[msg_len] = {
-        0x18, 0x05, 0x0,  0x0,
+        0x18, 0x00, 0x0,  0x0,
         0x0,  0x0,  0x0,  0x0,
         0x0,  0x0,  0x0,  0x0,
         0x0,  0x0,  0x0,  0x0,
@@ -516,7 +571,7 @@ static void Test_Gisf_SetLineNumber(void** state)
     Avtp_Gisf_SetLineNumber(gisf, 0xBFFF);
 
     uint8_t expected_msg[msg_len] = {
-        0x18, 0x05, 0x0,  0x0,
+        0x18, 0x00, 0x0,  0x0,
         0x0,  0x0,  0x0,  0x0,
         0x0,  0x0,  0x0,  0x0,
         0x0,  0x0,  0x0,  0x0,
@@ -526,13 +581,13 @@ static void Test_Gisf_SetLineNumber(void** state)
     assert_memory_equal(msg, expected_msg, msg_len);
 }
 
-static void Test_Gisf_SetPayloadLen(void** state)
+static void Test_Gisf_SetPayloadLength(void** state)
 {
     const size_t msg_len = AVTP_GISF_HEADER_LEN + 4;
     uint8_t msg[msg_len] = {0};
     Avtp_Gisf_t* gisf = (Avtp_Gisf_t*)msg;
     Avtp_Gisf_Init(gisf);
-    Avtp_Gisf_SetPayloadLen(gisf, 3);
+    Avtp_Gisf_SetPayloadLength(gisf, 3);
 
     uint8_t expected_msg[msg_len] = {
         0x18, 0x06, 0x40, 0x0,
@@ -545,13 +600,13 @@ static void Test_Gisf_SetPayloadLen(void** state)
     assert_memory_equal(msg, expected_msg, msg_len);
 }
 
-static void Test_Gisf_SetPayloadLen_NoPadding(void** state)
+static void Test_Gisf_SetPayloadLength_NoPadding(void** state)
 {
     const size_t msg_len = AVTP_GISF_HEADER_LEN + 4;
     uint8_t msg[msg_len] = {0};
     Avtp_Gisf_t* gisf = (Avtp_Gisf_t*)msg;
     Avtp_Gisf_Init(gisf);
-    Avtp_Gisf_SetPayloadLen(gisf, 4);
+    Avtp_Gisf_SetPayloadLength(gisf, 4);
 
     uint8_t expected_msg[msg_len] = {
         0x18, 0x06, 0x0,  0x0,
@@ -564,10 +619,88 @@ static void Test_Gisf_SetPayloadLen_NoPadding(void** state)
     assert_memory_equal(msg, expected_msg, msg_len);
 }
 
+static void Test_Gisf_Payload(void** state)
+{
+    const size_t msg_len = AVTP_GISF_HEADER_LEN + 8;
+    uint8_t msg[msg_len] = {0};
+    Avtp_Gisf_t* gisf = (Avtp_Gisf_t*)msg;
+    uint8_t payload[8] = {0,1,2,3,4,5,6,7};
+
+    Avtp_Gisf_Init(gisf);
+    Avtp_Gisf_SetPayload(gisf, payload, sizeof(payload));
+
+    assert_ptr_equal(Avtp_Gisf_GetPayload(gisf), msg + AVTP_GISF_HEADER_LEN);
+    assert_memory_equal(payload, Avtp_Gisf_GetPayload(gisf), sizeof(payload));
+}
+
+static void Test_Gisf_CreateAcfMessage(void** state)
+{
+    const size_t msg_len = AVTP_GISF_HEADER_LEN + 8;
+    uint8_t msg[msg_len] = {0};
+    Avtp_Gisf_t* gisf = (Avtp_Gisf_t*)msg;
+    uint8_t payload[8] = {0,1,2,3,4,5,6,7};
+
+    Avtp_Gisf_CreateAcfMessage(gisf, 0x5FF, payload, sizeof(payload));
+
+    assert_int_equal(Avtp_Gisf_GetAcfMsgType(gisf), AVTP_ACF_TYPE_GISF);
+    assert_int_equal(Avtp_Gisf_GetImageSensorId(gisf), 0x5FF);
+    assert_memory_equal(payload, msg + AVTP_GISF_HEADER_LEN, sizeof(payload));
+    assert_int_equal(Avtp_Gisf_GetPayloadLength(gisf), 8);
+    assert_int_equal(Avtp_Gisf_IsValid(gisf, msg_len), 1);
+}
+
+static void Test_Gisf_CreateFromGarbage(void** state)
+{
+    const size_t msg_len = AVTP_GISF_HEADER_LEN + 8;
+    uint8_t msg[msg_len];
+    Avtp_Gisf_t* gisf = (Avtp_Gisf_t*)msg;
+    uint8_t payload[8] = {0,1,2,3,4,5,6,7};
+
+    // CreateAcfMessage must fully initialize the header even on garbage input.
+    memset(msg, 0xAA, msg_len);
+    Avtp_Gisf_CreateAcfMessage(gisf, 0x5FF, payload, sizeof(payload));
+
+    assert_int_equal(Avtp_Gisf_GetAcfMsgType(gisf), AVTP_ACF_TYPE_GISF);
+    assert_int_equal(Avtp_Gisf_IsMtv(gisf), false);
+    assert_int_equal(Avtp_Gisf_IsEl(gisf), false);
+    assert_int_equal(Avtp_Gisf_IsTl(gisf), false);
+    assert_int_equal(Avtp_Gisf_IsEf(gisf), false);
+    assert_int_equal(Avtp_Gisf_IsBf(gisf), false);
+    assert_int_equal(Avtp_Gisf_GetMessageTimestamp(gisf), 0);
+    assert_memory_equal(payload, msg + AVTP_GISF_HEADER_LEN, sizeof(payload));
+    assert_int_equal(Avtp_Gisf_IsValid(gisf, msg_len), 1);
+}
+
+static void Test_Gisf_IsValid(void** state)
+{
+    const size_t msg_len = AVTP_GISF_HEADER_LEN + 32;
+    uint8_t msg[msg_len] = {0};
+    Avtp_Gisf_t* gisf = (Avtp_Gisf_t*)msg;
+    uint8_t payload[8] = {0,1,2,3,4,5,6,7};
+
+    // An Init-only PDU has AcfMsgLength == 0, so IsValid must reject it.
+    Avtp_Gisf_Init(gisf);
+    assert_int_equal(Avtp_Gisf_IsValid(gisf, msg_len), 0);
+
+    // A properly-formed frame with an 8-byte payload is valid.
+    Avtp_Gisf_CreateAcfMessage(gisf, 0x5FF, payload, sizeof(payload));
+    assert_int_equal(Avtp_Gisf_IsValid(gisf, msg_len), 1);
+
+    // Not a GISF message (zero buffer, AcfMsgType != GISF).
+    memset(msg, 0, msg_len);
+    assert_int_equal(Avtp_Gisf_IsValid(gisf, msg_len), 0);
+
+    // Declared length larger than the buffer is invalid.
+    Avtp_Gisf_CreateAcfMessage(gisf, 0x5FF, payload, sizeof(payload));
+    assert_int_equal(Avtp_Gisf_IsValid(gisf, AVTP_GISF_HEADER_LEN + 1), 0);
+}
+
 int main(void)
 {
     const struct CMUnitTest tests[] = {
         cmocka_unit_test(Test_Gisf_Init),
+        cmocka_unit_test(Test_Gisf_GetAcfMsgType),
+        cmocka_unit_test(Test_Gisf_GetAcfMsgLength),
         cmocka_unit_test(Test_Gisf_GetPad),
         cmocka_unit_test(Test_Gisf_IsMtv),
         cmocka_unit_test(Test_Gisf_GetImageSensorId),
@@ -580,9 +713,12 @@ int main(void)
         cmocka_unit_test(Test_Gisf_GetLineTypeId),
         cmocka_unit_test(Test_Gisf_GetEvt2),
         cmocka_unit_test(Test_Gisf_GetISeqNum),
-        cmocka_unit_test(Test_Gisf_GetPayloadLen),
-        cmocka_unit_test(Test_Gisf_GetPayloadLen_NoPadding),
-        cmocka_unit_test(Test_Gisf_GetLen),
+        cmocka_unit_test(Test_Gisf_GetLineNumber),
+        cmocka_unit_test(Test_Gisf_GetPayloadLength),
+        cmocka_unit_test(Test_Gisf_GetPayloadLength_NoPadding),
+        cmocka_unit_test(Test_Gisf_GetAcfMsgLengthInBytes),
+        cmocka_unit_test(Test_Gisf_SetAcfMsgType),
+        cmocka_unit_test(Test_Gisf_SetAcfMsgLength),
         cmocka_unit_test(Test_Gisf_SetMtv),
         cmocka_unit_test(Test_Gisf_SetImageSensorId),
         cmocka_unit_test(Test_Gisf_SetMessageTimestamp),
@@ -595,8 +731,12 @@ int main(void)
         cmocka_unit_test(Test_Gisf_SetEvt2),
         cmocka_unit_test(Test_Gisf_SetISeqNum),
         cmocka_unit_test(Test_Gisf_SetLineNumber),
-        cmocka_unit_test(Test_Gisf_SetPayloadLen),
-        cmocka_unit_test(Test_Gisf_SetPayloadLen_NoPadding),
+        cmocka_unit_test(Test_Gisf_SetPayloadLength),
+        cmocka_unit_test(Test_Gisf_SetPayloadLength_NoPadding),
+        cmocka_unit_test(Test_Gisf_Payload),
+        cmocka_unit_test(Test_Gisf_CreateAcfMessage),
+        cmocka_unit_test(Test_Gisf_CreateFromGarbage),
+        cmocka_unit_test(Test_Gisf_IsValid)
     };
 
     return cmocka_run_group_tests(tests, NULL, NULL);


### PR DESCRIPTION

- packed struct; 
- renamed Avtp_GisfField_t→Avtp_GisfFields_t, __AVTP_GISF_FIELDS→Avtp_GisfFieldDesc, __Avtp_Gisf_GetField/SetField→GET_GISF_FIELD/SET_GISF_FIELD, msg→pdu; 
- added Get/SetAcfMsgType, Get/SetAcfMsgLength, GetAcfMsgLengthInBytes, GetPayload, SetPayload, SetPad; renamed GetLen→GetAcfMsgLengthInBytes, GetPayloadLen→GetPayloadLength (uint16_t), SetPayloadLen→SetPayloadLength (pad-zeroing); 
- added inline CreateAcfMessage (image_sensor_id + payload) and IsValid;
- unit/test-gisf.c:  Updated