### PR TITLE
VSS Api alignement

### DIFF
--- a/examples/acf-vss/acf-vss-talker.c
+++ b/examples/acf-vss/acf-vss-talker.c
@@ -48,13 +48,13 @@
 #include "avtp/CommonHeader.h"
 #include "avtp/acf/custom/Vss.h"
 
-#define MAX_PDU_SIZE                1500
-#define STREAM_ID                   0xAABBCCDDEEFF0001
+#define MAX_PDU_SIZE 1500
+#define STREAM_ID 0xAABBCCDDEEFF0001
 
 static char ifname[IFNAMSIZ];
 static uint8_t macaddr[ETH_ALEN];
 static uint8_t ip_addr[sizeof(struct in_addr)];
-static uint32_t udp_port=17220;
+static uint32_t udp_port = 17220;
 static int priority = -1;
 static uint8_t seq_num = 0;
 static uint32_t udp_seq_num = 0;
@@ -74,12 +74,12 @@ static char args_doc[] = "[ifname] dst-mac-address/dst-nw-address:port";
 
 static struct argp_option options[] = {
     {"tscf", 't', 0, 0, "Use TSCF"},
-    {"udp", 'u', 0, 0, "Use UDP" },
+    {"udp", 'u', 0, 0, "Use UDP"},
     {"ifname", 0, 0, OPTION_DOC, "Network interface (If Ethernet)"},
     {"dst-mac-address", 0, 0, OPTION_DOC, "Stream destination MAC address (If Ethernet)"},
-    {"dst-nw-address:port", 0, 0, OPTION_DOC, "Stream destination network address and port (If UDP)"},
-    { 0 }
-};
+    {"dst-nw-address:port", 0, 0, OPTION_DOC,
+     "Stream destination network address and port (If UDP)"},
+    {0}};
 
 static error_t parser(int key, char *arg, struct argp_state *state)
 {
@@ -98,19 +98,17 @@ static error_t parser(int key, char *arg, struct argp_state *state)
 
     case ARGP_KEY_ARG:
 
-        if(state->argc < 2){
+        if (state->argc < 2) {
             argp_usage(state);
         }
 
-        if(!use_udp){
+        if (!use_udp) {
 
             strncpy(ifname, arg, sizeof(ifname) - 1);
 
-            if(state->next < state->argc)
-            {
-                res = sscanf(state->argv[state->next], "%hhx:%hhx:%hhx:%hhx:%hhx:%hhx",
-                        &macaddr[0], &macaddr[1], &macaddr[2],
-                        &macaddr[3], &macaddr[4], &macaddr[5]);
+            if (state->next < state->argc) {
+                res = sscanf(state->argv[state->next], "%hhx:%hhx:%hhx:%hhx:%hhx:%hhx", &macaddr[0],
+                             &macaddr[1], &macaddr[2], &macaddr[3], &macaddr[4], &macaddr[5]);
                 if (res != 6) {
                     fprintf(stderr, "Invalid MAC address\n\n");
                     argp_usage(state);
@@ -137,13 +135,13 @@ static error_t parser(int key, char *arg, struct argp_state *state)
     return 0;
 }
 
-static struct argp argp = { options, parser, args_doc, doc };
+static struct argp argp = {options, parser, args_doc, doc};
 
-static int init_cf_pdu(uint8_t* pdu)
+static int init_cf_pdu(uint8_t *pdu)
 {
     int res;
     if (use_tscf) {
-        Avtp_Tscf_t* tscf_pdu = (Avtp_Tscf_t*) pdu;
+        Avtp_Tscf_t *tscf_pdu = (Avtp_Tscf_t *)pdu;
         memset(tscf_pdu, 0, AVTP_TSCF_HEADER_LEN);
         Avtp_Tscf_Init(tscf_pdu);
         Avtp_Tscf_SetField(tscf_pdu, AVTP_TSCF_FIELD_TU, 0U);
@@ -151,7 +149,7 @@ static int init_cf_pdu(uint8_t* pdu)
         Avtp_Tscf_SetField(tscf_pdu, AVTP_TSCF_FIELD_STREAM_ID, STREAM_ID);
         res = AVTP_TSCF_HEADER_LEN;
     } else {
-        Avtp_Ntscf_t* ntscf_pdu = (Avtp_Ntscf_t*) pdu;
+        Avtp_Ntscf_t *ntscf_pdu = (Avtp_Ntscf_t *)pdu;
         memset(ntscf_pdu, 0, AVTP_NTSCF_HEADER_LEN);
         Avtp_Ntscf_Init(ntscf_pdu);
         Avtp_Ntscf_SetField(ntscf_pdu, AVTP_NTSCF_FIELD_SEQUENCE_NUM, seq_num++);
@@ -161,25 +159,25 @@ static int init_cf_pdu(uint8_t* pdu)
     return res;
 }
 
-static int update_cf_length(uint8_t* cf_pdu, uint64_t length)
+static int update_cf_length(uint8_t *cf_pdu, uint64_t length)
 {
     if (use_tscf) {
         uint64_t payloadLen = length - AVTP_TSCF_HEADER_LEN;
-        Avtp_Tscf_SetField((Avtp_Tscf_t*)cf_pdu, AVTP_TSCF_FIELD_STREAM_DATA_LENGTH, payloadLen);
+        Avtp_Tscf_SetField((Avtp_Tscf_t *)cf_pdu, AVTP_TSCF_FIELD_STREAM_DATA_LENGTH, payloadLen);
     } else {
         uint64_t payloadLen = length - AVTP_NTSCF_HEADER_LEN;
-        Avtp_Ntscf_SetField((Avtp_Ntscf_t*)cf_pdu, AVTP_NTSCF_FIELD_NTSCF_DATA_LENGTH, payloadLen);
+        Avtp_Ntscf_SetField((Avtp_Ntscf_t *)cf_pdu, AVTP_NTSCF_FIELD_NTSCF_DATA_LENGTH, payloadLen);
     }
     return 0;
 }
 
-static int prepare_vss_interop_packet(uint8_t* acf_pdu, Vss_Datatype_t dt,
-                              Vss_OpCode_t op, Vss_AddrMode_t am,
-                              VssPath_t* vp, VssData_t* vd) {
+static int prepare_vss_interop_packet(uint8_t *acf_pdu, Vss_Datatype_t dt, Vss_OpCode_t op,
+                                      Vss_AddrMode_t am, VssPath_t *vp, VssData_t *vd)
+{
 
     int processedBytes;
     struct timespec now;
-    Avtp_Vss_t* pdu = (Avtp_Vss_t*) acf_pdu;
+    Avtp_Vss_t *pdu = (Avtp_Vss_t *)acf_pdu;
 
     // Clear bits
     memset(pdu, 0, AVTP_VSS_FIXED_HEADER_LEN);
@@ -210,7 +208,7 @@ static int prepare_vss_interop_packet(uint8_t* acf_pdu, Vss_Datatype_t dt,
 int main(int argc, char *argv[])
 {
 
-    int fd, res, can_socket=0;
+    int fd, res, can_socket = 0;
     struct sockaddr_ll sk_ll_addr;
     struct sockaddr_in sk_udp_addr;
     uint8_t pdu[MAX_PDU_SIZE];
@@ -223,33 +221,33 @@ int main(int argc, char *argv[])
     // Setup the socket for sending to the destination
     if (use_udp) {
         fd = create_talker_socket_udp(priority);
-        if (fd < 0) return fd;
+        if (fd < 0)
+            return fd;
 
-        res = setup_udp_socket_address((struct in_addr*) ip_addr,
-                                       udp_port, &sk_udp_addr);
+        res = setup_udp_socket_address((struct in_addr *)ip_addr, udp_port, &sk_udp_addr);
     } else {
         fd = create_talker_socket(priority);
-        if (fd < 0) return fd;
-        res = setup_socket_address(fd, ifname, macaddr,
-                                   ETH_P_TSN, &sk_ll_addr);
+        if (fd < 0)
+            return fd;
+        res = setup_socket_address(fd, ifname, macaddr, ETH_P_TSN, &sk_ll_addr);
     }
-    if (res < 0) goto err;
+    if (res < 0)
+        goto err;
 
     // Sending loop
-    for(;;) {
+    for (;;) {
 
         // Pack into control formats
         uint8_t *cf_pdu;
         pdu_length = 0;
         cf_length = 0;
-        uint8_t acf_length= 0;
+        uint8_t acf_length = 0;
 
         // Usage of UDP means the PDU needs a
         if (use_udp) {
-            Avtp_Udp_t *udp_pdu = (Avtp_Udp_t *) pdu;
-            Avtp_Udp_SetField(udp_pdu, AVTP_UDP_FIELD_ENCAPSULATION_SEQ_NO,
-                              udp_seq_num++);
-            pdu_length +=  sizeof(Avtp_Udp_t);
+            Avtp_Udp_t *udp_pdu = (Avtp_Udp_t *)pdu;
+            Avtp_Udp_SetField(udp_pdu, AVTP_UDP_FIELD_ENCAPSULATION_SEQ_NO, udp_seq_num++);
+            pdu_length += sizeof(Avtp_Udp_t);
         }
 
         cf_pdu = pdu + pdu_length;
@@ -259,25 +257,20 @@ int main(int argc, char *argv[])
         pdu_length += res;
         cf_length += res;
 
-        uint8_t* acf_pdu = pdu + pdu_length;
-        VssPath_t vss_path = {
-            .vss_interop_path.path_length = strlen(VSS_PATH),
-            .vss_interop_path.path = VSS_PATH
-        };
-        VssData_t data = {
-            .data_float = (rand()%2500)/10.0
-        };
-        res = prepare_vss_interop_packet(acf_pdu, VSS_FLOAT,
-                                            PUBLISH_CURRENT_VALUE,
-                                            VSS_INTEROP_MODE, &vss_path, &data);
-        if (res < 0) goto err;
+        uint8_t *acf_pdu = pdu + pdu_length;
+        VssPath_t vss_path = {.vss_interop_path.path_length = strlen(VSS_PATH),
+                              .vss_interop_path.path = VSS_PATH};
+        VssData_t data = {.data_float = (rand() % 2500) / 10.0};
+        res = prepare_vss_interop_packet(acf_pdu, VSS_FLOAT, PUBLISH_CURRENT_VALUE,
+                                         VSS_INTEROP_MODE, &vss_path, &data);
+        if (res < 0)
+            goto err;
         pdu_length += res;
         cf_length += res;
         acf_length = res;
 
-        Avtp_Vss_SetPayloadLength((Avtp_Vss_t*) acf_pdu,
-                                  acf_length - AVTP_VSS_FIXED_HEADER_LEN);
-        uint8_t pad_length = Avtp_Vss_GetField((Avtp_Vss_t*)acf_pdu, AVTP_VSS_FIELD_PAD);
+        Avtp_Vss_SetPayloadLength((Avtp_Vss_t *)acf_pdu, acf_length - AVTP_VSS_FIXED_HEADER_LEN);
+        uint8_t pad_length = Avtp_Vss_GetField((Avtp_Vss_t *)acf_pdu, AVTP_VSS_FIELD_PAD);
         pdu_length += pad_length;
         cf_length += pad_length;
 
@@ -286,11 +279,11 @@ int main(int argc, char *argv[])
             goto err;
 
         if (use_udp) {
-            res = sendto(fd, pdu, pdu_length, 0,
-                    (struct sockaddr *) &sk_udp_addr, sizeof(sk_udp_addr));
+            res = sendto(fd, pdu, pdu_length, 0, (struct sockaddr *)&sk_udp_addr,
+                         sizeof(sk_udp_addr));
         } else {
-            res = sendto(fd, pdu, pdu_length, 0,
-                         (struct sockaddr *) &sk_ll_addr, sizeof(sk_ll_addr));
+            res =
+                sendto(fd, pdu, pdu_length, 0, (struct sockaddr *)&sk_ll_addr, sizeof(sk_ll_addr));
         }
         if (res < 0) {
             perror("Failed to send data");
@@ -302,5 +295,4 @@ int main(int argc, char *argv[])
 err:
     close(fd);
     return 1;
-
 }

--- a/examples/acf-vss/acf-vss-talker.c
+++ b/examples/acf-vss/acf-vss-talker.c
@@ -187,7 +187,7 @@ static int prepare_vss_interop_packet(uint8_t* acf_pdu, Vss_Datatype_t dt,
     // Prepare ACF PDU for VSS
     Avtp_Vss_Init(pdu);
     clock_gettime(CLOCK_REALTIME, &now);
-    Avtp_Vss_SetField(pdu, AVTP_VSS_FIELD_MSG_TIMESTAMP,
+    Avtp_Vss_SetField(pdu, AVTP_VSS_FIELD_MESSAGE_TIMESTAMP,
                       (uint64_t)now.tv_nsec + (uint64_t)(now.tv_sec * 1e9));
     Avtp_Vss_SetField(pdu, AVTP_VSS_FIELD_MTV, 1U);
 
@@ -275,7 +275,8 @@ int main(int argc, char *argv[])
         cf_length += res;
         acf_length = res;
 
-        Avtp_Vss_Pad((Avtp_Vss_t*) acf_pdu, acf_length);
+        Avtp_Vss_SetPayloadLength((Avtp_Vss_t*) acf_pdu,
+                                  acf_length - AVTP_VSS_FIXED_HEADER_LEN);
         uint8_t pad_length = Avtp_Vss_GetField((Avtp_Vss_t*)acf_pdu, AVTP_VSS_FIELD_PAD);
         pdu_length += pad_length;
         cf_length += pad_length;

--- a/include/avtp/acf/custom/Vss.h
+++ b/include/avtp/acf/custom/Vss.h
@@ -45,23 +45,17 @@
 extern "C" {
 #endif
 
-#define AVTP_VSS_FIXED_HEADER_LEN         (3 * AVTP_QUADLET_SIZE)
-#define AVTP_ACF_TYPE_VSS           0x42
+#define AVTP_VSS_FIXED_HEADER_LEN (3 * AVTP_QUADLET_SIZE)
+#define AVTP_ACF_TYPE_VSS 0x42
 
 typedef struct {
     uint8_t header[AVTP_VSS_FIXED_HEADER_LEN];
     uint8_t payload[0];
 } __attribute__((packed)) Avtp_Vss_t;
 
-typedef enum vss_op_code {
-    PUBLISH_CURRENT_VALUE   = 0,
-    PUBLISH_TARGET_VALUE    = 1
-} Vss_OpCode_t;
+typedef enum vss_op_code { PUBLISH_CURRENT_VALUE = 0, PUBLISH_TARGET_VALUE = 1 } Vss_OpCode_t;
 
-typedef enum vss_addr_mode {
-    VSS_INTEROP_MODE    = 0,
-    VSS_STATIC_ID_MODE  = 1
-} Vss_AddrMode_t;
+typedef enum vss_addr_mode { VSS_INTEROP_MODE = 0, VSS_STATIC_ID_MODE = 1 } Vss_AddrMode_t;
 
 typedef enum vss_datatype {
     VSS_UINT8 = 0,
@@ -90,7 +84,7 @@ typedef enum vss_datatype {
     VSS_STRING_ARRAY = 0x8B,
 } Vss_Datatype_t;
 
-typedef enum  {
+typedef enum {
 
     /* ACF common header fields */
     AVTP_VSS_FIELD_ACF_MSG_TYPE = 0,
@@ -111,7 +105,7 @@ typedef enum  {
 typedef struct vss_interop_path {
     uint16_t path_length;
     char *path;
-} VssInteropPath_t;    // Used for VSS Path in Interop Mode
+} VssInteropPath_t; // Used for VSS Path in Interop Mode
 
 typedef union vss_path {
     VssInteropPath_t vss_interop_path;
@@ -120,67 +114,67 @@ typedef union vss_path {
 
 typedef struct vss_data_string {
     uint16_t data_length;
-    char* data;
+    char *data;
 } VssDataString_t;
 
-typedef struct  vss_data_uint8_array {
+typedef struct vss_data_uint8_array {
     uint16_t data_length;
-    uint8_t* data;
+    uint8_t *data;
 } VssDataUint8Array_t;
 
-typedef struct  vss_data_int8_array {
+typedef struct vss_data_int8_array {
     uint16_t data_length;
-    int8_t* data;
+    int8_t *data;
 } VssDataInt8Array_t;
 
-typedef struct  vss_data_uint16_array {
+typedef struct vss_data_uint16_array {
     uint16_t data_length;
-    uint16_t* data;
+    uint16_t *data;
 } VssDataUint16Array_t;
 
-typedef struct  vss_data_int16_array {
+typedef struct vss_data_int16_array {
     uint16_t data_length;
-    int16_t* data;
+    int16_t *data;
 } VssDataInt16Array_t;
 
-typedef struct  vss_data_uint32_array {
+typedef struct vss_data_uint32_array {
     uint16_t data_length;
-    uint32_t* data;
+    uint32_t *data;
 } VssDataUint32Array_t;
 
-typedef struct  vss_data_int32_array {
+typedef struct vss_data_int32_array {
     uint16_t data_length;
-    int32_t* data;
+    int32_t *data;
 } VssDataInt32Array_t;
 
-typedef struct  vss_data_uint64_array {
+typedef struct vss_data_uint64_array {
     uint16_t data_length;
-    uint64_t* data;
+    uint64_t *data;
 } VssDataUint64Array_t;
 
-typedef struct  vss_data_int64_array {
+typedef struct vss_data_int64_array {
     uint16_t data_length;
-    int64_t* data;
+    int64_t *data;
 } VssDataInt64Array_t;
 
-typedef struct  vss_data_bool_array {
+typedef struct vss_data_bool_array {
     uint16_t data_length;
-    uint8_t* data;
+    uint8_t *data;
 } VssDataBoolArray_t;
 
-typedef struct  vss_data_float_array {
+typedef struct vss_data_float_array {
     uint16_t data_length;
-    float* data;
+    float *data;
 } VssDataFloatArray_t;
 
-typedef struct  vss_data_double_array {
+typedef struct vss_data_double_array {
     uint16_t data_length;
-    double* data;
+    double *data;
 } VssDataDoubleArray_t;
 
-typedef struct  vss_data_string_array {
+typedef struct vss_data_string_array {
     uint16_t data_length;
-    uint8_t* data;
+    uint8_t *data;
 } VssDataStringArray_t;
 
 typedef union vss_data {
@@ -195,19 +189,19 @@ typedef union vss_data {
     uint8_t data_bool;
     float data_float;
     double data_double;
-    VssDataString_t* data_string;
-    VssDataUint8Array_t* data_uint8_array;
-    VssDataInt8Array_t* data_int8_array;
-    VssDataUint16Array_t* data_uint16_array;
-    VssDataInt16Array_t* data_int16_array;
-    VssDataUint32Array_t* data_uint32_array;
-    VssDataInt32Array_t* data_int32_array;
-    VssDataUint64Array_t* data_uint64_array;
-    VssDataInt64Array_t* data_int64_array;
-    VssDataBoolArray_t* data_bool_array;
-    VssDataFloatArray_t* data_float_array;
-    VssDataDoubleArray_t* data_double_array;
-    VssDataStringArray_t* data_string_array;
+    VssDataString_t *data_string;
+    VssDataUint8Array_t *data_uint8_array;
+    VssDataInt8Array_t *data_int8_array;
+    VssDataUint16Array_t *data_uint16_array;
+    VssDataInt16Array_t *data_int16_array;
+    VssDataUint32Array_t *data_uint32_array;
+    VssDataInt32Array_t *data_int32_array;
+    VssDataUint64Array_t *data_uint64_array;
+    VssDataInt64Array_t *data_int64_array;
+    VssDataBoolArray_t *data_bool_array;
+    VssDataFloatArray_t *data_float_array;
+    VssDataDoubleArray_t *data_double_array;
+    VssDataStringArray_t *data_string_array;
 } VssData_t;
 
 /**
@@ -216,7 +210,7 @@ typedef union vss_data {
  *
  * @param vss_pdu Pointer to the first bit of a 1722 ACF VSS PDU.
  */
-void Avtp_Vss_Init(Avtp_Vss_t* vss_pdu);
+void Avtp_Vss_Init(Avtp_Vss_t *vss_pdu);
 
 /**
  * Returns the value of an an ACF VSS PDU field as specified in the
@@ -226,7 +220,7 @@ void Avtp_Vss_Init(Avtp_Vss_t* vss_pdu);
  * @param field Specifies the position of the data field to be read
  * @returns Value of the specified field of the ACF VSS PDU
  */
-uint64_t Avtp_Vss_GetField(const Avtp_Vss_t* const pdu, Avtp_VssFields_t field);
+uint64_t Avtp_Vss_GetField(const Avtp_Vss_t *const pdu, Avtp_VssFields_t field);
 
 /**
  * Sets the value of an an ACF VSS PDU field as specified in the
@@ -236,8 +230,7 @@ uint64_t Avtp_Vss_GetField(const Avtp_Vss_t* const pdu, Avtp_VssFields_t field);
  * @param field Specifies the position of the data field to be read
  * @param value Value of the specified field
  */
-void Avtp_Vss_SetField(Avtp_Vss_t* pdu, Avtp_VssFields_t field, uint64_t value);
-
+void Avtp_Vss_SetField(Avtp_Vss_t *pdu, Avtp_VssFields_t field, uint64_t value);
 
 /**
  * Finalizes the ACF VSS frame. This function will set the
@@ -246,37 +239,35 @@ void Avtp_Vss_SetField(Avtp_Vss_t* pdu, Avtp_VssFields_t field, uint64_t value);
  * @param pdu Pointer to the first bit of an 1722 ACF VSS PDU.
  * @param payload_length Length of the VSS payload (path + data) in bytes.
  */
-void Avtp_Vss_SetPayloadLength(Avtp_Vss_t* pdu, uint16_t payload_length);
+void Avtp_Vss_SetPayloadLength(Avtp_Vss_t *pdu, uint16_t payload_length);
 
 /* Getter and Setter Functions*/
-Avtp_AcfMsgType_t Avtp_Vss_GetAcfMsgType(const Avtp_Vss_t* const pdu);
-uint16_t Avtp_Vss_GetAcfMsgLength(const Avtp_Vss_t* const pdu);
-uint8_t Avtp_Vss_GetPad(const Avtp_Vss_t* const pdu);
-bool Avtp_Vss_IsMtv(const Avtp_Vss_t* const pdu);
-Vss_AddrMode_t Avtp_Vss_GetAddrMode(const Avtp_Vss_t* const pdu);
-Vss_OpCode_t Avtp_Vss_GetOpCode(const Avtp_Vss_t* const pdu);
-Vss_Datatype_t Avtp_Vss_GetDatatype(const Avtp_Vss_t* const pdu);
-uint64_t Avtp_Vss_GetMessageTimestamp(const Avtp_Vss_t* const pdu);
-void Avtp_Vss_GetVssPath(const Avtp_Vss_t* const pdu, VssPath_t* val);
-void Avtp_Vss_GetVssData(const Avtp_Vss_t* const pdu, VssData_t* val);
-uint16_t Avtp_Vss_GetVSSDataStringArrayLength(const VssDataStringArray_t* str_array);
-uint16_t Avtp_Vss_CalcVssPathLength (const Avtp_Vss_t* const pdu);
-void Avtp_Vss_DeserializeStringArray(const VssDataStringArray_t*  const vss_data_string_array,
-                                     VssDataString_t* strings[],
-                                     uint16_t num_strings);
-void Avtp_Vss_SetAcfMsgType(Avtp_Vss_t* pdu, Avtp_AcfMsgType_t val);
-void Avtp_Vss_SetAcfMsgLength(Avtp_Vss_t* pdu, uint16_t val);
-void Avtp_Vss_SetPad(Avtp_Vss_t* pdu, uint8_t val);
-void Avtp_Vss_SetMtv(Avtp_Vss_t* pdu, bool mtv);
-void Avtp_Vss_SetAddrMode(Avtp_Vss_t* pdu, Vss_AddrMode_t val);
-void Avtp_Vss_SetOpCode(Avtp_Vss_t* pdu, Vss_OpCode_t val);
-void Avtp_Vss_SetDatatype(Avtp_Vss_t* pdu, Vss_Datatype_t val);
-void Avtp_Vss_SetMessageTimestamp(Avtp_Vss_t* pdu, uint64_t val);
-void Avtp_Vss_SetVssPath(Avtp_Vss_t* pdu, VssPath_t* val);
-void Avtp_Vss_SetVssData(Avtp_Vss_t* pdu, VssData_t* val);
-void Avtp_Vss_SerializeStringArray(VssDataStringArray_t* vss_data_string_array,
-                                   VssDataString_t* strings[],
-                                   uint16_t num_strings);
+Avtp_AcfMsgType_t Avtp_Vss_GetAcfMsgType(const Avtp_Vss_t *const pdu);
+uint16_t Avtp_Vss_GetAcfMsgLength(const Avtp_Vss_t *const pdu);
+uint8_t Avtp_Vss_GetPad(const Avtp_Vss_t *const pdu);
+bool Avtp_Vss_IsMtv(const Avtp_Vss_t *const pdu);
+Vss_AddrMode_t Avtp_Vss_GetAddrMode(const Avtp_Vss_t *const pdu);
+Vss_OpCode_t Avtp_Vss_GetOpCode(const Avtp_Vss_t *const pdu);
+Vss_Datatype_t Avtp_Vss_GetDatatype(const Avtp_Vss_t *const pdu);
+uint64_t Avtp_Vss_GetMessageTimestamp(const Avtp_Vss_t *const pdu);
+void Avtp_Vss_GetVssPath(const Avtp_Vss_t *const pdu, VssPath_t *val);
+void Avtp_Vss_GetVssData(const Avtp_Vss_t *const pdu, VssData_t *val);
+uint16_t Avtp_Vss_GetVSSDataStringArrayLength(const VssDataStringArray_t *str_array);
+uint16_t Avtp_Vss_CalcVssPathLength(const Avtp_Vss_t *const pdu);
+void Avtp_Vss_DeserializeStringArray(const VssDataStringArray_t *const vss_data_string_array,
+                                     VssDataString_t *strings[], uint16_t num_strings);
+void Avtp_Vss_SetAcfMsgType(Avtp_Vss_t *pdu, Avtp_AcfMsgType_t val);
+void Avtp_Vss_SetAcfMsgLength(Avtp_Vss_t *pdu, uint16_t val);
+void Avtp_Vss_SetPad(Avtp_Vss_t *pdu, uint8_t val);
+void Avtp_Vss_SetMtv(Avtp_Vss_t *pdu, bool mtv);
+void Avtp_Vss_SetAddrMode(Avtp_Vss_t *pdu, Vss_AddrMode_t val);
+void Avtp_Vss_SetOpCode(Avtp_Vss_t *pdu, Vss_OpCode_t val);
+void Avtp_Vss_SetDatatype(Avtp_Vss_t *pdu, Vss_Datatype_t val);
+void Avtp_Vss_SetMessageTimestamp(Avtp_Vss_t *pdu, uint64_t val);
+void Avtp_Vss_SetVssPath(Avtp_Vss_t *pdu, VssPath_t *val);
+void Avtp_Vss_SetVssData(Avtp_Vss_t *pdu, VssData_t *val);
+void Avtp_Vss_SerializeStringArray(VssDataStringArray_t *vss_data_string_array,
+                                   VssDataString_t *strings[], uint16_t num_strings);
 
 #ifdef __cplusplus
 }

--- a/include/avtp/acf/custom/Vss.h
+++ b/include/avtp/acf/custom/Vss.h
@@ -36,6 +36,7 @@
 #pragma once
 
 #include <stdint.h>
+#include <stdbool.h>
 
 #include "avtp/Defines.h"
 #include "avtp/acf/AcfCommon.h"
@@ -50,7 +51,7 @@ extern "C" {
 typedef struct {
     uint8_t header[AVTP_VSS_FIXED_HEADER_LEN];
     uint8_t payload[0];
-} Avtp_Vss_t;
+} __attribute__((packed)) Avtp_Vss_t;
 
 typedef enum vss_op_code {
     PUBLISH_CURRENT_VALUE   = 0,
@@ -101,7 +102,7 @@ typedef enum  {
     AVTP_VSS_FIELD_ADDR_MODE,
     AVTP_VSS_FIELD_VSS_OP,
     AVTP_VSS_FIELD_VSS_DATATYPE,
-    AVTP_VSS_FIELD_MSG_TIMESTAMP,
+    AVTP_VSS_FIELD_MESSAGE_TIMESTAMP,
 
     /* Count number of fields for bound checks */
     AVTP_VSS_FIELD_MAX
@@ -243,19 +244,19 @@ void Avtp_Vss_SetField(Avtp_Vss_t* pdu, Avtp_VssFields_t field, uint64_t value);
  * length and pad fields while inserting the padded bytes.
  *
  * @param pdu Pointer to the first bit of an 1722 ACF VSS PDU.
- * @param vss_length Length of the VSS frame including the header bytes.
+ * @param payload_length Length of the VSS payload (path + data) in bytes.
  */
-void Avtp_Vss_Pad(Avtp_Vss_t* pdu, uint16_t vss_length);
+void Avtp_Vss_SetPayloadLength(Avtp_Vss_t* pdu, uint16_t payload_length);
 
 /* Getter and Setter Functions*/
 Avtp_AcfMsgType_t Avtp_Vss_GetAcfMsgType(const Avtp_Vss_t* const pdu);
-uint8_t Avtp_Vss_GetAcfMsgLength(const Avtp_Vss_t* const pdu);
+uint16_t Avtp_Vss_GetAcfMsgLength(const Avtp_Vss_t* const pdu);
 uint8_t Avtp_Vss_GetPad(const Avtp_Vss_t* const pdu);
-uint8_t Avtp_Vss_GetMtv(const Avtp_Vss_t* const pdu);
+bool Avtp_Vss_IsMtv(const Avtp_Vss_t* const pdu);
 Vss_AddrMode_t Avtp_Vss_GetAddrMode(const Avtp_Vss_t* const pdu);
 Vss_OpCode_t Avtp_Vss_GetOpCode(const Avtp_Vss_t* const pdu);
 Vss_Datatype_t Avtp_Vss_GetDatatype(const Avtp_Vss_t* const pdu);
-uint64_t Avtp_Vss_GetMsgTimestamp(const Avtp_Vss_t* const pdu);
+uint64_t Avtp_Vss_GetMessageTimestamp(const Avtp_Vss_t* const pdu);
 void Avtp_Vss_GetVssPath(const Avtp_Vss_t* const pdu, VssPath_t* val);
 void Avtp_Vss_GetVssData(const Avtp_Vss_t* const pdu, VssData_t* val);
 uint16_t Avtp_Vss_GetVSSDataStringArrayLength(const VssDataStringArray_t* str_array);
@@ -264,14 +265,13 @@ void Avtp_Vss_DeserializeStringArray(const VssDataStringArray_t*  const vss_data
                                      VssDataString_t* strings[],
                                      uint16_t num_strings);
 void Avtp_Vss_SetAcfMsgType(Avtp_Vss_t* pdu, Avtp_AcfMsgType_t val);
-void Avtp_Vss_SetAcfMsgLength(Avtp_Vss_t* pdu, uint8_t val);
+void Avtp_Vss_SetAcfMsgLength(Avtp_Vss_t* pdu, uint16_t val);
 void Avtp_Vss_SetPad(Avtp_Vss_t* pdu, uint8_t val);
-void Avtp_Vss_EnableMtv(Avtp_Vss_t* pdu);
-void Avtp_Vss_DisableMtv(Avtp_Vss_t* pdu);
+void Avtp_Vss_SetMtv(Avtp_Vss_t* pdu, bool mtv);
 void Avtp_Vss_SetAddrMode(Avtp_Vss_t* pdu, Vss_AddrMode_t val);
 void Avtp_Vss_SetOpCode(Avtp_Vss_t* pdu, Vss_OpCode_t val);
 void Avtp_Vss_SetDatatype(Avtp_Vss_t* pdu, Vss_Datatype_t val);
-void Avtp_Vss_SetMsgTimestamp(Avtp_Vss_t* pdu, uint64_t val);
+void Avtp_Vss_SetMessageTimestamp(Avtp_Vss_t* pdu, uint64_t val);
 void Avtp_Vss_SetVssPath(Avtp_Vss_t* pdu, VssPath_t* val);
 void Avtp_Vss_SetVssData(Avtp_Vss_t* pdu, VssData_t* val);
 void Avtp_Vss_SerializeStringArray(VssDataStringArray_t* vss_data_string_array,

--- a/src/avtp/acf/custom/Vss.c
+++ b/src/avtp/acf/custom/Vss.c
@@ -55,7 +55,7 @@ static const Avtp_FieldDescriptor_t Avtp_VssFieldDesc[AVTP_VSS_FIELD_MAX] =
     [AVTP_VSS_FIELD_ADDR_MODE]          = { .quadlet = 0, .offset = 19, .bits =  2 },
     [AVTP_VSS_FIELD_VSS_OP]             = { .quadlet = 0, .offset = 21, .bits =  3 },
     [AVTP_VSS_FIELD_VSS_DATATYPE]       = { .quadlet = 0, .offset = 24, .bits =  8 },
-    [AVTP_VSS_FIELD_MSG_TIMESTAMP]      = { .quadlet = 1, .offset =  0, .bits = 64 }
+    [AVTP_VSS_FIELD_MESSAGE_TIMESTAMP]  = { .quadlet = 1, .offset =  0, .bits = 64 }
 };
 
 /* Read a 16‑bit big‑endian length prefix at *ptr and clamp it so that
@@ -146,19 +146,23 @@ void Avtp_Vss_SetField(Avtp_Vss_t* pdu,
     SET_FIELD(field, value);
 }
 
-void Avtp_Vss_Pad(Avtp_Vss_t* vss_pdu, uint16_t vss_length) {
+void Avtp_Vss_SetPayloadLength(Avtp_Vss_t* vss_pdu, uint16_t payload_length) {
 
     uint8_t padSize;
+    uint16_t msgLenBytes;
     uint16_t padded_length;
 
+    // Compute the total message length including the fixed header
+    msgLenBytes = AVTP_VSS_FIXED_HEADER_LEN + payload_length;
+
     // Check if padding is required
-    padSize = (uint8_t)((AVTP_QUADLET_SIZE - (vss_length % AVTP_QUADLET_SIZE)) % AVTP_QUADLET_SIZE);
-    if (vss_length % AVTP_QUADLET_SIZE) {
-        memset((uint8_t*)vss_pdu + vss_length, 0, padSize);
+    padSize = (uint8_t)((AVTP_QUADLET_SIZE - (msgLenBytes % AVTP_QUADLET_SIZE)) % AVTP_QUADLET_SIZE);
+    if (msgLenBytes % AVTP_QUADLET_SIZE) {
+        memset((uint8_t*)vss_pdu + msgLenBytes, 0, padSize);
     }
 
     // Set the length and padding fields
-    padded_length = vss_length + padSize;
+    padded_length = msgLenBytes + padSize;
     Avtp_Vss_SetField(vss_pdu, AVTP_VSS_FIELD_ACF_MSG_LENGTH,
                         (uint64_t)(padded_length / AVTP_QUADLET_SIZE));
     Avtp_Vss_SetField(vss_pdu, AVTP_VSS_FIELD_PAD, padSize);
@@ -168,16 +172,16 @@ Avtp_AcfMsgType_t Avtp_Vss_GetAcfMsgType(const Avtp_Vss_t* const pdu) {
     return GET_FIELD(AVTP_VSS_FIELD_ACF_MSG_TYPE);
 }
 
-uint8_t Avtp_Vss_GetAcfMsgLength(const Avtp_Vss_t* const pdu) {
-    return (uint8_t)GET_FIELD(AVTP_VSS_FIELD_ACF_MSG_LENGTH);
+uint16_t Avtp_Vss_GetAcfMsgLength(const Avtp_Vss_t* const pdu) {
+    return (uint16_t)GET_FIELD(AVTP_VSS_FIELD_ACF_MSG_LENGTH);
 }
 
 uint8_t Avtp_Vss_GetPad(const Avtp_Vss_t* const pdu) {
     return (uint8_t)GET_FIELD(AVTP_VSS_FIELD_PAD);
 }
 
-uint8_t Avtp_Vss_GetMtv(const Avtp_Vss_t* const pdu) {
-    return (uint8_t)GET_FIELD(AVTP_VSS_FIELD_MTV);
+bool Avtp_Vss_IsMtv(const Avtp_Vss_t* const pdu) {
+    return (bool)GET_FIELD(AVTP_VSS_FIELD_MTV);
 }
 
 Vss_AddrMode_t Avtp_Vss_GetAddrMode(const Avtp_Vss_t* const pdu) {
@@ -192,8 +196,8 @@ Vss_Datatype_t Avtp_Vss_GetDatatype(const Avtp_Vss_t* const pdu) {
     return GET_FIELD(AVTP_VSS_FIELD_VSS_DATATYPE);
 }
 
-uint64_t Avtp_Vss_GetMsgTimestamp(const Avtp_Vss_t* const pdu) {
-    return GET_FIELD(AVTP_VSS_FIELD_MSG_TIMESTAMP);
+uint64_t Avtp_Vss_GetMessageTimestamp(const Avtp_Vss_t* const pdu) {
+    return GET_FIELD(AVTP_VSS_FIELD_MESSAGE_TIMESTAMP);
 }
 
 void Avtp_Vss_GetVssPath(const Avtp_Vss_t* const pdu, VssPath_t* val) {
@@ -495,7 +499,7 @@ void Avtp_Vss_SetAcfMsgType(Avtp_Vss_t* pdu, Avtp_AcfMsgType_t val) {
     SET_FIELD(AVTP_VSS_FIELD_ACF_MSG_TYPE, val);
 }
 
-void Avtp_Vss_SetAcfMsgLength(Avtp_Vss_t* pdu, uint8_t val) {
+void Avtp_Vss_SetAcfMsgLength(Avtp_Vss_t* pdu, uint16_t val) {
     SET_FIELD(AVTP_VSS_FIELD_ACF_MSG_LENGTH, val);
 }
 
@@ -503,14 +507,9 @@ void Avtp_Vss_SetPad(Avtp_Vss_t* pdu, uint8_t val) {
     SET_FIELD(AVTP_VSS_FIELD_PAD, val);
 }
 
-void Avtp_Vss_EnableMtv(Avtp_Vss_t* pdu)
+void Avtp_Vss_SetMtv(Avtp_Vss_t* pdu, bool mtv)
 {
-    SET_FIELD(AVTP_VSS_FIELD_MTV, 1);
-}
-
-void Avtp_Vss_DisableMtv(Avtp_Vss_t* pdu)
-{
-    SET_FIELD(AVTP_VSS_FIELD_MTV, 0);
+    SET_FIELD(AVTP_VSS_FIELD_MTV, mtv);
 }
 
 void Avtp_Vss_SetAddrMode(Avtp_Vss_t* pdu, Vss_AddrMode_t val) {
@@ -525,8 +524,8 @@ void Avtp_Vss_SetDatatype(Avtp_Vss_t* pdu, Vss_Datatype_t val) {
     SET_FIELD(AVTP_VSS_FIELD_VSS_DATATYPE, val);
 }
 
-void Avtp_Vss_SetMsgTimestamp(Avtp_Vss_t* pdu, uint64_t val)  {
-    SET_FIELD(AVTP_VSS_FIELD_MSG_TIMESTAMP, val);
+void Avtp_Vss_SetMessageTimestamp(Avtp_Vss_t* pdu, uint64_t val)  {
+    SET_FIELD(AVTP_VSS_FIELD_MESSAGE_TIMESTAMP, val);
  }
 
 void Avtp_Vss_SetVssPath(Avtp_Vss_t* pdu, VssPath_t* val)

--- a/src/avtp/acf/custom/Vss.c
+++ b/src/avtp/acf/custom/Vss.c
@@ -36,27 +36,25 @@
 #include "avtp/Utils.h"
 #include "avtp/Defines.h"
 
-#define GET_FIELD(field) \
-        (Avtp_GetField(Avtp_VssFieldDesc, AVTP_VSS_FIELD_MAX, (uint8_t*)pdu, field))
-#define SET_FIELD(field, value) \
-        (Avtp_SetField(Avtp_VssFieldDesc, AVTP_VSS_FIELD_MAX, (uint8_t*)pdu, field, value))
+#define GET_FIELD(field)                                                                           \
+    (Avtp_GetField(Avtp_VssFieldDesc, AVTP_VSS_FIELD_MAX, (uint8_t *)pdu, field))
+#define SET_FIELD(field, value)                                                                    \
+    (Avtp_SetField(Avtp_VssFieldDesc, AVTP_VSS_FIELD_MAX, (uint8_t *)pdu, field, value))
 
 /**
  * This table maps all IEEE 1722 ACF VSS header fields to a descriptor.
  */
-static const Avtp_FieldDescriptor_t Avtp_VssFieldDesc[AVTP_VSS_FIELD_MAX] =
-{
+static const Avtp_FieldDescriptor_t Avtp_VssFieldDesc[AVTP_VSS_FIELD_MAX] = {
     /* ACF common header fields */
-    [AVTP_VSS_FIELD_ACF_MSG_TYPE]       = { .quadlet = 0, .offset =  0, .bits = 7 },
-    [AVTP_VSS_FIELD_ACF_MSG_LENGTH]     = { .quadlet = 0, .offset =  7, .bits = 9 },
+    [AVTP_VSS_FIELD_ACF_MSG_TYPE] = {.quadlet = 0, .offset = 0, .bits = 7},
+    [AVTP_VSS_FIELD_ACF_MSG_LENGTH] = {.quadlet = 0, .offset = 7, .bits = 9},
     /* ACF VSS header fields */
-    [AVTP_VSS_FIELD_PAD]                = { .quadlet = 0, .offset = 16, .bits =  2 },
-    [AVTP_VSS_FIELD_MTV]                = { .quadlet = 0, .offset = 18, .bits =  1 },
-    [AVTP_VSS_FIELD_ADDR_MODE]          = { .quadlet = 0, .offset = 19, .bits =  2 },
-    [AVTP_VSS_FIELD_VSS_OP]             = { .quadlet = 0, .offset = 21, .bits =  3 },
-    [AVTP_VSS_FIELD_VSS_DATATYPE]       = { .quadlet = 0, .offset = 24, .bits =  8 },
-    [AVTP_VSS_FIELD_MESSAGE_TIMESTAMP]  = { .quadlet = 1, .offset =  0, .bits = 64 }
-};
+    [AVTP_VSS_FIELD_PAD] = {.quadlet = 0, .offset = 16, .bits = 2},
+    [AVTP_VSS_FIELD_MTV] = {.quadlet = 0, .offset = 18, .bits = 1},
+    [AVTP_VSS_FIELD_ADDR_MODE] = {.quadlet = 0, .offset = 19, .bits = 2},
+    [AVTP_VSS_FIELD_VSS_OP] = {.quadlet = 0, .offset = 21, .bits = 3},
+    [AVTP_VSS_FIELD_VSS_DATATYPE] = {.quadlet = 0, .offset = 24, .bits = 8},
+    [AVTP_VSS_FIELD_MESSAGE_TIMESTAMP] = {.quadlet = 1, .offset = 0, .bits = 64}};
 
 /* Read a 16‑bit big‑endian length prefix at *ptr and clamp it so that
  * ptr + 2 + length does not exceed the declared PDU size (msg_length in
@@ -67,25 +65,24 @@ static const Avtp_FieldDescriptor_t Avtp_VssFieldDesc[AVTP_VSS_FIELD_MAX] =
  * out‑of‑frame data pointer never produces an OOB read before clamping.
  * All offset arithmetic uses uint32_t to avoid wrap when ptr is far
  * past the PDU start. */
-static uint16_t vss_read_clamped_length(const Avtp_Vss_t* pdu,
-                                         const uint8_t* ptr)
+static uint16_t vss_read_clamped_length(const Avtp_Vss_t *pdu, const uint8_t *ptr)
 {
     uint16_t declared = (uint16_t)Avtp_Vss_GetAcfMsgLength(pdu) * AVTP_QUADLET_SIZE;
-    uint32_t offset   = (uint32_t)(ptr - (const uint8_t*)pdu);
+    uint32_t offset = (uint32_t)(ptr - (const uint8_t *)pdu);
 
     /* The 2‑byte length prefix must fit within the declared PDU. */
     if (offset + 2 > declared)
         return 0;
 
-    uint16_t wire_len = Avtp_BeToCpu16(*(const uint16_t*)ptr);
+    uint16_t wire_len = Avtp_BeToCpu16(*(const uint16_t *)ptr);
 
     if (offset + 2 + wire_len > declared) {
-        /* Prefix fits but the payload it describes is too long → clamp. 
-        * Clamp to the bytes available after the 2‑byte prefix.  The
-        * earlier guard ensures offset + 2 <= declared, so the result is
-        * non‑negative and fits uint16_t 
-        */
-        return (uint16_t) ((uint32_t) declared - offset - 2);
+        /* Prefix fits but the payload it describes is too long → clamp.
+         * Clamp to the bytes available after the 2‑byte prefix.  The
+         * earlier guard ensures offset + 2 <= declared, so the result is
+         * non‑negative and fits uint16_t
+         */
+        return (uint16_t)((uint32_t)declared - offset - 2);
     }
     /* The normal case: All bytes declared fit in frame and can be read. */
     return wire_len;
@@ -96,7 +93,7 @@ static uint16_t vss_read_clamped_length(const Avtp_Vss_t* pdu,
  * Setters use CalcVssPathLength (raw) instead; this helper is for the
  * read path only so that the data‑pointer computation never leaves the
  * frame.  */
-static uint16_t vss_get_clamped_path_length(const Avtp_Vss_t* pdu)
+static uint16_t vss_get_clamped_path_length(const Avtp_Vss_t *pdu)
 {
     uint16_t declared = (uint16_t)Avtp_Vss_GetAcfMsgLength(pdu) * AVTP_QUADLET_SIZE;
     Vss_AddrMode_t mode = Avtp_Vss_GetAddrMode(pdu);
@@ -104,11 +101,11 @@ static uint16_t vss_get_clamped_path_length(const Avtp_Vss_t* pdu)
     if (mode == VSS_STATIC_ID_MODE) {
         /* Fixed 4‑byte path: only count it when the frame is large enough. */
         return (declared >= AVTP_VSS_FIXED_HEADER_LEN + 4) ? 4
-             : (declared >  AVTP_VSS_FIXED_HEADER_LEN)
-                   ? declared - AVTP_VSS_FIXED_HEADER_LEN : 0;
+               : (declared > AVTP_VSS_FIXED_HEADER_LEN)    ? declared - AVTP_VSS_FIXED_HEADER_LEN
+                                                           : 0;
     }
     if (mode == VSS_INTEROP_MODE) {
-        const uint8_t* path_ptr = (const uint8_t*)pdu + AVTP_VSS_FIXED_HEADER_LEN;
+        const uint8_t *path_ptr = (const uint8_t *)pdu + AVTP_VSS_FIXED_HEADER_LEN;
         /* The 2‑byte prefix itself must fit before any path bytes count. */
         if (declared < AVTP_VSS_FIXED_HEADER_LEN + 2)
             return 0;
@@ -120,33 +117,33 @@ static uint16_t vss_get_clamped_path_length(const Avtp_Vss_t* pdu)
 /* True when there are at least `num_bytes` bytes available starting at `ptr`
  * within the declared frame.  Used to guard fixed‑size scalar reads in
  * GetVssData when the data pointer sits at or past the frame end. */
-static bool vss_has_bytes(const Avtp_Vss_t* pdu, const uint8_t* ptr,
-                          uint16_t num_bytes)
+static bool vss_has_bytes(const Avtp_Vss_t *pdu, const uint8_t *ptr, uint16_t num_bytes)
 {
     uint16_t declared = (uint16_t)Avtp_Vss_GetAcfMsgLength(pdu) * AVTP_QUADLET_SIZE;
-    return (uint32_t)(ptr - (const uint8_t*)pdu) + num_bytes <= declared;
+    return (uint32_t)(ptr - (const uint8_t *)pdu) + num_bytes <= declared;
 }
 
-void Avtp_Vss_Init(Avtp_Vss_t* vss_pdu) {
+void Avtp_Vss_Init(Avtp_Vss_t *vss_pdu)
+{
 
-    if(vss_pdu != NULL) {
+    if (vss_pdu != NULL) {
         memset(vss_pdu, 0, sizeof(Avtp_Vss_t));
         Avtp_Vss_SetField(vss_pdu, AVTP_VSS_FIELD_ACF_MSG_TYPE, AVTP_ACF_TYPE_VSS);
     }
 }
 
-uint64_t Avtp_Vss_GetField(const Avtp_Vss_t* const pdu, Avtp_VssFields_t field)
+uint64_t Avtp_Vss_GetField(const Avtp_Vss_t *const pdu, Avtp_VssFields_t field)
 {
     return GET_FIELD(field);
 }
 
-void Avtp_Vss_SetField(Avtp_Vss_t* pdu,
-                      Avtp_VssFields_t field, uint64_t value)
+void Avtp_Vss_SetField(Avtp_Vss_t *pdu, Avtp_VssFields_t field, uint64_t value)
 {
     SET_FIELD(field, value);
 }
 
-void Avtp_Vss_SetPayloadLength(Avtp_Vss_t* vss_pdu, uint16_t payload_length) {
+void Avtp_Vss_SetPayloadLength(Avtp_Vss_t *vss_pdu, uint16_t payload_length)
+{
 
     uint8_t padSize;
     uint16_t msgLenBytes;
@@ -156,60 +153,70 @@ void Avtp_Vss_SetPayloadLength(Avtp_Vss_t* vss_pdu, uint16_t payload_length) {
     msgLenBytes = AVTP_VSS_FIXED_HEADER_LEN + payload_length;
 
     // Check if padding is required
-    padSize = (uint8_t)((AVTP_QUADLET_SIZE - (msgLenBytes % AVTP_QUADLET_SIZE)) % AVTP_QUADLET_SIZE);
+    padSize =
+        (uint8_t)((AVTP_QUADLET_SIZE - (msgLenBytes % AVTP_QUADLET_SIZE)) % AVTP_QUADLET_SIZE);
     if (msgLenBytes % AVTP_QUADLET_SIZE) {
-        memset((uint8_t*)vss_pdu + msgLenBytes, 0, padSize);
+        memset((uint8_t *)vss_pdu + msgLenBytes, 0, padSize);
     }
 
     // Set the length and padding fields
     padded_length = msgLenBytes + padSize;
     Avtp_Vss_SetField(vss_pdu, AVTP_VSS_FIELD_ACF_MSG_LENGTH,
-                        (uint64_t)(padded_length / AVTP_QUADLET_SIZE));
+                      (uint64_t)(padded_length / AVTP_QUADLET_SIZE));
     Avtp_Vss_SetField(vss_pdu, AVTP_VSS_FIELD_PAD, padSize);
 }
 
-Avtp_AcfMsgType_t Avtp_Vss_GetAcfMsgType(const Avtp_Vss_t* const pdu) {
+Avtp_AcfMsgType_t Avtp_Vss_GetAcfMsgType(const Avtp_Vss_t *const pdu)
+{
     return GET_FIELD(AVTP_VSS_FIELD_ACF_MSG_TYPE);
 }
 
-uint16_t Avtp_Vss_GetAcfMsgLength(const Avtp_Vss_t* const pdu) {
+uint16_t Avtp_Vss_GetAcfMsgLength(const Avtp_Vss_t *const pdu)
+{
     return (uint16_t)GET_FIELD(AVTP_VSS_FIELD_ACF_MSG_LENGTH);
 }
 
-uint8_t Avtp_Vss_GetPad(const Avtp_Vss_t* const pdu) {
+uint8_t Avtp_Vss_GetPad(const Avtp_Vss_t *const pdu)
+{
     return (uint8_t)GET_FIELD(AVTP_VSS_FIELD_PAD);
 }
 
-bool Avtp_Vss_IsMtv(const Avtp_Vss_t* const pdu) {
+bool Avtp_Vss_IsMtv(const Avtp_Vss_t *const pdu)
+{
     return (bool)GET_FIELD(AVTP_VSS_FIELD_MTV);
 }
 
-Vss_AddrMode_t Avtp_Vss_GetAddrMode(const Avtp_Vss_t* const pdu) {
+Vss_AddrMode_t Avtp_Vss_GetAddrMode(const Avtp_Vss_t *const pdu)
+{
     return GET_FIELD(AVTP_VSS_FIELD_ADDR_MODE);
 }
 
-Vss_OpCode_t Avtp_Vss_GetOpCode(const Avtp_Vss_t* const pdu) {
+Vss_OpCode_t Avtp_Vss_GetOpCode(const Avtp_Vss_t *const pdu)
+{
     return GET_FIELD(AVTP_VSS_FIELD_VSS_OP);
 }
 
-Vss_Datatype_t Avtp_Vss_GetDatatype(const Avtp_Vss_t* const pdu) {
+Vss_Datatype_t Avtp_Vss_GetDatatype(const Avtp_Vss_t *const pdu)
+{
     return GET_FIELD(AVTP_VSS_FIELD_VSS_DATATYPE);
 }
 
-uint64_t Avtp_Vss_GetMessageTimestamp(const Avtp_Vss_t* const pdu) {
+uint64_t Avtp_Vss_GetMessageTimestamp(const Avtp_Vss_t *const pdu)
+{
     return GET_FIELD(AVTP_VSS_FIELD_MESSAGE_TIMESTAMP);
 }
 
-void Avtp_Vss_GetVssPath(const Avtp_Vss_t* const pdu, VssPath_t* val) {
+void Avtp_Vss_GetVssPath(const Avtp_Vss_t *const pdu, VssPath_t *val)
+{
 
-    const uint8_t* vss_path_ptr = (const uint8_t* const) pdu + AVTP_VSS_FIXED_HEADER_LEN;
+    const uint8_t *vss_path_ptr = (const uint8_t *const)pdu + AVTP_VSS_FIXED_HEADER_LEN;
     Vss_AddrMode_t addr_mode = Avtp_Vss_GetAddrMode(pdu);
     uint16_t clamped_len = vss_get_clamped_path_length(pdu);
 
     if (addr_mode == VSS_STATIC_ID_MODE) {
         /* Fixed 4‑byte path: only read it when the frame is large enough. */
         if (clamped_len >= 4)
-            val->vss_static_id_path = Avtp_BeToCpu32(*(const uint32_t*)vss_path_ptr);
+            val->vss_static_id_path = Avtp_BeToCpu32(*(const uint32_t *)vss_path_ptr);
         else
             val->vss_static_id_path = 0;
     } else if (addr_mode == VSS_INTEROP_MODE) {
@@ -222,9 +229,10 @@ void Avtp_Vss_GetVssPath(const Avtp_Vss_t* const pdu, VssPath_t* val) {
     }
 }
 
-uint16_t Avtp_Vss_CalcVssPathLength(const Avtp_Vss_t* const pdu) {
+uint16_t Avtp_Vss_CalcVssPathLength(const Avtp_Vss_t *const pdu)
+{
 
-    const uint8_t* vss_path_ptr = (const uint8_t* const) pdu + AVTP_VSS_FIXED_HEADER_LEN;
+    const uint8_t *vss_path_ptr = (const uint8_t *const)pdu + AVTP_VSS_FIXED_HEADER_LEN;
 
     // Check the used VSS addressing mode
     Vss_AddrMode_t addr_mode = Avtp_Vss_GetAddrMode(pdu);
@@ -233,12 +241,13 @@ uint16_t Avtp_Vss_CalcVssPathLength(const Avtp_Vss_t* const pdu) {
     if (addr_mode == VSS_STATIC_ID_MODE) {
         path_length = 4;
     } else if (addr_mode == VSS_INTEROP_MODE) {
-        path_length = Avtp_BeToCpu16(*(const uint16_t*)vss_path_ptr) + 2;
+        path_length = Avtp_BeToCpu16(*(const uint16_t *)vss_path_ptr) + 2;
     }
     return path_length;
 }
 
-uint16_t Avtp_Vss_GetVSSDataStringArrayLength(const VssDataStringArray_t* const str_array) {
+uint16_t Avtp_Vss_GetVSSDataStringArrayLength(const VssDataStringArray_t *const str_array)
+{
     /* Walk the [length-prefix : 2 bytes][string : length bytes] pairs that
      * make up the on-wire string-array layout, counting how many fit in
      * str_array->data_length.
@@ -252,11 +261,12 @@ uint16_t Avtp_Vss_GetVSSDataStringArrayLength(const VssDataStringArray_t* const 
      * Return type uint16_t should be enough as any 1722 frame (raw or UDP) is
      * fundamentally limited by Ethernet frame size. */
     uint16_t total_length = str_array->data_length;
-    const uint8_t * vss_data_string_array_raw = str_array->data;
+    const uint8_t *vss_data_string_array_raw = str_array->data;
     uint16_t idx = 0, ptr_idx = 0;
     while ((uint32_t)ptr_idx + 2 <= total_length) {
 
-        uint16_t str_length = Avtp_BeToCpu16(*(const uint16_t*)(vss_data_string_array_raw+ptr_idx));
+        uint16_t str_length =
+            Avtp_BeToCpu16(*(const uint16_t *)(vss_data_string_array_raw + ptr_idx));
         if ((uint32_t)ptr_idx + 2 + str_length > total_length) {
             /* Truncated or malformed array: stop counting at the last
              * fully-contained string. */
@@ -269,42 +279,46 @@ uint16_t Avtp_Vss_GetVSSDataStringArrayLength(const VssDataStringArray_t* const 
     return idx;
 }
 
-void Avtp_Vss_DeserializeStringArray(const VssDataStringArray_t* const vss_data_string_array,
-                                     VssDataString_t* strings[],
-                                     uint16_t num_strings) {
+void Avtp_Vss_DeserializeStringArray(const VssDataStringArray_t *const vss_data_string_array,
+                                     VssDataString_t *strings[], uint16_t num_strings)
+{
     /* Same on-wire layout as in GetVSSDataStringArrayLength above, but here
      * we copy each string's body into the caller-supplied output structs.
-     *     
+     *
      * Track bytes consumed and validate (a) that 2 length-prefix bytes are
      * available before reading them, and (b) that str_length more bytes
      * are available before memcpy'ing them. The additions are computed in
      * uint32_t so the bound check itself cannot overflow. */
     uint16_t array_length = vss_data_string_array->data_length;
-    const uint8_t* array_data = vss_data_string_array->data;
+    const uint8_t *array_data = vss_data_string_array->data;
     uint16_t consumed = 0;
 
     for (uint16_t i = 0; i < num_strings; i++) {
-        if ((uint32_t)consumed + 2 > array_length) break;
+        if ((uint32_t)consumed + 2 > array_length)
+            break;
 
-        uint16_t str_length = Avtp_BeToCpu16(*(const uint16_t*)array_data);
-        if ((uint32_t)consumed + 2 + str_length > array_length) break;
+        uint16_t str_length = Avtp_BeToCpu16(*(const uint16_t *)array_data);
+        if ((uint32_t)consumed + 2 + str_length > array_length)
+            break;
 
-        if (strings[i] == NULL) break;
+        if (strings[i] == NULL)
+            break;
         strings[i]->data_length = str_length;
         if (strings[i]->data != NULL) {
             memcpy(strings[i]->data, array_data + 2, str_length);
         }
         array_data += 2 + str_length;
-        consumed   += (uint16_t)(2 + str_length);
+        consumed += (uint16_t)(2 + str_length);
     }
 }
 
-void Avtp_Vss_GetVssData(const Avtp_Vss_t* const pdu, VssData_t* val) {
+void Avtp_Vss_GetVssData(const Avtp_Vss_t *const pdu, VssData_t *val)
+{
 
     /* Compute the data pointer using the clamped getter‑side path length
      * so that the pointer itself never leaves the declared frame. */
-    const uint8_t* vss_data_ptr = (const uint8_t* const) pdu + AVTP_VSS_FIXED_HEADER_LEN +
-                                vss_get_clamped_path_length(pdu);
+    const uint8_t *vss_data_ptr =
+        (const uint8_t *const)pdu + AVTP_VSS_FIXED_HEADER_LEN + vss_get_clamped_path_length(pdu);
     Vss_Datatype_t datatype = Avtp_Vss_GetDatatype(pdu);
 
     uint32_t temp_float;
@@ -312,244 +326,258 @@ void Avtp_Vss_GetVssData(const Avtp_Vss_t* const pdu, VssData_t* val) {
 
     // Check VSS Datatype
     switch (datatype) {
-        case VSS_UINT8:
-            if (vss_has_bytes(pdu, vss_data_ptr, 1))
-                val->data_uint8 = *vss_data_ptr;
-            break;
+    case VSS_UINT8:
+        if (vss_has_bytes(pdu, vss_data_ptr, 1))
+            val->data_uint8 = *vss_data_ptr;
+        break;
 
-        case VSS_INT8:
-            if (vss_has_bytes(pdu, vss_data_ptr, 1))
-                val->data_int8 = *(const int8_t*) vss_data_ptr;
-            break;
+    case VSS_INT8:
+        if (vss_has_bytes(pdu, vss_data_ptr, 1))
+            val->data_int8 = *(const int8_t *)vss_data_ptr;
+        break;
 
-        case VSS_UINT16:
-            if (vss_has_bytes(pdu, vss_data_ptr, 2))
-                val->data_uint16 = Avtp_BeToCpu16(*(const uint16_t*) vss_data_ptr);
-            break;
+    case VSS_UINT16:
+        if (vss_has_bytes(pdu, vss_data_ptr, 2))
+            val->data_uint16 = Avtp_BeToCpu16(*(const uint16_t *)vss_data_ptr);
+        break;
 
-        case VSS_INT16:
-            if (vss_has_bytes(pdu, vss_data_ptr, 2))
-                val->data_int16 =  (int16_t) Avtp_BeToCpu16(*(const uint16_t*) vss_data_ptr);
-            break;
+    case VSS_INT16:
+        if (vss_has_bytes(pdu, vss_data_ptr, 2))
+            val->data_int16 = (int16_t)Avtp_BeToCpu16(*(const uint16_t *)vss_data_ptr);
+        break;
 
-        case VSS_UINT32:
-            if (vss_has_bytes(pdu, vss_data_ptr, 4))
-                val->data_uint32 = Avtp_BeToCpu32(*(const uint32_t*) vss_data_ptr);
-            break;
+    case VSS_UINT32:
+        if (vss_has_bytes(pdu, vss_data_ptr, 4))
+            val->data_uint32 = Avtp_BeToCpu32(*(const uint32_t *)vss_data_ptr);
+        break;
 
-        case VSS_INT32:
-            if (vss_has_bytes(pdu, vss_data_ptr, 4))
-                val->data_int32 = (int32_t) Avtp_BeToCpu32(*(const uint32_t*) vss_data_ptr);
-            break;
+    case VSS_INT32:
+        if (vss_has_bytes(pdu, vss_data_ptr, 4))
+            val->data_int32 = (int32_t)Avtp_BeToCpu32(*(const uint32_t *)vss_data_ptr);
+        break;
 
-        case VSS_UINT64:
-            if (vss_has_bytes(pdu, vss_data_ptr, 8))
-                val->data_uint64 = Avtp_BeToCpu64(*(const uint64_t*) vss_data_ptr);
-            break;
+    case VSS_UINT64:
+        if (vss_has_bytes(pdu, vss_data_ptr, 8))
+            val->data_uint64 = Avtp_BeToCpu64(*(const uint64_t *)vss_data_ptr);
+        break;
 
-        case VSS_INT64:
-            if (vss_has_bytes(pdu, vss_data_ptr, 8))
-                val->data_int64 = (int64_t) Avtp_BeToCpu64(*(const uint64_t*) vss_data_ptr);
-            break;
+    case VSS_INT64:
+        if (vss_has_bytes(pdu, vss_data_ptr, 8))
+            val->data_int64 = (int64_t)Avtp_BeToCpu64(*(const uint64_t *)vss_data_ptr);
+        break;
 
-        case VSS_BOOL:
-            if (vss_has_bytes(pdu, vss_data_ptr, 1))
-                val->data_bool = *vss_data_ptr;
-            break;
+    case VSS_BOOL:
+        if (vss_has_bytes(pdu, vss_data_ptr, 1))
+            val->data_bool = *vss_data_ptr;
+        break;
 
-        case VSS_FLOAT:
-            if (vss_has_bytes(pdu, vss_data_ptr, 4)) {
-                temp_float =  Avtp_BeToCpu32(*(const uint32_t*) vss_data_ptr);
-                memcpy(&(val->data_float), &temp_float, sizeof(float));
+    case VSS_FLOAT:
+        if (vss_has_bytes(pdu, vss_data_ptr, 4)) {
+            temp_float = Avtp_BeToCpu32(*(const uint32_t *)vss_data_ptr);
+            memcpy(&(val->data_float), &temp_float, sizeof(float));
+        }
+        break;
+
+    case VSS_DOUBLE:
+        if (vss_has_bytes(pdu, vss_data_ptr, 8)) {
+            temp_double = Avtp_BeToCpu64(*(const uint64_t *)vss_data_ptr);
+            memcpy(&(val->data_double), &temp_double, sizeof(double));
+        }
+        break;
+
+    case VSS_STRING:
+        val->data_string->data_length = vss_read_clamped_length(pdu, vss_data_ptr);
+        if (val->data_string->data != NULL) {
+            memcpy(val->data_string->data, vss_data_ptr + 2, val->data_string->data_length);
+        }
+        break;
+
+    case VSS_UINT8_ARRAY:
+        val->data_uint8_array->data_length = vss_read_clamped_length(pdu, vss_data_ptr);
+        if (val->data_uint8_array->data != NULL) {
+            memcpy(val->data_uint8_array->data, vss_data_ptr + 2,
+                   val->data_uint8_array->data_length);
+        }
+        break;
+
+    case VSS_INT8_ARRAY:
+        val->data_int8_array->data_length = vss_read_clamped_length(pdu, vss_data_ptr);
+        if (val->data_int8_array->data != NULL) {
+            memcpy(val->data_int8_array->data, vss_data_ptr + 2, val->data_int8_array->data_length);
+        }
+        break;
+
+    case VSS_UINT16_ARRAY:
+        val->data_uint16_array->data_length = vss_read_clamped_length(pdu, vss_data_ptr);
+        vss_data_ptr += 2;
+        if (val->data_uint16_array->data != NULL) {
+            for (uint16_t i = 0; i < (uint16_t)(val->data_uint16_array->data_length / 2); i++) {
+                *(val->data_uint16_array->data + i) =
+                    Avtp_BeToCpu16(*((const uint16_t *)vss_data_ptr + i));
             }
-            break;
+        }
+        break;
 
-        case VSS_DOUBLE:
-            if (vss_has_bytes(pdu, vss_data_ptr, 8)) {
-                temp_double = Avtp_BeToCpu64(*(const uint64_t*) vss_data_ptr);
-                memcpy(&(val->data_double), &temp_double, sizeof(double));
+    case VSS_INT16_ARRAY:
+        val->data_int16_array->data_length = vss_read_clamped_length(pdu, vss_data_ptr);
+        vss_data_ptr += 2;
+        if (val->data_int16_array->data != NULL) {
+            for (uint16_t i = 0; i < (uint16_t)(val->data_int16_array->data_length / 2); i++) {
+                *(val->data_int16_array->data + i) =
+                    (int16_t)Avtp_BeToCpu16(*((const uint16_t *)vss_data_ptr + i));
             }
-            break;
+        }
+        break;
 
-        case VSS_STRING:
-            val->data_string->data_length = vss_read_clamped_length(pdu, vss_data_ptr);
-            if (val->data_string->data != NULL) {
-                memcpy(val->data_string->data, vss_data_ptr+2, val->data_string->data_length);
+    case VSS_UINT32_ARRAY:
+        val->data_uint32_array->data_length = vss_read_clamped_length(pdu, vss_data_ptr);
+        vss_data_ptr += 2;
+        if (val->data_uint32_array->data != NULL) {
+            for (uint16_t i = 0; i < (uint16_t)(val->data_uint32_array->data_length / 4); i++) {
+                *(val->data_uint32_array->data + i) =
+                    Avtp_BeToCpu32(*((const uint32_t *)vss_data_ptr + i));
             }
-            break;
+        }
+        break;
 
-        case VSS_UINT8_ARRAY:
-            val->data_uint8_array->data_length = vss_read_clamped_length(pdu, vss_data_ptr);
-            if (val->data_uint8_array->data != NULL) {
-                memcpy(val->data_uint8_array->data, vss_data_ptr+2, val->data_uint8_array->data_length);
+    case VSS_INT32_ARRAY:
+        val->data_int32_array->data_length = vss_read_clamped_length(pdu, vss_data_ptr);
+        vss_data_ptr += 2;
+        if (val->data_int32_array->data != NULL) {
+            for (uint16_t i = 0; i < (uint16_t)(val->data_int32_array->data_length / 4); i++) {
+                *(val->data_int32_array->data + i) =
+                    (int32_t)Avtp_BeToCpu32(*((const uint32_t *)vss_data_ptr + i));
             }
-            break;
+        }
+        break;
 
-        case VSS_INT8_ARRAY:
-            val->data_int8_array->data_length = vss_read_clamped_length(pdu, vss_data_ptr);
-            if (val->data_int8_array->data != NULL) {
-                memcpy(val->data_int8_array->data, vss_data_ptr+2, val->data_int8_array->data_length);
+    case VSS_UINT64_ARRAY:
+        val->data_uint64_array->data_length = vss_read_clamped_length(pdu, vss_data_ptr);
+        vss_data_ptr += 2;
+        if (val->data_uint64_array->data != NULL) {
+            for (uint16_t i = 0; i < (uint16_t)(val->data_uint64_array->data_length / 8); i++) {
+                *(val->data_uint64_array->data + i) =
+                    Avtp_BeToCpu64(*((const uint64_t *)vss_data_ptr + i));
             }
-            break;
+        }
+        break;
 
-        case VSS_UINT16_ARRAY:
-            val->data_uint16_array->data_length = vss_read_clamped_length(pdu, vss_data_ptr);
-            vss_data_ptr += 2;
-            if (val->data_uint16_array->data != NULL) {
-                for (uint16_t i = 0; i < (uint16_t)(val->data_uint16_array->data_length/2); i++) {
-                    *(val->data_uint16_array->data + i) = Avtp_BeToCpu16(*((const uint16_t*)vss_data_ptr+i));
-                }
+    case VSS_INT64_ARRAY:
+        val->data_int64_array->data_length = vss_read_clamped_length(pdu, vss_data_ptr);
+        vss_data_ptr += 2;
+        if (val->data_int64_array->data != NULL) {
+            for (int i = 0; i < val->data_int64_array->data_length / 8; i++) {
+                *(val->data_int64_array->data + i) =
+                    (int64_t)Avtp_BeToCpu64(*((const uint64_t *)vss_data_ptr + i));
             }
-            break;
+        }
+        break;
 
-        case VSS_INT16_ARRAY:
-            val->data_int16_array->data_length = vss_read_clamped_length(pdu, vss_data_ptr);
-            vss_data_ptr += 2;
-            if (val->data_int16_array->data != NULL) {
-                for (uint16_t i = 0; i < (uint16_t)(val->data_int16_array->data_length/2); i++) {
-                    *(val->data_int16_array->data + i) = (int16_t) Avtp_BeToCpu16(*((const uint16_t*)vss_data_ptr+i));
-                }
+    case VSS_BOOL_ARRAY:
+        val->data_bool_array->data_length = vss_read_clamped_length(pdu, vss_data_ptr);
+        if (val->data_bool_array->data != NULL) {
+            memcpy(val->data_bool_array->data, vss_data_ptr + 2, val->data_bool_array->data_length);
+        }
+        break;
+
+    case VSS_FLOAT_ARRAY:
+        val->data_float_array->data_length = vss_read_clamped_length(pdu, vss_data_ptr);
+        vss_data_ptr += 2;
+        if (val->data_float_array->data != NULL) {
+            for (uint16_t i = 0; i < (uint16_t)(val->data_float_array->data_length / 4); i++) {
+                uint32_t temp_float = Avtp_BeToCpu32(*((const uint32_t *)vss_data_ptr + i));
+                memcpy(val->data_float_array->data + i, &temp_float, sizeof(float));
             }
-            break;
+        }
+        break;
 
-        case VSS_UINT32_ARRAY:
-            val->data_uint32_array->data_length = vss_read_clamped_length(pdu, vss_data_ptr);
-            vss_data_ptr += 2;
-            if (val->data_uint32_array->data != NULL) {
-                for (uint16_t i = 0; i < (uint16_t)(val->data_uint32_array->data_length/4); i++) {
-                    *(val->data_uint32_array->data + i) = Avtp_BeToCpu32(*((const uint32_t*)vss_data_ptr+i));
-                }
+    case VSS_DOUBLE_ARRAY:
+        val->data_double_array->data_length = vss_read_clamped_length(pdu, vss_data_ptr);
+        vss_data_ptr += 2;
+        if (val->data_double_array->data != NULL) {
+            for (uint16_t i = 0; i < (uint16_t)(val->data_double_array->data_length / 8); i++) {
+                uint64_t temp_double = Avtp_BeToCpu64(*((const uint64_t *)vss_data_ptr + i));
+                memcpy(val->data_double_array->data + i, &temp_double, sizeof(double));
             }
-            break;
+        }
+        break;
 
-        case VSS_INT32_ARRAY:
-            val->data_int32_array->data_length = vss_read_clamped_length(pdu, vss_data_ptr);
-            vss_data_ptr += 2;
-            if (val->data_int32_array->data != NULL) {
-                for (uint16_t i = 0; i < (uint16_t)(val->data_int32_array->data_length/4); i++) {
-                    *(val->data_int32_array->data + i) = (int32_t) Avtp_BeToCpu32(*((const uint32_t*)vss_data_ptr+i));
-                }
-            }
-            break;
+    case VSS_STRING_ARRAY:
+        val->data_string_array->data_length = vss_read_clamped_length(pdu, vss_data_ptr);
+        vss_data_ptr += 2;
+        if (val->data_string_array->data != NULL) {
+            memcpy(val->data_string_array->data, vss_data_ptr, val->data_string_array->data_length);
+        }
+        break;
 
-        case VSS_UINT64_ARRAY:
-            val->data_uint64_array->data_length = vss_read_clamped_length(pdu, vss_data_ptr);
-            vss_data_ptr += 2;
-            if (val->data_uint64_array->data != NULL) {
-                for (uint16_t i = 0; i < (uint16_t)(val->data_uint64_array->data_length/8); i++) {
-                    *(val->data_uint64_array->data + i) = Avtp_BeToCpu64(*((const uint64_t*)vss_data_ptr+i));
-                }
-            }
-            break;
-
-        case VSS_INT64_ARRAY:
-            val->data_int64_array->data_length = vss_read_clamped_length(pdu, vss_data_ptr);
-            vss_data_ptr += 2;
-            if (val->data_int64_array->data != NULL) {
-                for (int i = 0; i < val->data_int64_array->data_length/8; i++) {
-                    *(val->data_int64_array->data + i) = (int64_t) Avtp_BeToCpu64(*((const uint64_t*)vss_data_ptr+i));
-                }
-            }
-            break;
-
-        case VSS_BOOL_ARRAY:
-            val->data_bool_array->data_length = vss_read_clamped_length(pdu, vss_data_ptr);
-            if (val->data_bool_array->data != NULL) {
-                memcpy(val->data_bool_array->data, vss_data_ptr+2, val->data_bool_array->data_length);
-            }
-            break;
-
-        case VSS_FLOAT_ARRAY:
-            val->data_float_array->data_length = vss_read_clamped_length(pdu, vss_data_ptr);
-            vss_data_ptr += 2;
-            if (val->data_float_array->data != NULL) {
-                for (uint16_t i = 0; i < (uint16_t)(val->data_float_array->data_length/4); i++) {
-                    uint32_t temp_float = Avtp_BeToCpu32(*((const uint32_t*)vss_data_ptr+i));
-                    memcpy(val->data_float_array->data + i, &temp_float, sizeof(float));
-                }
-            }
-            break;
-
-        case VSS_DOUBLE_ARRAY:
-            val->data_double_array->data_length = vss_read_clamped_length(pdu, vss_data_ptr);
-            vss_data_ptr += 2;
-            if (val->data_double_array->data != NULL) {
-                for (uint16_t i = 0; i < (uint16_t)(val->data_double_array->data_length/8); i++) {
-                    uint64_t temp_double = Avtp_BeToCpu64(*((const uint64_t*)vss_data_ptr+i));
-                    memcpy(val->data_double_array->data + i, &temp_double, sizeof(double));
-                }
-            }
-            break;
-
-        case VSS_STRING_ARRAY:
-            val->data_string_array->data_length = vss_read_clamped_length(pdu, vss_data_ptr);
-            vss_data_ptr += 2;
-            if (val->data_string_array->data != NULL) {
-                memcpy(val->data_string_array->data, vss_data_ptr, val->data_string_array->data_length);
-            }
-            break;
-
-        default:
-            break;
-
+    default:
+        break;
     }
 }
 
-void Avtp_Vss_SetAcfMsgType(Avtp_Vss_t* pdu, Avtp_AcfMsgType_t val) {
+void Avtp_Vss_SetAcfMsgType(Avtp_Vss_t *pdu, Avtp_AcfMsgType_t val)
+{
     SET_FIELD(AVTP_VSS_FIELD_ACF_MSG_TYPE, val);
 }
 
-void Avtp_Vss_SetAcfMsgLength(Avtp_Vss_t* pdu, uint16_t val) {
+void Avtp_Vss_SetAcfMsgLength(Avtp_Vss_t *pdu, uint16_t val)
+{
     SET_FIELD(AVTP_VSS_FIELD_ACF_MSG_LENGTH, val);
 }
 
-void Avtp_Vss_SetPad(Avtp_Vss_t* pdu, uint8_t val) {
+void Avtp_Vss_SetPad(Avtp_Vss_t *pdu, uint8_t val)
+{
     SET_FIELD(AVTP_VSS_FIELD_PAD, val);
 }
 
-void Avtp_Vss_SetMtv(Avtp_Vss_t* pdu, bool mtv)
+void Avtp_Vss_SetMtv(Avtp_Vss_t *pdu, bool mtv)
 {
     SET_FIELD(AVTP_VSS_FIELD_MTV, mtv);
 }
 
-void Avtp_Vss_SetAddrMode(Avtp_Vss_t* pdu, Vss_AddrMode_t val) {
+void Avtp_Vss_SetAddrMode(Avtp_Vss_t *pdu, Vss_AddrMode_t val)
+{
     SET_FIELD(AVTP_VSS_FIELD_ADDR_MODE, val);
 }
 
-void Avtp_Vss_SetOpCode(Avtp_Vss_t* pdu, Vss_OpCode_t val) {
+void Avtp_Vss_SetOpCode(Avtp_Vss_t *pdu, Vss_OpCode_t val)
+{
     SET_FIELD(AVTP_VSS_FIELD_VSS_OP, val);
 }
 
-void Avtp_Vss_SetDatatype(Avtp_Vss_t* pdu, Vss_Datatype_t val) {
+void Avtp_Vss_SetDatatype(Avtp_Vss_t *pdu, Vss_Datatype_t val)
+{
     SET_FIELD(AVTP_VSS_FIELD_VSS_DATATYPE, val);
 }
 
-void Avtp_Vss_SetMessageTimestamp(Avtp_Vss_t* pdu, uint64_t val)  {
-    SET_FIELD(AVTP_VSS_FIELD_MESSAGE_TIMESTAMP, val);
- }
-
-void Avtp_Vss_SetVssPath(Avtp_Vss_t* pdu, VssPath_t* val)
+void Avtp_Vss_SetMessageTimestamp(Avtp_Vss_t *pdu, uint64_t val)
 {
-    uint8_t* vss_path_ptr = (uint8_t*) pdu + AVTP_VSS_FIXED_HEADER_LEN;
+    SET_FIELD(AVTP_VSS_FIELD_MESSAGE_TIMESTAMP, val);
+}
+
+void Avtp_Vss_SetVssPath(Avtp_Vss_t *pdu, VssPath_t *val)
+{
+    uint8_t *vss_path_ptr = (uint8_t *)pdu + AVTP_VSS_FIXED_HEADER_LEN;
 
     // Check the used VSS addressing mode
     Vss_AddrMode_t addr_mode = Avtp_Vss_GetAddrMode(pdu);
 
     if (addr_mode == VSS_STATIC_ID_MODE) {
-        uint32_t* static_id = (uint32_t*) vss_path_ptr;
+        uint32_t *static_id = (uint32_t *)vss_path_ptr;
         *static_id = Avtp_CpuToBe32(val->vss_static_id_path);
     } else if (addr_mode == VSS_INTEROP_MODE) {
-        uint16_t* interop_path_len = (uint16_t*) vss_path_ptr;
+        uint16_t *interop_path_len = (uint16_t *)vss_path_ptr;
         *interop_path_len = Avtp_CpuToBe16(val->vss_interop_path.path_length);
-        memcpy(vss_path_ptr+2, val->vss_interop_path.path, val->vss_interop_path.path_length);
+        memcpy(vss_path_ptr + 2, val->vss_interop_path.path, val->vss_interop_path.path_length);
     }
 }
 
-void Avtp_Vss_SetVssData(Avtp_Vss_t* pdu, VssData_t* val) {
+void Avtp_Vss_SetVssData(Avtp_Vss_t *pdu, VssData_t *val)
+{
 
     // Get a pointer to the start of the VSS data
-    uint8_t* vss_data_ptr = (uint8_t*) pdu + AVTP_VSS_FIXED_HEADER_LEN +
-                                Avtp_Vss_CalcVssPathLength(pdu);
+    uint8_t *vss_data_ptr =
+        (uint8_t *)pdu + AVTP_VSS_FIXED_HEADER_LEN + Avtp_Vss_CalcVssPathLength(pdu);
     Vss_Datatype_t datatype = Avtp_Vss_GetDatatype(pdu);
 
     uint32_t temp_float;
@@ -557,152 +585,153 @@ void Avtp_Vss_SetVssData(Avtp_Vss_t* pdu, VssData_t* val) {
 
     // Check VSS Datatype
     switch (datatype) {
-        case VSS_UINT8:
-            *vss_data_ptr = val->data_uint8;
-            break;
+    case VSS_UINT8:
+        *vss_data_ptr = val->data_uint8;
+        break;
 
-        case VSS_INT8:
-            *(int8_t*) vss_data_ptr = val->data_int8;
-            break;
+    case VSS_INT8:
+        *(int8_t *)vss_data_ptr = val->data_int8;
+        break;
 
-        case VSS_UINT16:
-            *(uint16_t*) vss_data_ptr = Avtp_CpuToBe16(val->data_uint16);
-            break;
+    case VSS_UINT16:
+        *(uint16_t *)vss_data_ptr = Avtp_CpuToBe16(val->data_uint16);
+        break;
 
-        case VSS_INT16:
-            *(int16_t*) vss_data_ptr = (int16_t)Avtp_CpuToBe16((uint16_t)val->data_int16);
-            break;
+    case VSS_INT16:
+        *(int16_t *)vss_data_ptr = (int16_t)Avtp_CpuToBe16((uint16_t)val->data_int16);
+        break;
 
-        case VSS_UINT32:
-            *(uint32_t*) vss_data_ptr = Avtp_CpuToBe32(val->data_uint32);
-            break;
+    case VSS_UINT32:
+        *(uint32_t *)vss_data_ptr = Avtp_CpuToBe32(val->data_uint32);
+        break;
 
-        case VSS_INT32:
-            *(int32_t*) vss_data_ptr = (int32_t)Avtp_CpuToBe32((uint32_t)val->data_int32);
-            break;
+    case VSS_INT32:
+        *(int32_t *)vss_data_ptr = (int32_t)Avtp_CpuToBe32((uint32_t)val->data_int32);
+        break;
 
-        case VSS_UINT64:
-            *(uint64_t*) vss_data_ptr = Avtp_CpuToBe64(val->data_uint64);
-            break;
+    case VSS_UINT64:
+        *(uint64_t *)vss_data_ptr = Avtp_CpuToBe64(val->data_uint64);
+        break;
 
-        case VSS_INT64:
-            *(int64_t*) vss_data_ptr = (int64_t)Avtp_CpuToBe64((uint64_t)val->data_int64);
-            break;
+    case VSS_INT64:
+        *(int64_t *)vss_data_ptr = (int64_t)Avtp_CpuToBe64((uint64_t)val->data_int64);
+        break;
 
-        case VSS_BOOL:
-            *vss_data_ptr = val->data_bool;
-            break;
+    case VSS_BOOL:
+        *vss_data_ptr = val->data_bool;
+        break;
 
-        case VSS_FLOAT:
-            temp_float = Avtp_CpuToBe32(*(uint32_t*)&(val->data_float));
-            memcpy(vss_data_ptr, &temp_float, sizeof(float));
-            break;
+    case VSS_FLOAT:
+        temp_float = Avtp_CpuToBe32(*(uint32_t *)&(val->data_float));
+        memcpy(vss_data_ptr, &temp_float, sizeof(float));
+        break;
 
-        case VSS_DOUBLE:
-            temp_double = Avtp_CpuToBe64(*(uint64_t*)&(val->data_double));
-            memcpy(vss_data_ptr, &temp_double, sizeof(double));
-            break;
+    case VSS_DOUBLE:
+        temp_double = Avtp_CpuToBe64(*(uint64_t *)&(val->data_double));
+        memcpy(vss_data_ptr, &temp_double, sizeof(double));
+        break;
 
-        case VSS_STRING:
-            *(uint16_t*)vss_data_ptr = Avtp_CpuToBe16(val->data_string->data_length);
-            memcpy(vss_data_ptr+2, val->data_string->data,
-                    val->data_string->data_length);
-            break;
+    case VSS_STRING:
+        *(uint16_t *)vss_data_ptr = Avtp_CpuToBe16(val->data_string->data_length);
+        memcpy(vss_data_ptr + 2, val->data_string->data, val->data_string->data_length);
+        break;
 
-        case VSS_UINT8_ARRAY:
-            *(uint16_t*)vss_data_ptr = Avtp_CpuToBe16(val->data_uint8_array->data_length);
-            memcpy(vss_data_ptr+2, val->data_uint8_array->data,
-                    val->data_uint8_array->data_length);
-            break;
+    case VSS_UINT8_ARRAY:
+        *(uint16_t *)vss_data_ptr = Avtp_CpuToBe16(val->data_uint8_array->data_length);
+        memcpy(vss_data_ptr + 2, val->data_uint8_array->data, val->data_uint8_array->data_length);
+        break;
 
-        case VSS_INT8_ARRAY:
-            *(uint16_t*)vss_data_ptr = Avtp_CpuToBe16(val->data_int8_array->data_length);
-            memcpy(vss_data_ptr+2, val->data_int8_array->data,
-                    val->data_int8_array->data_length);
-            break;
+    case VSS_INT8_ARRAY:
+        *(uint16_t *)vss_data_ptr = Avtp_CpuToBe16(val->data_int8_array->data_length);
+        memcpy(vss_data_ptr + 2, val->data_int8_array->data, val->data_int8_array->data_length);
+        break;
 
-        case VSS_UINT16_ARRAY:
-            *(uint16_t*)vss_data_ptr = Avtp_CpuToBe16(val->data_uint16_array->data_length);
-            for (uint16_t i = 0; i < (uint16_t)(val->data_uint16_array->data_length/2); i++) {
-                *((uint16_t*)(vss_data_ptr+2) + i) = Avtp_CpuToBe16(*(val->data_uint16_array->data+i));
-            }
-            break;
+    case VSS_UINT16_ARRAY:
+        *(uint16_t *)vss_data_ptr = Avtp_CpuToBe16(val->data_uint16_array->data_length);
+        for (uint16_t i = 0; i < (uint16_t)(val->data_uint16_array->data_length / 2); i++) {
+            *((uint16_t *)(vss_data_ptr + 2) + i) =
+                Avtp_CpuToBe16(*(val->data_uint16_array->data + i));
+        }
+        break;
 
-        case VSS_INT16_ARRAY:
-            *(uint16_t*)vss_data_ptr = Avtp_CpuToBe16(val->data_int16_array->data_length);
-            for (uint16_t i = 0; i < val->data_int16_array->data_length/2; i++) {
-                *((int16_t*)(vss_data_ptr+2) + i) = (int16_t)Avtp_CpuToBe16(*(uint16_t*)(val->data_int16_array->data+i));
-            }
-            break;
+    case VSS_INT16_ARRAY:
+        *(uint16_t *)vss_data_ptr = Avtp_CpuToBe16(val->data_int16_array->data_length);
+        for (uint16_t i = 0; i < val->data_int16_array->data_length / 2; i++) {
+            *((int16_t *)(vss_data_ptr + 2) + i) =
+                (int16_t)Avtp_CpuToBe16(*(uint16_t *)(val->data_int16_array->data + i));
+        }
+        break;
 
-        case VSS_UINT32_ARRAY:
-            *(uint16_t*)vss_data_ptr = Avtp_CpuToBe16(val->data_uint32_array->data_length);
-            for (uint16_t i = 0; i < (uint16_t)(val->data_uint32_array->data_length/4); i++) {
-                *((uint32_t*)(vss_data_ptr+2) + i) = Avtp_CpuToBe32(*(val->data_uint32_array->data+i));
-            }
-            break;
+    case VSS_UINT32_ARRAY:
+        *(uint16_t *)vss_data_ptr = Avtp_CpuToBe16(val->data_uint32_array->data_length);
+        for (uint16_t i = 0; i < (uint16_t)(val->data_uint32_array->data_length / 4); i++) {
+            *((uint32_t *)(vss_data_ptr + 2) + i) =
+                Avtp_CpuToBe32(*(val->data_uint32_array->data + i));
+        }
+        break;
 
-        case VSS_INT32_ARRAY:
-            *(uint16_t*)vss_data_ptr = Avtp_CpuToBe16(val->data_int32_array->data_length);
-            for (uint16_t i = 0; i < val->data_int32_array->data_length/4; i++) {
-                *((int32_t*)(vss_data_ptr+2) + i) = (int32_t)Avtp_CpuToBe32(*(uint32_t*)(val->data_int32_array->data+i));
-            }
-            break;
+    case VSS_INT32_ARRAY:
+        *(uint16_t *)vss_data_ptr = Avtp_CpuToBe16(val->data_int32_array->data_length);
+        for (uint16_t i = 0; i < val->data_int32_array->data_length / 4; i++) {
+            *((int32_t *)(vss_data_ptr + 2) + i) =
+                (int32_t)Avtp_CpuToBe32(*(uint32_t *)(val->data_int32_array->data + i));
+        }
+        break;
 
-        case VSS_UINT64_ARRAY:
-            *(uint16_t*)vss_data_ptr = Avtp_CpuToBe16(val->data_uint64_array->data_length);
-            for (uint16_t i = 0; i < (uint16_t)(val->data_uint64_array->data_length/8); i++) {
-                *((uint64_t*)(vss_data_ptr+2) + i) = Avtp_CpuToBe64(*(val->data_uint64_array->data+i));
-            }
-            break;
+    case VSS_UINT64_ARRAY:
+        *(uint16_t *)vss_data_ptr = Avtp_CpuToBe16(val->data_uint64_array->data_length);
+        for (uint16_t i = 0; i < (uint16_t)(val->data_uint64_array->data_length / 8); i++) {
+            *((uint64_t *)(vss_data_ptr + 2) + i) =
+                Avtp_CpuToBe64(*(val->data_uint64_array->data + i));
+        }
+        break;
 
-        case VSS_INT64_ARRAY:
-            *(uint16_t*)vss_data_ptr = Avtp_CpuToBe16(val->data_int64_array->data_length);
-            for (uint16_t i = 0; i < val->data_int64_array->data_length/8; i++) {
-                *((int64_t*)(vss_data_ptr+2) + i) = (int64_t)Avtp_CpuToBe64(*(uint64_t*)(val->data_int64_array->data+i));
-            }
-            break;
+    case VSS_INT64_ARRAY:
+        *(uint16_t *)vss_data_ptr = Avtp_CpuToBe16(val->data_int64_array->data_length);
+        for (uint16_t i = 0; i < val->data_int64_array->data_length / 8; i++) {
+            *((int64_t *)(vss_data_ptr + 2) + i) =
+                (int64_t)Avtp_CpuToBe64(*(uint64_t *)(val->data_int64_array->data + i));
+        }
+        break;
 
-        case VSS_BOOL_ARRAY:
-            *(uint16_t*)vss_data_ptr = Avtp_CpuToBe16(val->data_bool_array->data_length);
-            memcpy(vss_data_ptr+2, val->data_bool_array->data,
-                    val->data_bool_array->data_length);
-            break;
+    case VSS_BOOL_ARRAY:
+        *(uint16_t *)vss_data_ptr = Avtp_CpuToBe16(val->data_bool_array->data_length);
+        memcpy(vss_data_ptr + 2, val->data_bool_array->data, val->data_bool_array->data_length);
+        break;
 
-        case VSS_FLOAT_ARRAY:
-            *(uint16_t*)vss_data_ptr = Avtp_CpuToBe16(val->data_float_array->data_length);
-            for (uint16_t i = 0; i < (uint16_t)(val->data_float_array->data_length/4); i++) {
-                uint32_t temp_float = Avtp_CpuToBe32(*(uint32_t*)(val->data_float_array->data+i));
-                memcpy((uint32_t*)(vss_data_ptr+2) + i, &temp_float, sizeof(float));
-            }
-            break;
+    case VSS_FLOAT_ARRAY:
+        *(uint16_t *)vss_data_ptr = Avtp_CpuToBe16(val->data_float_array->data_length);
+        for (uint16_t i = 0; i < (uint16_t)(val->data_float_array->data_length / 4); i++) {
+            uint32_t temp_float = Avtp_CpuToBe32(*(uint32_t *)(val->data_float_array->data + i));
+            memcpy((uint32_t *)(vss_data_ptr + 2) + i, &temp_float, sizeof(float));
+        }
+        break;
 
-        case VSS_DOUBLE_ARRAY:
-            *(uint16_t*)vss_data_ptr = Avtp_CpuToBe16(val->data_double_array->data_length);
-            for (uint16_t i = 0; i < (uint16_t)(val->data_double_array->data_length/8); i++) {
-                uint64_t temp_double = Avtp_CpuToBe64(*(uint64_t*)(val->data_double_array->data+i));
-                memcpy((uint64_t*)(vss_data_ptr+2) + i, &temp_double, sizeof(double));
-            }
-            break;
+    case VSS_DOUBLE_ARRAY:
+        *(uint16_t *)vss_data_ptr = Avtp_CpuToBe16(val->data_double_array->data_length);
+        for (uint16_t i = 0; i < (uint16_t)(val->data_double_array->data_length / 8); i++) {
+            uint64_t temp_double = Avtp_CpuToBe64(*(uint64_t *)(val->data_double_array->data + i));
+            memcpy((uint64_t *)(vss_data_ptr + 2) + i, &temp_double, sizeof(double));
+        }
+        break;
 
-        case VSS_STRING_ARRAY:
-            *(uint16_t*)vss_data_ptr = Avtp_CpuToBe16(val->data_string_array->data_length);
-            vss_data_ptr += 2;
-            memcpy(vss_data_ptr, val->data_string_array->data, val->data_string_array->data_length);
-            break;
+    case VSS_STRING_ARRAY:
+        *(uint16_t *)vss_data_ptr = Avtp_CpuToBe16(val->data_string_array->data_length);
+        vss_data_ptr += 2;
+        memcpy(vss_data_ptr, val->data_string_array->data, val->data_string_array->data_length);
+        break;
 
-        default:
-            break;
-
+    default:
+        break;
     }
-
 }
 
-void Avtp_Vss_SerializeStringArray(VssDataStringArray_t* vss_data_string_array,
-                                   VssDataString_t* strings[], uint16_t num_strings) {
+void Avtp_Vss_SerializeStringArray(VssDataStringArray_t *vss_data_string_array,
+                                   VssDataString_t *strings[], uint16_t num_strings)
+{
 
     uint32_t total_length = 0;
-    uint8_t* data = vss_data_string_array->data;
+    uint8_t *data = vss_data_string_array->data;
     for (uint16_t i = 0; i < num_strings; i++) {
         uint32_t entry_size = (uint32_t)strings[i]->data_length + 2;
         if (total_length + entry_size > UINT16_MAX) {
@@ -710,10 +739,9 @@ void Avtp_Vss_SerializeStringArray(VssDataStringArray_t* vss_data_string_array,
         }
         total_length += entry_size;
 
-        *(uint16_t*)data = Avtp_CpuToBe16(strings[i]->data_length);
-        memcpy(data+2, strings[i]->data, strings[i]->data_length);
+        *(uint16_t *)data = Avtp_CpuToBe16(strings[i]->data_length);
+        memcpy(data + 2, strings[i]->data, strings[i]->data_length);
         data += entry_size;
     }
     vss_data_string_array->data_length = (uint16_t)total_length;
-
 }

--- a/unit/test-vss.c
+++ b/unit/test-vss.c
@@ -46,59 +46,60 @@ extern "C" {
 #include "avtp/acf/custom/Vss.h"
 #include "avtp/acf/AcfCommon.h"
 
-#define MAX_PDU_SIZE        1500
+#define MAX_PDU_SIZE 1500
 
-static void vss_init(void **state) {
+static void vss_init(void **state)
+{
 
     uint8_t pdu[MAX_PDU_SIZE];
     uint8_t init_pdu[AVTP_VSS_FIXED_HEADER_LEN];
 
     // Check if the function is initializing properly
-    Avtp_Vss_Init((Avtp_Vss_t*)pdu);
+    Avtp_Vss_Init((Avtp_Vss_t *)pdu);
     memset(init_pdu, 0, AVTP_VSS_FIXED_HEADER_LEN);
     init_pdu[0] = 0x42 << 1; // Setting ACF type as ACF_VSS
     assert_memory_equal(init_pdu, pdu, AVTP_VSS_FIXED_HEADER_LEN);
 
-    Avtp_AcfMsgType_t type = Avtp_AcfCommon_GetAcfMsgType((Avtp_AcfCommon_t*) pdu);
+    Avtp_AcfMsgType_t type = Avtp_AcfCommon_GetAcfMsgType((Avtp_AcfCommon_t *)pdu);
     assert_int_equal(type, 0x42);
 }
 
-static void vss_pad(void **state) {
+static void vss_pad(void **state)
+{
 
     uint8_t pdu[MAX_PDU_SIZE];
-    Avtp_Vss_t* vss_pdu = (Avtp_Vss_t*) pdu;
+    Avtp_Vss_t *vss_pdu = (Avtp_Vss_t *)pdu;
     Avtp_Vss_Init(vss_pdu);
     Avtp_Vss_SetAcfMsgLength(vss_pdu, 20);
 
     // Check if the function is initializing properly
     Avtp_Vss_Init(vss_pdu);
 
-    for(int i = 1; i < 4; i++) {
+    for (int i = 1; i < 4; i++) {
         Avtp_Vss_SetPayloadLength(vss_pdu, i);
 
         uint8_t vss_quadlets = Avtp_Vss_GetAcfMsgLength(vss_pdu);
-        assert_int_equal(vss_quadlets, AVTP_VSS_FIXED_HEADER_LEN/4 + 1);
+        assert_int_equal(vss_quadlets, AVTP_VSS_FIXED_HEADER_LEN / 4 + 1);
 
         uint8_t vss_pad = Avtp_Vss_GetPad(vss_pdu);
-        assert_int_equal(vss_pad, 4-i);
+        assert_int_equal(vss_pad, 4 - i);
     }
 }
 
-static void vss_static_path(void **state) {
+static void vss_static_path(void **state)
+{
 
     uint8_t pdu[MAX_PDU_SIZE];
-    Avtp_Vss_t* vss_pdu = (Avtp_Vss_t*) pdu;
+    Avtp_Vss_t *vss_pdu = (Avtp_Vss_t *)pdu;
     Avtp_Vss_Init(vss_pdu);
     Avtp_Vss_SetAcfMsgLength(vss_pdu, 20);
 
-    VssPath_t path_id = {
-        .vss_static_id_path = 0x01020304
-    };
+    VssPath_t path_id = {.vss_static_id_path = 0x01020304};
     Avtp_Vss_SetAddrMode(vss_pdu, VSS_STATIC_ID_MODE);
     Avtp_Vss_SetVssPath(vss_pdu, &path_id);
 
-    uint8_t exp_static_id[] = {1,2,3,4};
-    assert_memory_equal(pdu+AVTP_VSS_FIXED_HEADER_LEN, exp_static_id, 4);
+    uint8_t exp_static_id[] = {1, 2, 3, 4};
+    assert_memory_equal(pdu + AVTP_VSS_FIXED_HEADER_LEN, exp_static_id, 4);
 
     VssPath_t get_path_id;
     Avtp_Vss_GetVssPath(vss_pdu, &get_path_id);
@@ -107,10 +108,11 @@ static void vss_static_path(void **state) {
     assert_int_equal(Avtp_Vss_CalcVssPathLength(vss_pdu), 4);
 }
 
-static void vss_interop_path(void **state) {
+static void vss_interop_path(void **state)
+{
 
     uint8_t pdu[MAX_PDU_SIZE];
-    Avtp_Vss_t* vss_pdu = (Avtp_Vss_t*) pdu;
+    Avtp_Vss_t *vss_pdu = (Avtp_Vss_t *)pdu;
     Avtp_Vss_Init(vss_pdu);
     Avtp_Vss_SetAcfMsgLength(vss_pdu, 20);
 
@@ -124,7 +126,7 @@ static void vss_interop_path(void **state) {
     Avtp_Vss_SetVssPath(vss_pdu, &path_id);
 
     uint8_t get_path_len[] = {0, 13};
-    assert_memory_equal(pdu+AVTP_VSS_FIXED_HEADER_LEN, get_path_len, 2);
+    assert_memory_equal(pdu + AVTP_VSS_FIXED_HEADER_LEN, get_path_len, 2);
     assert_int_equal(Avtp_Vss_GetAddrMode(vss_pdu), VSS_INTEROP_MODE);
     assert_int_equal(Avtp_Vss_CalcVssPathLength(vss_pdu), 15);
 
@@ -134,13 +136,13 @@ static void vss_interop_path(void **state) {
     Avtp_Vss_GetVssPath(vss_pdu, &get_vss_path);
     assert_int_equal(get_vss_path.vss_interop_path.path_length, 13);
     assert_memory_equal(get_vss_path.vss_interop_path.path, path, 13);
-
 }
 
-static void vss_data_uint8(void **state) {
+static void vss_data_uint8(void **state)
+{
 
     uint8_t pdu[MAX_PDU_SIZE];
-    Avtp_Vss_t* vss_pdu = (Avtp_Vss_t*) pdu;
+    Avtp_Vss_t *vss_pdu = (Avtp_Vss_t *)pdu;
     Avtp_Vss_Init(vss_pdu);
     Avtp_Vss_SetAcfMsgLength(vss_pdu, 20);
     char path[] = "Vehicle.Speed";
@@ -152,9 +154,7 @@ static void vss_data_uint8(void **state) {
     Avtp_Vss_SetAddrMode(vss_pdu, VSS_INTEROP_MODE);
     Avtp_Vss_SetVssPath(vss_pdu, &path_id);
 
-    VssData_t vss_data_uint8 = {
-        .data_uint8 = 0x05
-    };
+    VssData_t vss_data_uint8 = {.data_uint8 = 0x05};
     Avtp_Vss_SetDatatype(vss_pdu, VSS_UINT8);
     Avtp_Vss_SetVssData(vss_pdu, &vss_data_uint8);
     uint8_t mem[] = {5};
@@ -164,13 +164,13 @@ static void vss_data_uint8(void **state) {
     assert_int_equal(Avtp_Vss_GetDatatype(vss_pdu), VSS_UINT8);
     Avtp_Vss_GetVssData(vss_pdu, &vss_data_uint8_get);
     assert_int_equal(vss_data_uint8_get.data_uint8, 0x05);
-
 }
 
-static void vss_data_int8(void **state) {
+static void vss_data_int8(void **state)
+{
 
     uint8_t pdu[MAX_PDU_SIZE];
-    Avtp_Vss_t* vss_pdu = (Avtp_Vss_t*) pdu;
+    Avtp_Vss_t *vss_pdu = (Avtp_Vss_t *)pdu;
     Avtp_Vss_Init(vss_pdu);
     Avtp_Vss_SetAcfMsgLength(vss_pdu, 20);
     char path[] = "Vehicle.Speed";
@@ -182,25 +182,23 @@ static void vss_data_int8(void **state) {
     Avtp_Vss_SetAddrMode(vss_pdu, VSS_INTEROP_MODE);
     Avtp_Vss_SetVssPath(vss_pdu, &path_id);
 
-    VssData_t vss_data_int8 = {
-        .data_int8 = -0x05
-    };
+    VssData_t vss_data_int8 = {.data_int8 = -0x05};
     Avtp_Vss_SetDatatype(vss_pdu, VSS_INT8);
     Avtp_Vss_SetVssData(vss_pdu, &vss_data_int8);
     int8_t mem[] = {-5};
-    assert_memory_equal(pdu + AVTP_VSS_FIXED_HEADER_LEN + 15, (uint8_t*) mem, 1);
+    assert_memory_equal(pdu + AVTP_VSS_FIXED_HEADER_LEN + 15, (uint8_t *)mem, 1);
 
     VssData_t vss_data_int8_get;
     assert_int_equal(Avtp_Vss_GetDatatype(vss_pdu), VSS_INT8);
     Avtp_Vss_GetVssData(vss_pdu, &vss_data_int8_get);
     assert_int_equal(vss_data_int8_get.data_int8, -0x05);
-
 }
 
-static void vss_data_uint16(void **state) {
+static void vss_data_uint16(void **state)
+{
 
     uint8_t pdu[MAX_PDU_SIZE];
-    Avtp_Vss_t* vss_pdu = (Avtp_Vss_t*) pdu;
+    Avtp_Vss_t *vss_pdu = (Avtp_Vss_t *)pdu;
     Avtp_Vss_Init(vss_pdu);
     Avtp_Vss_SetAcfMsgLength(vss_pdu, 20);
     char path[] = "Vehicle.Speed";
@@ -212,9 +210,7 @@ static void vss_data_uint16(void **state) {
     Avtp_Vss_SetAddrMode(vss_pdu, VSS_INTEROP_MODE);
     Avtp_Vss_SetVssPath(vss_pdu, &path_id);
 
-    VssData_t vss_data_uint16 = {
-        .data_uint16 = 0x0504
-    };
+    VssData_t vss_data_uint16 = {.data_uint16 = 0x0504};
     Avtp_Vss_SetDatatype(vss_pdu, VSS_UINT16);
     Avtp_Vss_SetVssData(vss_pdu, &vss_data_uint16);
     uint8_t mem[] = {5, 4};
@@ -224,13 +220,13 @@ static void vss_data_uint16(void **state) {
     assert_int_equal(Avtp_Vss_GetDatatype(vss_pdu), VSS_UINT16);
     Avtp_Vss_GetVssData(vss_pdu, &vss_data_uint16_get);
     assert_int_equal(vss_data_uint16_get.data_uint16, 0x0504);
-
 }
 
-static void vss_data_int16(void **state) {
+static void vss_data_int16(void **state)
+{
 
     uint8_t pdu[MAX_PDU_SIZE];
-    Avtp_Vss_t* vss_pdu = (Avtp_Vss_t*) pdu;
+    Avtp_Vss_t *vss_pdu = (Avtp_Vss_t *)pdu;
     Avtp_Vss_Init(vss_pdu);
     Avtp_Vss_SetAcfMsgLength(vss_pdu, 20);
     char path[] = "Vehicle.Speed";
@@ -242,9 +238,7 @@ static void vss_data_int16(void **state) {
     Avtp_Vss_SetAddrMode(vss_pdu, VSS_INTEROP_MODE);
     Avtp_Vss_SetVssPath(vss_pdu, &path_id);
 
-    VssData_t vss_data_int16 = {
-        .data_int16 = -0x0504
-    };
+    VssData_t vss_data_int16 = {.data_int16 = -0x0504};
     Avtp_Vss_SetDatatype(vss_pdu, VSS_INT16);
     Avtp_Vss_SetVssData(vss_pdu, &vss_data_int16);
     uint8_t mem[] = {0xFA, 0xFC};
@@ -254,13 +248,13 @@ static void vss_data_int16(void **state) {
     assert_int_equal(Avtp_Vss_GetDatatype(vss_pdu), VSS_INT16);
     Avtp_Vss_GetVssData(vss_pdu, &vss_data_int16_get);
     assert_int_equal(vss_data_int16_get.data_int16, -0x0504);
-
 }
 
-static void vss_data_uint32(void **state) {
+static void vss_data_uint32(void **state)
+{
 
     uint8_t pdu[MAX_PDU_SIZE];
-    Avtp_Vss_t* vss_pdu = (Avtp_Vss_t*) pdu;
+    Avtp_Vss_t *vss_pdu = (Avtp_Vss_t *)pdu;
     Avtp_Vss_Init(vss_pdu);
     Avtp_Vss_SetAcfMsgLength(vss_pdu, 20);
     char path[] = "Vehicle.Speed";
@@ -272,9 +266,7 @@ static void vss_data_uint32(void **state) {
     Avtp_Vss_SetAddrMode(vss_pdu, VSS_INTEROP_MODE);
     Avtp_Vss_SetVssPath(vss_pdu, &path_id);
 
-    VssData_t vss_data_uint32 = {
-        .data_uint32 = 0x05040302
-    };
+    VssData_t vss_data_uint32 = {.data_uint32 = 0x05040302};
     Avtp_Vss_SetDatatype(vss_pdu, VSS_UINT32);
     Avtp_Vss_SetVssData(vss_pdu, &vss_data_uint32);
     uint8_t mem[] = {5, 4, 3, 2};
@@ -284,13 +276,13 @@ static void vss_data_uint32(void **state) {
     assert_int_equal(Avtp_Vss_GetDatatype(vss_pdu), VSS_UINT32);
     Avtp_Vss_GetVssData(vss_pdu, &vss_data_uint32_get);
     assert_int_equal(vss_data_uint32_get.data_uint32, 0x05040302);
-
 }
 
-static void vss_data_int32(void **state) {
+static void vss_data_int32(void **state)
+{
 
     uint8_t pdu[MAX_PDU_SIZE];
-    Avtp_Vss_t* vss_pdu = (Avtp_Vss_t*) pdu;
+    Avtp_Vss_t *vss_pdu = (Avtp_Vss_t *)pdu;
     Avtp_Vss_Init(vss_pdu);
     Avtp_Vss_SetAcfMsgLength(vss_pdu, 20);
     char path[] = "Vehicle.Speed";
@@ -302,9 +294,7 @@ static void vss_data_int32(void **state) {
     Avtp_Vss_SetAddrMode(vss_pdu, VSS_INTEROP_MODE);
     Avtp_Vss_SetVssPath(vss_pdu, &path_id);
 
-    VssData_t vss_data_int32 = {
-        .data_int32 = -0x05040302
-    };
+    VssData_t vss_data_int32 = {.data_int32 = -0x05040302};
     Avtp_Vss_SetDatatype(vss_pdu, VSS_INT32);
     Avtp_Vss_SetVssData(vss_pdu, &vss_data_int32);
     uint8_t mem[] = {0xFA, 0xFB, 0xFC, 0xFE};
@@ -316,10 +306,11 @@ static void vss_data_int32(void **state) {
     assert_int_equal(vss_data_int32_get.data_int32, -0x05040302);
 }
 
-static void vss_data_uint64(void **state) {
+static void vss_data_uint64(void **state)
+{
 
     uint8_t pdu[MAX_PDU_SIZE];
-    Avtp_Vss_t* vss_pdu = (Avtp_Vss_t*) pdu;
+    Avtp_Vss_t *vss_pdu = (Avtp_Vss_t *)pdu;
     Avtp_Vss_Init(vss_pdu);
     Avtp_Vss_SetAcfMsgLength(vss_pdu, 20);
     char path[] = "Vehicle.Speed";
@@ -331,9 +322,7 @@ static void vss_data_uint64(void **state) {
     Avtp_Vss_SetAddrMode(vss_pdu, VSS_INTEROP_MODE);
     Avtp_Vss_SetVssPath(vss_pdu, &path_id);
 
-    VssData_t vss_data_uint64 = {
-        .data_uint64 = 0x0504030201060708
-    };
+    VssData_t vss_data_uint64 = {.data_uint64 = 0x0504030201060708};
     Avtp_Vss_SetDatatype(vss_pdu, VSS_UINT64);
     Avtp_Vss_SetVssData(vss_pdu, &vss_data_uint64);
     uint8_t mem[] = {5, 4, 3, 2, 1, 6, 7, 8};
@@ -344,13 +333,13 @@ static void vss_data_uint64(void **state) {
     Avtp_Vss_GetVssData(vss_pdu, &vss_data_uint64_get);
     uint8_t mem_cpu[] = {8, 7, 6, 1, 2, 3, 4, 5};
     assert_memory_equal(&(vss_data_uint64_get.data_uint64), mem_cpu, 8);
-
 }
 
-static void vss_data_int64(void **state) {
+static void vss_data_int64(void **state)
+{
 
     uint8_t pdu[MAX_PDU_SIZE];
-    Avtp_Vss_t* vss_pdu = (Avtp_Vss_t*) pdu;
+    Avtp_Vss_t *vss_pdu = (Avtp_Vss_t *)pdu;
     Avtp_Vss_Init(vss_pdu);
     Avtp_Vss_SetAcfMsgLength(vss_pdu, 20);
     char path[] = "Vehicle.Speed";
@@ -362,9 +351,7 @@ static void vss_data_int64(void **state) {
     Avtp_Vss_SetAddrMode(vss_pdu, VSS_INTEROP_MODE);
     Avtp_Vss_SetVssPath(vss_pdu, &path_id);
 
-    VssData_t vss_data_int64 = {
-        .data_int64 = -0x0504030201060708
-    };
+    VssData_t vss_data_int64 = {.data_int64 = -0x0504030201060708};
     Avtp_Vss_SetDatatype(vss_pdu, VSS_INT64);
     Avtp_Vss_SetVssData(vss_pdu, &vss_data_int64);
     uint8_t mem[] = {0xFA, 0xFB, 0xFC, 0xFD, 0xFE, 0xF9, 0xF8, 0xF8};
@@ -375,13 +362,13 @@ static void vss_data_int64(void **state) {
     Avtp_Vss_GetVssData(vss_pdu, &vss_data_int64_get);
     uint8_t mem_cpu[] = {0xF8, 0xF8, 0xF9, 0xFE, 0xFD, 0xFC, 0xFB, 0xFA};
     assert_memory_equal(&(vss_data_int64_get.data_int64), mem_cpu, 8);
-
 }
 
-static void vss_data_bool(void **state) {
+static void vss_data_bool(void **state)
+{
 
     uint8_t pdu[MAX_PDU_SIZE];
-    Avtp_Vss_t* vss_pdu = (Avtp_Vss_t*) pdu;
+    Avtp_Vss_t *vss_pdu = (Avtp_Vss_t *)pdu;
     Avtp_Vss_Init(vss_pdu);
     Avtp_Vss_SetAcfMsgLength(vss_pdu, 20);
     char path[] = "Vehicle.Speed";
@@ -393,9 +380,7 @@ static void vss_data_bool(void **state) {
     Avtp_Vss_SetAddrMode(vss_pdu, VSS_INTEROP_MODE);
     Avtp_Vss_SetVssPath(vss_pdu, &path_id);
 
-    VssData_t vss_data_bool = {
-        .data_bool = 0x01
-    };
+    VssData_t vss_data_bool = {.data_bool = 0x01};
     Avtp_Vss_SetDatatype(vss_pdu, VSS_BOOL);
     Avtp_Vss_SetVssData(vss_pdu, &vss_data_bool);
     uint8_t mem[] = {1};
@@ -405,13 +390,13 @@ static void vss_data_bool(void **state) {
     assert_int_equal(Avtp_Vss_GetDatatype(vss_pdu), VSS_BOOL);
     Avtp_Vss_GetVssData(vss_pdu, &vss_data_bool_get);
     assert_int_equal(vss_data_bool_get.data_bool, 1);
-
 }
 
-static void vss_data_float(void **state) {
+static void vss_data_float(void **state)
+{
 
     uint8_t pdu[MAX_PDU_SIZE];
-    Avtp_Vss_t* vss_pdu = (Avtp_Vss_t*) pdu;
+    Avtp_Vss_t *vss_pdu = (Avtp_Vss_t *)pdu;
     Avtp_Vss_Init(vss_pdu);
     Avtp_Vss_SetAcfMsgLength(vss_pdu, 20);
     char path[] = "Vehicle.Speed";
@@ -423,9 +408,7 @@ static void vss_data_float(void **state) {
     Avtp_Vss_SetAddrMode(vss_pdu, VSS_INTEROP_MODE);
     Avtp_Vss_SetVssPath(vss_pdu, &path_id);
 
-    VssData_t vss_data_float = {
-        .data_float = -1.2
-    };
+    VssData_t vss_data_float = {.data_float = -1.2};
     Avtp_Vss_SetDatatype(vss_pdu, VSS_FLOAT);
     Avtp_Vss_SetVssData(vss_pdu, &vss_data_float);
     uint8_t mem[] = {0xbf, 0x99, 0x99, 0x9a};
@@ -435,13 +418,13 @@ static void vss_data_float(void **state) {
     assert_int_equal(Avtp_Vss_GetDatatype(vss_pdu), VSS_FLOAT);
     Avtp_Vss_GetVssData(vss_pdu, &vss_data_float_get);
     assert_float_equal(vss_data_float_get.data_float, -1.2, 0.5);
-
 }
 
-static void vss_data_double(void **state) {
+static void vss_data_double(void **state)
+{
 
     uint8_t pdu[MAX_PDU_SIZE];
-    Avtp_Vss_t* vss_pdu = (Avtp_Vss_t*) pdu;
+    Avtp_Vss_t *vss_pdu = (Avtp_Vss_t *)pdu;
     Avtp_Vss_Init(vss_pdu);
     Avtp_Vss_SetAcfMsgLength(vss_pdu, 20);
     char path[] = "Vehicle.Speed";
@@ -453,9 +436,7 @@ static void vss_data_double(void **state) {
     Avtp_Vss_SetAddrMode(vss_pdu, VSS_INTEROP_MODE);
     Avtp_Vss_SetVssPath(vss_pdu, &path_id);
 
-    VssData_t vss_data_double = {
-        .data_double = -1.2
-    };
+    VssData_t vss_data_double = {.data_double = -1.2};
     Avtp_Vss_SetDatatype(vss_pdu, VSS_DOUBLE);
     Avtp_Vss_SetVssData(vss_pdu, &vss_data_double);
     uint8_t mem[] = {0xbf, 0xf3, 0x33, 0x33, 0x33, 0x33, 0x33, 0x33};
@@ -465,13 +446,13 @@ static void vss_data_double(void **state) {
     assert_int_equal(Avtp_Vss_GetDatatype(vss_pdu), VSS_DOUBLE);
     Avtp_Vss_GetVssData(vss_pdu, &vss_data_double_get);
     assert_float_equal(vss_data_double_get.data_double, -1.2, 0.1);
-
 }
 
-static void vss_data_string(void **state) {
+static void vss_data_string(void **state)
+{
 
     uint8_t pdu[MAX_PDU_SIZE];
-    Avtp_Vss_t* vss_pdu = (Avtp_Vss_t*) pdu;
+    Avtp_Vss_t *vss_pdu = (Avtp_Vss_t *)pdu;
     Avtp_Vss_Init(vss_pdu);
     Avtp_Vss_SetAcfMsgLength(vss_pdu, 20);
     char path[] = "Vehicle.Speed";
@@ -497,9 +478,7 @@ static void vss_data_string(void **state) {
     assert_memory_equal(pdu + AVTP_VSS_FIXED_HEADER_LEN + 17, str_value, strlen(str_value));
 
     VssData_t vss_data_get;
-    VssDataString_t vss_data_string_get = {
-        .data = 0
-    };
+    VssDataString_t vss_data_string_get = {.data = 0};
     vss_data_get.data_string = &vss_data_string_get;
     assert_int_equal(Avtp_Vss_GetDatatype(vss_pdu), VSS_STRING);
     Avtp_Vss_GetVssData(vss_pdu, &vss_data_get);
@@ -510,10 +489,11 @@ static void vss_data_string(void **state) {
     assert_string_equal(vss_data_get.data_string->data, str_value);
 }
 
-static void vss_data_uint8_array(void **state) {
+static void vss_data_uint8_array(void **state)
+{
 
     uint8_t pdu[MAX_PDU_SIZE];
-    Avtp_Vss_t* vss_pdu = (Avtp_Vss_t*) pdu;
+    Avtp_Vss_t *vss_pdu = (Avtp_Vss_t *)pdu;
     Avtp_Vss_Init(vss_pdu);
     Avtp_Vss_SetAcfMsgLength(vss_pdu, 20);
     char path[] = "Vehicle.Speed";
@@ -539,9 +519,7 @@ static void vss_data_uint8_array(void **state) {
     assert_memory_equal(pdu + AVTP_VSS_FIXED_HEADER_LEN + 17, uint8_arr_value, 5);
 
     VssData_t vss_data_get;
-    VssDataUint8Array_t vss_data_uint8_arr_get = {
-        .data = 0
-    };
+    VssDataUint8Array_t vss_data_uint8_arr_get = {.data = 0};
     vss_data_get.data_uint8_array = &vss_data_uint8_arr_get;
     assert_int_equal(Avtp_Vss_GetDatatype(vss_pdu), VSS_UINT8_ARRAY);
     Avtp_Vss_GetVssData(vss_pdu, &vss_data_get);
@@ -552,10 +530,11 @@ static void vss_data_uint8_array(void **state) {
     assert_memory_equal(vss_data_get.data_uint8_array->data, uint8_arr_value, 5);
 }
 
-static void vss_data_int8_array(void **state) {
+static void vss_data_int8_array(void **state)
+{
 
     uint8_t pdu[MAX_PDU_SIZE];
-    Avtp_Vss_t* vss_pdu = (Avtp_Vss_t*) pdu;
+    Avtp_Vss_t *vss_pdu = (Avtp_Vss_t *)pdu;
     Avtp_Vss_Init(vss_pdu);
     Avtp_Vss_SetAcfMsgLength(vss_pdu, 20);
     char path[] = "Vehicle.Speed";
@@ -593,10 +572,11 @@ static void vss_data_int8_array(void **state) {
     assert_memory_equal(vss_data_get.data_int8_array->data, int8_arr_value, 5);
 }
 
-static void vss_data_uint16_array(void **state) {
+static void vss_data_uint16_array(void **state)
+{
 
     uint8_t pdu[MAX_PDU_SIZE];
-    Avtp_Vss_t* vss_pdu = (Avtp_Vss_t*) pdu;
+    Avtp_Vss_t *vss_pdu = (Avtp_Vss_t *)pdu;
     Avtp_Vss_Init(vss_pdu);
     Avtp_Vss_SetAcfMsgLength(vss_pdu, 20);
     char path[] = "Vehicle.Speed";
@@ -629,16 +609,17 @@ static void vss_data_uint16_array(void **state) {
     assert_int_equal(Avtp_Vss_GetDatatype(vss_pdu), VSS_UINT16_ARRAY);
     Avtp_Vss_GetVssData(vss_pdu, &vss_data_get);
     assert_int_equal(vss_data_get.data_uint16_array->data_length, 10);
-    uint16_t uint16_arr_value_recv[vss_data_get.data_uint16_array->data_length/2];
+    uint16_t uint16_arr_value_recv[vss_data_get.data_uint16_array->data_length / 2];
     vss_data_uint16_arr_get.data = uint16_arr_value_recv;
     Avtp_Vss_GetVssData(vss_pdu, &vss_data_get);
     assert_memory_equal(vss_data_get.data_uint16_array->data, uint16_arr_value, 10);
 }
 
-static void vss_data_int16_array(void **state) {
+static void vss_data_int16_array(void **state)
+{
 
     uint8_t pdu[MAX_PDU_SIZE];
-    Avtp_Vss_t* vss_pdu = (Avtp_Vss_t*) pdu;
+    Avtp_Vss_t *vss_pdu = (Avtp_Vss_t *)pdu;
     Avtp_Vss_Init(vss_pdu);
     Avtp_Vss_SetAcfMsgLength(vss_pdu, 20);
     char path[] = "Vehicle.Speed";
@@ -671,16 +652,17 @@ static void vss_data_int16_array(void **state) {
     assert_int_equal(Avtp_Vss_GetDatatype(vss_pdu), VSS_INT16_ARRAY);
     Avtp_Vss_GetVssData(vss_pdu, &vss_data_get);
     assert_int_equal(vss_data_get.data_int16_array->data_length, 10);
-    int16_t int16_arr_value_recv[vss_data_get.data_int16_array->data_length/2];
+    int16_t int16_arr_value_recv[vss_data_get.data_int16_array->data_length / 2];
     vss_data_int16_arr_get.data = int16_arr_value_recv;
     Avtp_Vss_GetVssData(vss_pdu, &vss_data_get);
     assert_memory_equal(vss_data_get.data_int16_array->data, int16_arr_value, 10);
 }
 
-static void vss_data_uint32_array(void **state) {
+static void vss_data_uint32_array(void **state)
+{
 
     uint8_t pdu[MAX_PDU_SIZE];
-    Avtp_Vss_t* vss_pdu = (Avtp_Vss_t*) pdu;
+    Avtp_Vss_t *vss_pdu = (Avtp_Vss_t *)pdu;
     Avtp_Vss_Init(vss_pdu);
     Avtp_Vss_SetAcfMsgLength(vss_pdu, 20);
     char path[] = "Vehicle.Speed";
@@ -713,16 +695,17 @@ static void vss_data_uint32_array(void **state) {
     assert_int_equal(Avtp_Vss_GetDatatype(vss_pdu), VSS_UINT32_ARRAY);
     Avtp_Vss_GetVssData(vss_pdu, &vss_data_get);
     assert_int_equal(vss_data_get.data_uint32_array->data_length, 20);
-    uint32_t uint32_arr_value_recv[vss_data_get.data_uint32_array->data_length/4];
+    uint32_t uint32_arr_value_recv[vss_data_get.data_uint32_array->data_length / 4];
     vss_data_uint32_arr_get.data = uint32_arr_value_recv;
     Avtp_Vss_GetVssData(vss_pdu, &vss_data_get);
     assert_memory_equal(vss_data_get.data_uint32_array->data, uint32_arr_value, 20);
 }
 
-static void vss_data_int32_array(void **state) {
+static void vss_data_int32_array(void **state)
+{
 
     uint8_t pdu[MAX_PDU_SIZE];
-    Avtp_Vss_t* vss_pdu = (Avtp_Vss_t*) pdu;
+    Avtp_Vss_t *vss_pdu = (Avtp_Vss_t *)pdu;
     Avtp_Vss_Init(vss_pdu);
     Avtp_Vss_SetAcfMsgLength(vss_pdu, 20);
     char path[] = "Vehicle.Speed";
@@ -745,11 +728,8 @@ static void vss_data_int32_array(void **state) {
     Avtp_Vss_SetVssData(vss_pdu, &data);
     uint8_t len_in_mem[] = {0, 20};
     assert_memory_equal(pdu + AVTP_VSS_FIXED_HEADER_LEN + 15, len_in_mem, 2);
-    uint8_t arr_in_mem[] = {0xff, 0xff, 0, 0,
-                            0xff, 0xfe, 0xff, 0,
-                            0xff, 0xfe, 0xfe, 0,
-                            0xff, 0xfe, 0xfd, 0,
-                            0xff, 0xfe, 0xfc, 0};
+    uint8_t arr_in_mem[] = {0xff, 0xff, 0,    0,    0xff, 0xfe, 0xff, 0,    0xff, 0xfe,
+                            0xfe, 0,    0xff, 0xfe, 0xfd, 0,    0xff, 0xfe, 0xfc, 0};
     assert_memory_equal(pdu + AVTP_VSS_FIXED_HEADER_LEN + 17, arr_in_mem, 20);
 
     VssData_t vss_data_get = {0};
@@ -759,16 +739,17 @@ static void vss_data_int32_array(void **state) {
     assert_int_equal(Avtp_Vss_GetDatatype(vss_pdu), VSS_INT32_ARRAY);
     Avtp_Vss_GetVssData(vss_pdu, &vss_data_get);
     assert_int_equal(vss_data_get.data_int32_array->data_length, 20);
-    int32_t int32_arr_value_recv[vss_data_get.data_int32_array->data_length/4];
+    int32_t int32_arr_value_recv[vss_data_get.data_int32_array->data_length / 4];
     vss_data_int32_arr_get.data = int32_arr_value_recv;
     Avtp_Vss_GetVssData(vss_pdu, &vss_data_get);
     assert_memory_equal(vss_data_get.data_int32_array->data, int32_arr_value, 20);
 }
 
-static void vss_data_uint64_array(void **state) {
+static void vss_data_uint64_array(void **state)
+{
 
     uint8_t pdu[MAX_PDU_SIZE];
-    Avtp_Vss_t* vss_pdu = (Avtp_Vss_t*) pdu;
+    Avtp_Vss_t *vss_pdu = (Avtp_Vss_t *)pdu;
     Avtp_Vss_Init(vss_pdu);
     Avtp_Vss_SetAcfMsgLength(vss_pdu, 20);
     char path[] = "Vehicle.Speed";
@@ -791,11 +772,8 @@ static void vss_data_uint64_array(void **state) {
     Avtp_Vss_SetVssData(vss_pdu, &data);
     uint8_t len_in_mem[] = {0, 40};
     assert_memory_equal(pdu + AVTP_VSS_FIXED_HEADER_LEN + 15, len_in_mem, 2);
-    uint8_t arr_in_mem[] = {0, 0, 0, 0, 0, 1, 0, 0,
-                             0, 0, 0, 0, 0, 1, 1, 0,
-                             0, 0, 0, 0, 0, 1, 2, 0,
-                             0, 0, 0, 0, 0, 1, 3, 0,
-                             0, 0, 0, 0, 0, 1, 4, 0};
+    uint8_t arr_in_mem[] = {0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 1, 1, 0, 0, 0, 0, 0,
+                            0, 1, 2, 0, 0, 0, 0, 0, 0, 1, 3, 0, 0, 0, 0, 0, 0, 1, 4, 0};
     assert_memory_equal(pdu + AVTP_VSS_FIXED_HEADER_LEN + 17, arr_in_mem, 40);
 
     VssData_t vss_data_get = {0};
@@ -804,16 +782,17 @@ static void vss_data_uint64_array(void **state) {
     assert_int_equal(Avtp_Vss_GetDatatype(vss_pdu), VSS_UINT64_ARRAY);
     Avtp_Vss_GetVssData(vss_pdu, &vss_data_get);
     assert_int_equal(vss_data_get.data_uint64_array->data_length, 40);
-    uint64_t uint64_arr_value_recv[vss_data_get.data_uint64_array->data_length/8];
+    uint64_t uint64_arr_value_recv[vss_data_get.data_uint64_array->data_length / 8];
     vss_data_uint64_arr_get.data = uint64_arr_value_recv;
     Avtp_Vss_GetVssData(vss_pdu, &vss_data_get);
     assert_memory_equal(vss_data_get.data_uint64_array->data, uint64_arr_value, 40);
 }
 
-static void vss_data_int64_array(void **state) {
+static void vss_data_int64_array(void **state)
+{
 
     uint8_t pdu[MAX_PDU_SIZE];
-    Avtp_Vss_t* vss_pdu = (Avtp_Vss_t*) pdu;
+    Avtp_Vss_t *vss_pdu = (Avtp_Vss_t *)pdu;
     Avtp_Vss_Init(vss_pdu);
     Avtp_Vss_SetAcfMsgLength(vss_pdu, 20);
     char path[] = "Vehicle.Speed";
@@ -836,11 +815,11 @@ static void vss_data_int64_array(void **state) {
     Avtp_Vss_SetVssData(vss_pdu, &data);
     uint8_t len_in_mem[] = {0, 40};
     assert_memory_equal(pdu + AVTP_VSS_FIXED_HEADER_LEN + 15, len_in_mem, 2);
-    uint8_t arr_in_mem[] = {0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0, 0,
-                             0xff, 0xff, 0xff, 0xff, 0xff, 0xfe, 0xff, 0,
-                             0xff, 0xff, 0xff, 0xff, 0xff, 0xfe, 0xfe, 0,
-                             0xff, 0xff, 0xff, 0xff, 0xff, 0xfe, 0xfd, 0,
-                             0xff, 0xff, 0xff, 0xff, 0xff, 0xfe, 0xfc, 0,};
+    uint8_t arr_in_mem[] = {
+        0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0,    0,    0xff, 0xff, 0xff, 0xff, 0xff, 0xfe,
+        0xff, 0,    0xff, 0xff, 0xff, 0xff, 0xff, 0xfe, 0xfe, 0,    0xff, 0xff, 0xff, 0xff,
+        0xff, 0xfe, 0xfd, 0,    0xff, 0xff, 0xff, 0xff, 0xff, 0xfe, 0xfc, 0,
+    };
     assert_memory_equal(pdu + AVTP_VSS_FIXED_HEADER_LEN + 17, arr_in_mem, 40);
 
     VssData_t vss_data_get = {0};
@@ -851,16 +830,17 @@ static void vss_data_int64_array(void **state) {
     assert_int_equal(Avtp_Vss_GetDatatype(vss_pdu), VSS_INT64_ARRAY);
     Avtp_Vss_GetVssData(vss_pdu, &vss_data_get);
     assert_int_equal(vss_data_get.data_int64_array->data_length, 40);
-    int64_t int64_arr_value_recv[vss_data_get.data_int64_array->data_length/8];
+    int64_t int64_arr_value_recv[vss_data_get.data_int64_array->data_length / 8];
     vss_data_int64_arr_get.data = int64_arr_value_recv;
     Avtp_Vss_GetVssData(vss_pdu, &vss_data_get);
     assert_memory_equal(vss_data_get.data_int64_array->data, int64_arr_value, 40);
 }
 
-static void vss_data_bool_array(void **state) {
+static void vss_data_bool_array(void **state)
+{
 
     uint8_t pdu[MAX_PDU_SIZE];
-    Avtp_Vss_t* vss_pdu = (Avtp_Vss_t*) pdu;
+    Avtp_Vss_t *vss_pdu = (Avtp_Vss_t *)pdu;
     Avtp_Vss_Init(vss_pdu);
     Avtp_Vss_SetAcfMsgLength(vss_pdu, 20);
     char path[] = "Vehicle.Speed";
@@ -899,10 +879,11 @@ static void vss_data_bool_array(void **state) {
     assert_memory_equal(vss_data_get.data_bool_array->data, bool_arr_value, 5);
 }
 
-static void vss_data_float_array(void **state) {
+static void vss_data_float_array(void **state)
+{
 
     uint8_t pdu[MAX_PDU_SIZE];
-    Avtp_Vss_t* vss_pdu = (Avtp_Vss_t*) pdu;
+    Avtp_Vss_t *vss_pdu = (Avtp_Vss_t *)pdu;
     Avtp_Vss_Init(vss_pdu);
     Avtp_Vss_SetAcfMsgLength(vss_pdu, 20);
     char path[] = "Vehicle.Speed";
@@ -925,11 +906,8 @@ static void vss_data_float_array(void **state) {
     Avtp_Vss_SetVssData(vss_pdu, &data);
     uint8_t len_in_mem[] = {0, 20};
     assert_memory_equal(pdu + AVTP_VSS_FIXED_HEADER_LEN + 15, len_in_mem, 2);
-    uint8_t arr_in_mem[] = {0x3f, 0x99, 0x99, 0x9a,
-                             0xbf, 0x99, 0x99, 0x9a,
-                             0x3f, 0xa6, 0x66, 0x66,
-                             0xbf, 0xa6, 0x66, 0x66,
-                             0x3f, 0xc0, 0, 0, 0};
+    uint8_t arr_in_mem[] = {0x3f, 0x99, 0x99, 0x9a, 0xbf, 0x99, 0x99, 0x9a, 0x3f, 0xa6, 0x66,
+                            0x66, 0xbf, 0xa6, 0x66, 0x66, 0x3f, 0xc0, 0,    0,    0};
     assert_memory_equal(pdu + AVTP_VSS_FIXED_HEADER_LEN + 17, arr_in_mem, 20);
 
     VssData_t vss_data_get = {0};
@@ -940,16 +918,17 @@ static void vss_data_float_array(void **state) {
     assert_int_equal(Avtp_Vss_GetDatatype(vss_pdu), VSS_FLOAT_ARRAY);
     Avtp_Vss_GetVssData(vss_pdu, &vss_data_get);
     assert_int_equal(vss_data_get.data_float_array->data_length, 20);
-    float float_arr_value_recv[vss_data_get.data_float_array->data_length/4];
+    float float_arr_value_recv[vss_data_get.data_float_array->data_length / 4];
     vss_data_float_arr_get.data = float_arr_value_recv;
     Avtp_Vss_GetVssData(vss_pdu, &vss_data_get);
     assert_memory_equal(vss_data_get.data_float_array->data, float_arr_value, 20);
 }
 
-static void vss_data_double_array(void **state) {
+static void vss_data_double_array(void **state)
+{
 
     uint8_t pdu[MAX_PDU_SIZE];
-    Avtp_Vss_t* vss_pdu = (Avtp_Vss_t*) pdu;
+    Avtp_Vss_t *vss_pdu = (Avtp_Vss_t *)pdu;
     Avtp_Vss_Init(vss_pdu);
     Avtp_Vss_SetAcfMsgLength(vss_pdu, 20);
     char path[] = "Vehicle.Speed";
@@ -972,11 +951,10 @@ static void vss_data_double_array(void **state) {
     Avtp_Vss_SetVssData(vss_pdu, &data);
     uint8_t len_in_mem[] = {0, 40};
     assert_memory_equal(pdu + AVTP_VSS_FIXED_HEADER_LEN + 15, len_in_mem, 2);
-    uint8_t arr_in_mem[] = {0x3f, 0xf3, 0x33, 0x33, 0x33, 0x33, 0x33, 0x33,
-                             0xbf, 0xf3, 0x33, 0x33, 0x33, 0x33, 0x33, 0x33,
-                             0x3f, 0xf4, 0xcc, 0xcc, 0xcc, 0xcc, 0xcc, 0xcd,
-                             0xbf, 0xf4, 0xcc, 0xcc, 0xcc, 0xcc, 0xcc, 0xcd,
-                             0x3f, 0xf8, 0, 0, 0, 0, 0, 0};
+    uint8_t arr_in_mem[] = {0x3f, 0xf3, 0x33, 0x33, 0x33, 0x33, 0x33, 0x33, 0xbf, 0xf3,
+                            0x33, 0x33, 0x33, 0x33, 0x33, 0x33, 0x3f, 0xf4, 0xcc, 0xcc,
+                            0xcc, 0xcc, 0xcc, 0xcd, 0xbf, 0xf4, 0xcc, 0xcc, 0xcc, 0xcc,
+                            0xcc, 0xcd, 0x3f, 0xf8, 0,    0,    0,    0,    0,    0};
     assert_memory_equal(pdu + AVTP_VSS_FIXED_HEADER_LEN + 17, arr_in_mem, 40);
 
     VssData_t vss_data_get = {0};
@@ -985,16 +963,17 @@ static void vss_data_double_array(void **state) {
     assert_int_equal(Avtp_Vss_GetDatatype(vss_pdu), VSS_DOUBLE_ARRAY);
     Avtp_Vss_GetVssData(vss_pdu, &vss_data_get);
     assert_int_equal(vss_data_get.data_double_array->data_length, 40);
-    double double_arr_value_recv[vss_data_get.data_double_array->data_length/8];
+    double double_arr_value_recv[vss_data_get.data_double_array->data_length / 8];
     vss_data_double_arr_get.data = double_arr_value_recv;
     Avtp_Vss_GetVssData(vss_pdu, &vss_data_get);
     assert_memory_equal(vss_data_get.data_double_array->data, double_arr_value, 40);
 }
 
-static void vss_data_string_array(void **state) {
+static void vss_data_string_array(void **state)
+{
 
     uint8_t pdu[MAX_PDU_SIZE];
-    Avtp_Vss_t* vss_pdu = (Avtp_Vss_t*) pdu;
+    Avtp_Vss_t *vss_pdu = (Avtp_Vss_t *)pdu;
     Avtp_Vss_Init(vss_pdu);
     Avtp_Vss_SetAcfMsgLength(vss_pdu, 20);
     char path[] = "Vehicle.Speed";
@@ -1019,8 +998,8 @@ static void vss_data_string_array(void **state) {
     vss_str3.data = str3;
     vss_str3.data_length = strlen(str3);
 
-    VssDataString_t* arr[] = {&vss_str1, &vss_str2, &vss_str3};
-    uint8_t buffer[strlen(str1) + strlen(str2) + strlen(str3)+2];
+    VssDataString_t *arr[] = {&vss_str1, &vss_str2, &vss_str3};
+    uint8_t buffer[strlen(str1) + strlen(str2) + strlen(str3) + 2];
     VssDataStringArray_t vss_str_array = {0};
     vss_str_array.data = buffer;
     Avtp_Vss_SerializeStringArray(&vss_str_array, arr, 3);
@@ -1032,9 +1011,8 @@ static void vss_data_string_array(void **state) {
     Avtp_Vss_SetVssData(vss_pdu, &data);
     uint8_t len_in_mem[] = {0, 23};
     assert_memory_equal(pdu + AVTP_VSS_FIXED_HEADER_LEN + 15, len_in_mem, 2);
-    uint8_t arr_in_mem[] = {0x00, 0x05, 'H', 'e', 'l', 'l', 'o',
-                             0x00, 0x05, 'W', 'o', 'r', 'l', 'd',
-                             0x00, 0x07, 'T', 's', 'c', 'h', 'u', 's', 's'};
+    uint8_t arr_in_mem[] = {0x00, 0x05, 'H',  'e',  'l', 'l', 'o', 0x00, 0x05, 'W', 'o', 'r',
+                            'l',  'd',  0x00, 0x07, 'T', 's', 'c', 'h',  'u',  's', 's'};
     assert_memory_equal(pdu + AVTP_VSS_FIXED_HEADER_LEN + 17, arr_in_mem, 23);
 
     VssData_t vss_data_get = {0};
@@ -1049,13 +1027,10 @@ static void vss_data_string_array(void **state) {
     assert_memory_equal(vss_data_get.data_string_array->data, arr_in_mem, 23);
 
     assert_int_equal(Avtp_Vss_GetVSSDataStringArrayLength(vss_data_get.data_string_array), 3);
-    VssDataString_t strings[3] = {
-        {.data = 0},
-        {.data = 0},
-        {.data = 0}
-    };
-    VssDataString_t* strings_array[] = {&strings[0], &strings[1], &strings[2]};
-    Avtp_Vss_DeserializeStringArray(vss_data_get.data_string_array, (VssDataString_t**) &strings_array, 3);
+    VssDataString_t strings[3] = {{.data = 0}, {.data = 0}, {.data = 0}};
+    VssDataString_t *strings_array[] = {&strings[0], &strings[1], &strings[2]};
+    Avtp_Vss_DeserializeStringArray(vss_data_get.data_string_array,
+                                    (VssDataString_t **)&strings_array, 3);
 
     assert_int_equal(strings[0].data_length, 5);
     assert_int_equal(strings[1].data_length, 5);
@@ -1064,18 +1039,17 @@ static void vss_data_string_array(void **state) {
     char str1_recd[5];
     char str2_recd[5];
     char str3_recd[7];
-    strings[0].data = str1_recd,
-    strings[1].data = str2_recd,
-    strings[2].data = str3_recd,
+    strings[0].data = str1_recd, strings[1].data = str2_recd, strings[2].data = str3_recd,
 
-    Avtp_Vss_DeserializeStringArray(vss_data_get.data_string_array, (VssDataString_t**) &strings_array, 3);
+    Avtp_Vss_DeserializeStringArray(vss_data_get.data_string_array,
+                                    (VssDataString_t **)&strings_array, 3);
     assert_memory_equal(strings[0].data, str1, 5);
     assert_memory_equal(strings[1].data, str2, 5);
     assert_memory_equal(strings[2].data, str3, 7);
-
 }
 
-static void vss_data_string_array_malformed(void **state) {
+static void vss_data_string_array_malformed(void **state)
+{
     /* On-wire layout for a VSS string array is [u16 length][bytes ...]
      * pairs. Construct a 23-byte payload identical to the well-formed
      * fixture in vss_data_string_array, except the third length prefix
@@ -1091,9 +1065,8 @@ static void vss_data_string_array_malformed(void **state) {
      *     with the well-formed strings and leaves the third untouched.
      */
     uint8_t arr_in_mem[] = {
-        0x00, 0x05, 'H', 'e', 'l', 'l', 'o',
-        0x00, 0x05, 'W', 'o', 'r', 'l', 'd',
-        0x00, 0xAA, 'T', 's', 'c', 'h', 'u', 's', 's',
+        0x00, 0x05, 'H',  'e',  'l', 'l', 'o', 0x00, 0x05, 'W', 'o', 'r',
+        'l',  'd',  0x00, 0xAA, 'T', 's', 'c', 'h',  'u',  's', 's',
     };
 
     VssDataStringArray_t str_array = {0};
@@ -1106,10 +1079,13 @@ static void vss_data_string_array_malformed(void **state) {
     /* Deserialisation must fill only the first two entries. The third
      * struct stays at its initial state (data_length == 0). */
     char buf1[8] = {0}, buf2[8] = {0}, buf3[8] = {0};
-    VssDataString_t s1 = {0}; s1.data = buf1;
-    VssDataString_t s2 = {0}; s2.data = buf2;
-    VssDataString_t s3 = {0}; s3.data = buf3;
-    VssDataString_t* strings_array[] = {&s1, &s2, &s3};
+    VssDataString_t s1 = {0};
+    s1.data = buf1;
+    VssDataString_t s2 = {0};
+    s2.data = buf2;
+    VssDataString_t s3 = {0};
+    s3.data = buf3;
+    VssDataString_t *strings_array[] = {&s1, &s2, &s3};
 
     Avtp_Vss_DeserializeStringArray(&str_array, strings_array, 3);
 
@@ -1139,11 +1115,9 @@ static void vss_data_string_array_malformed(void **state) {
 /* Helper: build a VSS PDU with STATIC_ID path, given msg_quadlets, datatype,
  * and plant 0xFFFF as the on‑wire data_length followed by fill_data.
  * Available data bytes = msg_quadlets × 4 − 16 (header+path) − 2 (prefix). */
-static Avtp_Vss_t* vss_build_data_oob_pdu(uint8_t *buf, size_t buf_size,
-                                            uint8_t msg_quadlets,
-                                            Vss_Datatype_t datatype,
-                                            const uint8_t *fill_data,
-                                            uint16_t fill_len)
+static Avtp_Vss_t *vss_build_data_oob_pdu(uint8_t *buf, size_t buf_size, uint8_t msg_quadlets,
+                                          Vss_Datatype_t datatype, const uint8_t *fill_data,
+                                          uint16_t fill_len)
 {
     memset(buf, 0, buf_size);
     Avtp_Vss_t *pdu = (Avtp_Vss_t *)buf;
@@ -1178,9 +1152,11 @@ static void vss_path_interop_oob(void **state)
     Avtp_Vss_SetAddrMode(pdu, VSS_INTEROP_MODE);
     Avtp_Vss_SetAcfMsgLength(pdu, 5);
 
-    buf[12] = 0xFF; buf[13] = 0xFF;    /* wire path_length = 0xFFFF */
-    buf[14] = 'A';  buf[15] = 'B';     /* only 2 bytes of real path data
-                                         * (bytes 16‑17 are zero from memset) */
+    buf[12] = 0xFF;
+    buf[13] = 0xFF; /* wire path_length = 0xFFFF */
+    buf[14] = 'A';
+    buf[15] = 'B'; /* only 2 bytes of real path data
+                    * (bytes 16‑17 are zero from memset) */
 
     char path_buf[16];
     memset(path_buf, 0x5A, sizeof(path_buf));
@@ -1205,10 +1181,9 @@ static void vss_data_string_oob(void **state)
 {
     uint8_t buf[64];
     uint8_t fill[] = {0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08};
-    Avtp_Vss_t *pdu = vss_build_data_oob_pdu(buf, sizeof(buf), 6,
-                                               VSS_STRING, fill, sizeof(fill));
+    Avtp_Vss_t *pdu = vss_build_data_oob_pdu(buf, sizeof(buf), 6, VSS_STRING, fill, sizeof(fill));
 
-    VssDataString_t str = { .data = NULL };
+    VssDataString_t str = {.data = NULL};
     VssData_t vd;
     memset(&vd, 0, sizeof(vd));
     vd.data_string = &str;
@@ -1228,10 +1203,10 @@ static void vss_data_uint8_array_oob(void **state)
 {
     uint8_t buf[64];
     uint8_t fill[] = {0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08};
-    Avtp_Vss_t *pdu = vss_build_data_oob_pdu(buf, sizeof(buf), 6,
-                                               VSS_UINT8_ARRAY, fill, sizeof(fill));
+    Avtp_Vss_t *pdu =
+        vss_build_data_oob_pdu(buf, sizeof(buf), 6, VSS_UINT8_ARRAY, fill, sizeof(fill));
 
-    VssDataUint8Array_t arr = { .data = NULL };
+    VssDataUint8Array_t arr = {.data = NULL};
     VssData_t vd;
     memset(&vd, 0, sizeof(vd));
     vd.data_uint8_array = &arr;
@@ -1250,10 +1225,10 @@ static void vss_data_int8_array_oob(void **state)
 {
     uint8_t buf[64];
     uint8_t fill[] = {0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08};
-    Avtp_Vss_t *pdu = vss_build_data_oob_pdu(buf, sizeof(buf), 6,
-                                               VSS_INT8_ARRAY, fill, sizeof(fill));
+    Avtp_Vss_t *pdu =
+        vss_build_data_oob_pdu(buf, sizeof(buf), 6, VSS_INT8_ARRAY, fill, sizeof(fill));
 
-    VssDataInt8Array_t arr = { .data = NULL };
+    VssDataInt8Array_t arr = {.data = NULL};
     VssData_t vd;
     memset(&vd, 0, sizeof(vd));
     vd.data_int8_array = &arr;
@@ -1272,10 +1247,10 @@ static void vss_data_bool_array_oob(void **state)
 {
     uint8_t buf[64];
     uint8_t fill[] = {0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08};
-    Avtp_Vss_t *pdu = vss_build_data_oob_pdu(buf, sizeof(buf), 6,
-                                               VSS_BOOL_ARRAY, fill, sizeof(fill));
+    Avtp_Vss_t *pdu =
+        vss_build_data_oob_pdu(buf, sizeof(buf), 6, VSS_BOOL_ARRAY, fill, sizeof(fill));
 
-    VssDataBoolArray_t arr = { .data = NULL };
+    VssDataBoolArray_t arr = {.data = NULL};
     VssData_t vd;
     memset(&vd, 0, sizeof(vd));
     vd.data_bool_array = &arr;
@@ -1296,10 +1271,10 @@ static void vss_data_string_array_oob(void **state)
 {
     uint8_t buf[64];
     uint8_t fill[] = {0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08};
-    Avtp_Vss_t *pdu = vss_build_data_oob_pdu(buf, sizeof(buf), 6,
-                                               VSS_STRING_ARRAY, fill, sizeof(fill));
+    Avtp_Vss_t *pdu =
+        vss_build_data_oob_pdu(buf, sizeof(buf), 6, VSS_STRING_ARRAY, fill, sizeof(fill));
 
-    VssDataStringArray_t arr = { .data = NULL };
+    VssDataStringArray_t arr = {.data = NULL};
     VssData_t vd;
     memset(&vd, 0, sizeof(vd));
     vd.data_string_array = &arr;
@@ -1320,10 +1295,10 @@ static void vss_data_uint16_array_oob(void **state)
 {
     uint8_t buf[64];
     uint8_t fill[] = {0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08};
-    Avtp_Vss_t *pdu = vss_build_data_oob_pdu(buf, sizeof(buf), 6,
-                                               VSS_UINT16_ARRAY, fill, sizeof(fill));
+    Avtp_Vss_t *pdu =
+        vss_build_data_oob_pdu(buf, sizeof(buf), 6, VSS_UINT16_ARRAY, fill, sizeof(fill));
 
-    VssDataUint16Array_t arr = { .data = NULL };
+    VssDataUint16Array_t arr = {.data = NULL};
     VssData_t vd;
     memset(&vd, 0, sizeof(vd));
     vd.data_uint16_array = &arr;
@@ -1345,10 +1320,10 @@ static void vss_data_int16_array_oob(void **state)
 {
     uint8_t buf[64];
     uint8_t fill[] = {0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08};
-    Avtp_Vss_t *pdu = vss_build_data_oob_pdu(buf, sizeof(buf), 6,
-                                               VSS_INT16_ARRAY, fill, sizeof(fill));
+    Avtp_Vss_t *pdu =
+        vss_build_data_oob_pdu(buf, sizeof(buf), 6, VSS_INT16_ARRAY, fill, sizeof(fill));
 
-    VssDataInt16Array_t arr = { .data = NULL };
+    VssDataInt16Array_t arr = {.data = NULL};
     VssData_t vd;
     memset(&vd, 0, sizeof(vd));
     vd.data_int16_array = &arr;
@@ -1370,10 +1345,10 @@ static void vss_data_uint32_array_oob(void **state)
 {
     uint8_t buf[64];
     uint8_t fill[] = {0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08};
-    Avtp_Vss_t *pdu = vss_build_data_oob_pdu(buf, sizeof(buf), 6,
-                                               VSS_UINT32_ARRAY, fill, sizeof(fill));
+    Avtp_Vss_t *pdu =
+        vss_build_data_oob_pdu(buf, sizeof(buf), 6, VSS_UINT32_ARRAY, fill, sizeof(fill));
 
-    VssDataUint32Array_t arr = { .data = NULL };
+    VssDataUint32Array_t arr = {.data = NULL};
     VssData_t vd;
     memset(&vd, 0, sizeof(vd));
     vd.data_uint32_array = &arr;
@@ -1393,10 +1368,10 @@ static void vss_data_int32_array_oob(void **state)
 {
     uint8_t buf[64];
     uint8_t fill[] = {0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08};
-    Avtp_Vss_t *pdu = vss_build_data_oob_pdu(buf, sizeof(buf), 6,
-                                               VSS_INT32_ARRAY, fill, sizeof(fill));
+    Avtp_Vss_t *pdu =
+        vss_build_data_oob_pdu(buf, sizeof(buf), 6, VSS_INT32_ARRAY, fill, sizeof(fill));
 
-    VssDataInt32Array_t arr = { .data = NULL };
+    VssDataInt32Array_t arr = {.data = NULL};
     VssData_t vd;
     memset(&vd, 0, sizeof(vd));
     vd.data_int32_array = &arr;
@@ -1418,10 +1393,10 @@ static void vss_data_uint64_array_oob(void **state)
 {
     uint8_t buf[64];
     uint8_t fill[] = {0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08};
-    Avtp_Vss_t *pdu = vss_build_data_oob_pdu(buf, sizeof(buf), 7,
-                                               VSS_UINT64_ARRAY, fill, sizeof(fill));
+    Avtp_Vss_t *pdu =
+        vss_build_data_oob_pdu(buf, sizeof(buf), 7, VSS_UINT64_ARRAY, fill, sizeof(fill));
 
-    VssDataUint64Array_t arr = { .data = NULL };
+    VssDataUint64Array_t arr = {.data = NULL};
     VssData_t vd;
     memset(&vd, 0, sizeof(vd));
     vd.data_uint64_array = &arr;
@@ -1441,10 +1416,10 @@ static void vss_data_int64_array_oob(void **state)
 {
     uint8_t buf[64];
     uint8_t fill[] = {0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08};
-    Avtp_Vss_t *pdu = vss_build_data_oob_pdu(buf, sizeof(buf), 7,
-                                               VSS_INT64_ARRAY, fill, sizeof(fill));
+    Avtp_Vss_t *pdu =
+        vss_build_data_oob_pdu(buf, sizeof(buf), 7, VSS_INT64_ARRAY, fill, sizeof(fill));
 
-    VssDataInt64Array_t arr = { .data = NULL };
+    VssDataInt64Array_t arr = {.data = NULL};
     VssData_t vd;
     memset(&vd, 0, sizeof(vd));
     vd.data_int64_array = &arr;
@@ -1464,10 +1439,10 @@ static void vss_data_float_array_oob(void **state)
 {
     uint8_t buf[64];
     uint8_t fill[] = {0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08};
-    Avtp_Vss_t *pdu = vss_build_data_oob_pdu(buf, sizeof(buf), 6,
-                                               VSS_FLOAT_ARRAY, fill, sizeof(fill));
+    Avtp_Vss_t *pdu =
+        vss_build_data_oob_pdu(buf, sizeof(buf), 6, VSS_FLOAT_ARRAY, fill, sizeof(fill));
 
-    VssDataFloatArray_t arr = { .data = NULL };
+    VssDataFloatArray_t arr = {.data = NULL};
     VssData_t vd;
     memset(&vd, 0, sizeof(vd));
     vd.data_float_array = &arr;
@@ -1493,10 +1468,10 @@ static void vss_data_double_array_oob(void **state)
 {
     uint8_t buf[64];
     uint8_t fill[] = {0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08};
-    Avtp_Vss_t *pdu = vss_build_data_oob_pdu(buf, sizeof(buf), 7,
-                                               VSS_DOUBLE_ARRAY, fill, sizeof(fill));
+    Avtp_Vss_t *pdu =
+        vss_build_data_oob_pdu(buf, sizeof(buf), 7, VSS_DOUBLE_ARRAY, fill, sizeof(fill));
 
-    VssDataDoubleArray_t arr = { .data = NULL };
+    VssDataDoubleArray_t arr = {.data = NULL};
     VssData_t vd;
     memset(&vd, 0, sizeof(vd));
     vd.data_double_array = &arr;
@@ -1522,9 +1497,8 @@ static void vss_data_double_array_oob(void **state)
  * msg_length allows.  CalcVssPathLength would return 0xFFFD + 2 = 0xFFFF
  * (65535 — no uint16_t wrap), pushing the computed data pointer 65547 bytes
  * past the PDU start — well beyond any plausible frame. */
-static Avtp_Vss_t* vss_build_inflated_path_pdu(uint8_t *buf, size_t buf_size,
-                                                uint8_t msg_quadlets,
-                                                Vss_Datatype_t datatype)
+static Avtp_Vss_t *vss_build_inflated_path_pdu(uint8_t *buf, size_t buf_size, uint8_t msg_quadlets,
+                                               Vss_Datatype_t datatype)
 {
     memset(buf, 0, buf_size);
     Avtp_Vss_t *pdu = (Avtp_Vss_t *)buf;
@@ -1552,10 +1526,9 @@ static Avtp_Vss_t* vss_build_inflated_path_pdu(uint8_t *buf, size_t buf_size,
 static void vss_data_string_inflated_path_oob(void **state)
 {
     uint8_t buf[64];
-    Avtp_Vss_t *pdu = vss_build_inflated_path_pdu(buf, sizeof(buf), 6,
-                                                    VSS_STRING);
+    Avtp_Vss_t *pdu = vss_build_inflated_path_pdu(buf, sizeof(buf), 6, VSS_STRING);
 
-    VssDataString_t str = { .data = NULL };
+    VssDataString_t str = {.data = NULL};
     VssData_t vd;
     memset(&vd, 0, sizeof(vd));
     vd.data_string = &str;
@@ -1570,13 +1543,12 @@ static void vss_data_string_inflated_path_oob(void **state)
 }
 
 /* Scalar VSS_UINT8: the raw dereference of *vss_data_ptr must be guarded
- * so that an out‑of‑frame data pointer is never read.  
+ * so that an out‑of‑frame data pointer is never read.
  * Correct behavior: Avtp_Vss_GetVssData is noop, pre‑set sentinel survives. */
 static void vss_data_uint8_inflated_path_oob(void **state)
 {
     uint8_t buf[64];
-    Avtp_Vss_t *pdu = vss_build_inflated_path_pdu(buf, sizeof(buf), 6,
-                                                    VSS_UINT8);
+    Avtp_Vss_t *pdu = vss_build_inflated_path_pdu(buf, sizeof(buf), 6, VSS_UINT8);
 
     VssData_t vd;
     memset(&vd, 0xAA, sizeof(vd));
@@ -1589,10 +1561,9 @@ static void vss_data_uint8_inflated_path_oob(void **state)
 static void vss_data_uint8_array_inflated_path_oob(void **state)
 {
     uint8_t buf[64];
-    Avtp_Vss_t *pdu = vss_build_inflated_path_pdu(buf, sizeof(buf), 6,
-                                                    VSS_UINT8_ARRAY);
+    Avtp_Vss_t *pdu = vss_build_inflated_path_pdu(buf, sizeof(buf), 6, VSS_UINT8_ARRAY);
 
-    VssDataUint8Array_t arr = { .data = NULL };
+    VssDataUint8Array_t arr = {.data = NULL};
     VssData_t vd;
     memset(&vd, 0, sizeof(vd));
     vd.data_uint8_array = &arr;
@@ -1616,17 +1587,17 @@ static void vss_data_static_id_truncated_oob(void **state)
     memset(buf, 0, sizeof(buf));
     Avtp_Vss_Init(pdu);
     Avtp_Vss_SetAddrMode(pdu, VSS_STATIC_ID_MODE);
-    Avtp_Vss_SetAcfMsgLength(pdu, 3);  /* 12 bytes — header only */
+    Avtp_Vss_SetAcfMsgLength(pdu, 3); /* 12 bytes — header only */
     Avtp_Vss_SetDatatype(pdu, VSS_UINT8);
 
     VssData_t vd;
     memset(&vd, 0xAA, sizeof(vd));
-     Avtp_Vss_GetVssData(pdu, &vd);
+    Avtp_Vss_GetVssData(pdu, &vd);
     assert_int_equal(vd.data_uint8, 0xAA);
 }
 
-/* ACF msg_length == 0 means the declared PDU size is 0 bytes.  
- * This is testing for a regression: There used to be a 
+/* ACF msg_length == 0 means the declared PDU size is 0 bytes.
+ * This is testing for a regression: There used to be a
  * legacy bypass where the lentghts in ACF-VSS frames where trusted
  * when the ACF length was set to 0.
  * Correct behavior:: A zero‑msg‑length frame is treated as empty
@@ -1639,8 +1610,7 @@ static void vss_path_interop_zero_msg_length_oob(void **state)
 {
     uint8_t buf[64];
     /* msg_quadlets = 0 → declared PDU = 0 bytes */
-    Avtp_Vss_t *pdu = vss_build_inflated_path_pdu(buf, sizeof(buf), 0,
-                                                    VSS_UINT8);
+    Avtp_Vss_t *pdu = vss_build_inflated_path_pdu(buf, sizeof(buf), 0, VSS_UINT8);
 
     char path_buf[16];
     memset(path_buf, 0x5A, sizeof(path_buf));
@@ -1658,10 +1628,9 @@ static void vss_data_string_zero_msg_length_oob(void **state)
 {
     uint8_t buf[64];
     /* msg_quadlets = 0 → declared PDU = 0 bytes */
-    Avtp_Vss_t *pdu = vss_build_inflated_path_pdu(buf, sizeof(buf), 0,
-                                                    VSS_STRING);
+    Avtp_Vss_t *pdu = vss_build_inflated_path_pdu(buf, sizeof(buf), 0, VSS_STRING);
 
-    VssDataString_t str = { .data = NULL };
+    VssDataString_t str = {.data = NULL};
     VssData_t vd;
     memset(&vd, 0, sizeof(vd));
     vd.data_string = &str;

--- a/unit/test-vss.c
+++ b/unit/test-vss.c
@@ -74,8 +74,7 @@ static void vss_pad(void **state) {
     Avtp_Vss_Init(vss_pdu);
 
     for(int i = 1; i < 4; i++) {
-        int vss_length = AVTP_VSS_FIXED_HEADER_LEN + i;
-        Avtp_Vss_Pad(vss_pdu, vss_length);
+        Avtp_Vss_SetPayloadLength(vss_pdu, i);
 
         uint8_t vss_quadlets = Avtp_Vss_GetAcfMsgLength(vss_pdu);
         assert_int_equal(vss_quadlets, AVTP_VSS_FIXED_HEADER_LEN/4 + 1);


### PR DESCRIPTION
While VSS is a bit of a wildcard implementing custom/more complex ACF, this one brings it closer to the API guidelines, mainly by renaming functions

 - include/avtp/acf/custom/Vss.h: packed Avtp_Vss_t; added <stdbool.h>; GetMtv→IsMtv (bool), EnableMtv/DisableMtv→SetMtv(bool); Get/SetAcfMsgLength→uint16_t; GetMsgTimestamp/SetMsgTimestamp→GetMessageTimestamp/SetMessageTimestamp (enum AVTP_VSS_FIELD_MSG_TIMESTAMP→AVTP_VSS_FIELD_MESSAGE_TIMESTAMP); Pad(pdu, vss_length)→SetPayloadLength(pdu, payload_length).
- src/avtp/acf/custom/Vss.c: matching renames; SetPayloadLength now adds the fixed header internally from the payload length.
- examples/acf-vss/acf-vss-talker.c: updated the field enum and the SetPayloadLength call (acf_length - AVTP_VSS_FIXED_HEADER_LEN).
- unit/test-vss.c: vss_pad updated to pass payload length.