### PR TITLE
Remove per ACF set/get ACFType and ACFMsgLength

### DIFF
--- a/docs/api-design.md
+++ b/docs/api-design.md
@@ -446,7 +446,7 @@ OPEN1722_INLINE void Avtp_Can_Init(Avtp_Can_t *pdu)
 {
     if (pdu != NULL) {
         memset(pdu, 0, sizeof(Avtp_Can_t));
-        Avtp_Can_SetAcfMsgType(pdu, AVTP_ACF_TYPE_CAN);
+        Avtp_AcfCommon_SetAcfMsgType((Avtp_AcfCommon_t *)pdu, AVTP_ACF_TYPE_CAN);
     }
 }
 ```
@@ -483,14 +483,27 @@ described once in [`AcfCommon.h`](../include/avtp/acf/AcfCommon.h):
 - `Avtp_AcfCommon_t` - the common-header PDU struct.
 - `Avtp_AcfMsgType_t` - the enumeration of all ACF message types
   (`AVTP_ACF_TYPE_CAN`, `AVTP_ACF_TYPE_LIN`, …).
-- `Avtp_AcfCommon_Get/SetAcfMsgType`, `Get/SetAcfMsgLength` - accessors for the
-  two shared fields.
+- `Avtp_AcfCommon_GetAcfMsgType`, `Avtp_AcfCommon_SetAcfMsgType`,
+  `Avtp_AcfCommon_Get/SetAcfMsgLength` - accessors for the two shared fields,
+  typed against `Avtp_AcfMsgType_t`.
 
-Each concrete format then defines its *own* field enum and descriptor table that
-*include* the two common fields, so a format's accessors are self-contained and
-do not require the caller to mix in the common-header struct. That is why
-`Avtp_Can_GetAcfMsgType` exists even though the field is formally part of the
-ACF common header.
+Each concrete format defines its *own* field enum and descriptor table that
+*include* the two common fields, so the format's struct can be overlaid on the
+common header and its format-specific accessors stay self-contained.
+
+The two common fields are accessed through the generic `AcfCommon` accessors,
+never through per-format functions:
+
+- The `acf_msg_type` field has exactly one correct value per format, so there
+  is **no per-format `Get/SetAcfMsgType`**. `Init` stamps the message type with
+  `Avtp_AcfCommon_SetAcfMsgType((Avtp_AcfCommon_t *)pdu, AVTP_ACF_TYPE_<NAME>)`,
+  and `IsValid` checks it with `Avtp_AcfCommon_GetAcfMsgType((const
+  Avtp_AcfCommon_t *)pdu)`. Since every ACF format struct starts with the
+  common header (one quadlet), casting the format PDU pointer to
+  `Avtp_AcfCommon_t *` is always safe.
+- The `acf_msg_length` field is a real variable field, so each format keeps
+  `GetAcfMsgLength`, `SetAcfMsgLength` and `GetAcfMsgLengthInBytes`, but they
+  are thin inline wrappers that delegate to `Avtp_AcfCommon_*`.
 
 ## The field-access engine
 

--- a/docs/api-design.md
+++ b/docs/api-design.md
@@ -142,7 +142,7 @@ Getters return the natural C type for the field width - `uint8_t`,
 
 ```c
 OPEN1722_INLINE uint8_t  Avtp_Can_GetPad(const Avtp_Can_t *const pdu);
-OPEN1722_INLINE uint16_t Avtp_Can_GetAcfMsgLength(const Avtp_Can_t *const pdu);
+OPEN1722_INLINE uint16_t Avtp_AcfCommon_GetAcfMsgLengthInBytes(const Avtp_AcfCommon_t *const pdu);
 OPEN1722_INLINE uint64_t Avtp_Can_GetMessageTimestamp(const Avtp_Can_t *const pdu);
 ```
 
@@ -247,7 +247,7 @@ The canonical set (CAN as reference):
           memset(can_pdu->payload + payload_length, 0, pad);
       uint16_t msgLenQuadlets = (uint16_t)((msgLenBytes + pad) / 4);
       Avtp_Can_SetPad(can_pdu, pad);
-      Avtp_Can_SetAcfMsgLength(can_pdu, msgLenQuadlets);
+      Avtp_AcfCommon_SetAcfMsgLength((Avtp_AcfCommon_t *)can_pdu, msgLenQuadlets);
   }
   ```
 
@@ -261,9 +261,10 @@ The canonical set (CAN as reference):
   header fields (e.g. `mtv`, `message_timestamp`, `rtr`, `brs`, `esi`) *after*
   calling it.
 
-`SetAcfMsgLength` itself remains available for when you want to set the raw
-quadlet value directly; `SetPayloadLength` is the friendlier path that keeps the
-padding consistent for you.
+The raw quadlet-encoded `acf_msg_length` field can still be written directly
+via `Avtp_AcfCommon_SetAcfMsgLength` when you need it;
+`SetPayloadLength` is the friendlier path that keeps the padding consistent for
+you.
 
 ## Inline accessors & the shared library
 
@@ -484,26 +485,32 @@ described once in [`AcfCommon.h`](../include/avtp/acf/AcfCommon.h):
 - `Avtp_AcfMsgType_t` - the enumeration of all ACF message types
   (`AVTP_ACF_TYPE_CAN`, `AVTP_ACF_TYPE_LIN`, …).
 - `Avtp_AcfCommon_GetAcfMsgType`, `Avtp_AcfCommon_SetAcfMsgType`,
-  `Avtp_AcfCommon_Get/SetAcfMsgLength` - accessors for the two shared fields,
-  typed against `Avtp_AcfMsgType_t`.
+  `Avtp_AcfCommon_Get/SetAcfMsgLength`,
+  `Avtp_AcfCommon_GetAcfMsgLengthInBytes` - accessors for the two shared
+  fields (the message type accessors are typed against
+  `Avtp_AcfMsgType_t`).
 
 Each concrete format defines its *own* field enum and descriptor table that
 *include* the two common fields, so the format's struct can be overlaid on the
 common header and its format-specific accessors stay self-contained.
 
 The two common fields are accessed through the generic `AcfCommon` accessors,
-never through per-format functions:
+never through per-format functions. Since every ACF format struct starts with
+the common header (one quadlet), casting the format PDU pointer to
+`Avtp_AcfCommon_t *` is always safe:
 
 - The `acf_msg_type` field has exactly one correct value per format, so there
   is **no per-format `Get/SetAcfMsgType`**. `Init` stamps the message type with
   `Avtp_AcfCommon_SetAcfMsgType((Avtp_AcfCommon_t *)pdu, AVTP_ACF_TYPE_<NAME>)`,
   and `IsValid` checks it with `Avtp_AcfCommon_GetAcfMsgType((const
-  Avtp_AcfCommon_t *)pdu)`. Since every ACF format struct starts with the
-  common header (one quadlet), casting the format PDU pointer to
-  `Avtp_AcfCommon_t *` is always safe.
-- The `acf_msg_length` field is a real variable field, so each format keeps
-  `GetAcfMsgLength`, `SetAcfMsgLength` and `GetAcfMsgLengthInBytes`, but they
-  are thin inline wrappers that delegate to `Avtp_AcfCommon_*`.
+  Avtp_AcfCommon_t *)pdu)`.
+- The `acf_msg_length` field is likewise accessed only through
+  `Avtp_AcfCommon_GetAcfMsgLength`, `SetAcfMsgLength` and
+  `Avtp_AcfCommon_GetAcfMsgLengthInBytes` - there are **no per-format
+  `Get/SetAcfMsgLength` or `GetAcfMsgLengthInBytes`** either. The per-format
+  convenience functions that deal in payload bytes (`SetPayloadLength`, and
+  `GetPayloadLength` where the format encodes enough information to recover
+  it) are where the raw quadlet-encoded length field is read or written.
 
 ## The field-access engine
 

--- a/examples/acf-can/acf-can-common.c
+++ b/examples/acf-can/acf-can-common.c
@@ -321,7 +321,8 @@ int avtp_to_can(uint8_t *pdu, frame_t *can_frames, Avtp_CanVariant_t can_variant
 
         canid_t can_id = Avtp_Can_GetCanIdentifier((Avtp_Can_t *)acf_pdu);
         const uint8_t *can_payload = Avtp_Can_GetPayload((Avtp_Can_t *)acf_pdu);
-        uint16_t acf_msg_length = Avtp_AcfCommon_GetAcfMsgLengthInBytes((Avtp_AcfCommon_t *)acf_pdu);
+        uint16_t acf_msg_length =
+            Avtp_AcfCommon_GetAcfMsgLengthInBytes((Avtp_AcfCommon_t *)acf_pdu);
         uint16_t can_payload_length = Avtp_Can_GetPayloadLength((Avtp_Can_t *)acf_pdu);
         proc_bytes += acf_msg_length;
 

--- a/examples/acf-can/acf-can-common.c
+++ b/examples/acf-can/acf-can-common.c
@@ -207,7 +207,7 @@ static int prepare_acf_packet(uint8_t *acf_pdu, frame_t *frame, Avtp_CanVariant_
         }
     }
 
-    return Avtp_Can_GetAcfMsgLength(pdu) * 4;
+    return Avtp_AcfCommon_GetAcfMsgLengthInBytes((Avtp_AcfCommon_t *)pdu);
 }
 
 int can_to_avtp(frame_t *can_frames, Avtp_CanVariant_t can_variant, uint8_t *pdu, int use_udp,
@@ -321,7 +321,7 @@ int avtp_to_can(uint8_t *pdu, frame_t *can_frames, Avtp_CanVariant_t can_variant
 
         canid_t can_id = Avtp_Can_GetCanIdentifier((Avtp_Can_t *)acf_pdu);
         const uint8_t *can_payload = Avtp_Can_GetPayload((Avtp_Can_t *)acf_pdu);
-        uint16_t acf_msg_length = Avtp_Can_GetAcfMsgLength((Avtp_Can_t *)acf_pdu) * 4;
+        uint16_t acf_msg_length = Avtp_AcfCommon_GetAcfMsgLengthInBytes((Avtp_AcfCommon_t *)acf_pdu);
         uint16_t can_payload_length = Avtp_Can_GetPayloadLength((Avtp_Can_t *)acf_pdu);
         proc_bytes += acf_msg_length;
 

--- a/examples/acf-can/linux-kernel-mod/1722ethernet.c
+++ b/examples/acf-can/linux-kernel-mod/1722ethernet.c
@@ -91,8 +91,7 @@ void prepare_can_header(Avtp_Can_t *can_header, struct acfcan_cfg *cfg, const st
     uint8_t padSize = (AVTP_QUADLET_SIZE - ((AVTP_CAN_HEADER_LEN + cfd->len) % AVTP_QUADLET_SIZE)) %
                       AVTP_QUADLET_SIZE;
     Avtp_AcfCommon_SetAcfMsgLength((Avtp_AcfCommon_t *)can_header,
-                                   (AVTP_CAN_HEADER_LEN + cfd->len + padSize) /
-                                       AVTP_QUADLET_SIZE);
+                                   (AVTP_CAN_HEADER_LEN + cfd->len + padSize) / AVTP_QUADLET_SIZE);
     Avtp_Can_SetPad(can_header, padSize);
 
     pr_debug("Prepared AVTP ACFCAN msg for can id 0x%08x, len %i\n",
@@ -111,7 +110,8 @@ void prepare_can_header(Avtp_Can_t *can_header, struct acfcan_cfg *cfg, const st
 void calculate_and_set_ntscf_size(ACFCANPdu_t *pdu)
 {
     // 1722 is a mess. Bytes, lukicly we have padded quadlets in can already....
-    uint16_t canandpadinbytes = Avtp_AcfCommon_GetAcfMsgLengthInBytes((Avtp_AcfCommon_t *)&pdu->can);
+    uint16_t canandpadinbytes =
+        Avtp_AcfCommon_GetAcfMsgLengthInBytes((Avtp_AcfCommon_t *)&pdu->can);
     Avtp_Ntscf_SetNtscfDataLength(&pdu->ntscf, canandpadinbytes);
 }
 

--- a/examples/acf-can/linux-kernel-mod/1722ethernet.c
+++ b/examples/acf-can/linux-kernel-mod/1722ethernet.c
@@ -90,8 +90,9 @@ void prepare_can_header(Avtp_Can_t *can_header, struct acfcan_cfg *cfg, const st
     // 1722 is a mess. Here we need to pad to quadlets
     uint8_t padSize = (AVTP_QUADLET_SIZE - ((AVTP_CAN_HEADER_LEN + cfd->len) % AVTP_QUADLET_SIZE)) %
                       AVTP_QUADLET_SIZE;
-    Avtp_Can_SetAcfMsgLength(can_header,
-                             (AVTP_CAN_HEADER_LEN + cfd->len + padSize) / AVTP_QUADLET_SIZE);
+    Avtp_AcfCommon_SetAcfMsgLength((Avtp_AcfCommon_t *)can_header,
+                                   (AVTP_CAN_HEADER_LEN + cfd->len + padSize) /
+                                       AVTP_QUADLET_SIZE);
     Avtp_Can_SetPad(can_header, padSize);
 
     pr_debug("Prepared AVTP ACFCAN msg for can id 0x%08x, len %i\n",
@@ -110,7 +111,7 @@ void prepare_can_header(Avtp_Can_t *can_header, struct acfcan_cfg *cfg, const st
 void calculate_and_set_ntscf_size(ACFCANPdu_t *pdu)
 {
     // 1722 is a mess. Bytes, lukicly we have padded quadlets in can already....
-    uint16_t canandpadinbytes = Avtp_Can_GetAcfMsgLength(&pdu->can) * AVTP_QUADLET_SIZE;
+    uint16_t canandpadinbytes = Avtp_AcfCommon_GetAcfMsgLengthInBytes((Avtp_AcfCommon_t *)&pdu->can);
     Avtp_Ntscf_SetNtscfDataLength(&pdu->ntscf, canandpadinbytes);
 }
 

--- a/examples/hello-world/hello-world-listener.c
+++ b/examples/hello-world/hello-world-listener.c
@@ -155,7 +155,7 @@ int main(int argc, char *argv[])
 
         // Parse the GPC Packet and print contents on the STDOUT
         gpc_code = Avtp_Gpc_GetGpcMsgId((Avtp_Gpc_t*)acf_pdu);
-        acf_msg_length = Avtp_Gpc_GetAcfMsgLength((Avtp_Gpc_t*)acf_pdu);
+        acf_msg_length = Avtp_AcfCommon_GetAcfMsgLength((Avtp_AcfCommon_t*)acf_pdu);
         if (acf_msg_length * 4 <= MAX_MSG_SIZE) {
             recd_msg = (char *) acf_pdu + AVTP_GPC_HEADER_LEN;
             printf("%s : GPC Code %ld\n", recd_msg, gpc_code);

--- a/examples/hello-world/hello-world-listener.c
+++ b/examples/hello-world/hello-world-listener.c
@@ -45,8 +45,8 @@
 #include "avtp/acf/Gpc.h"
 #include "avtp/CommonHeader.h"
 
-#define MAX_PDU_SIZE                1500
-#define MAX_MSG_SIZE                100
+#define MAX_PDU_SIZE 1500
+#define MAX_MSG_SIZE 100
 
 static char ifname[IFNAMSIZ];
 static uint8_t macaddr[ETH_ALEN];
@@ -54,12 +54,11 @@ static uint8_t use_udp;
 static uint32_t udp_port = 17220;
 
 static struct argp_option options[] = {
-    {"udp", 'u', 0, 0, "Use UDP" },
+    {"udp", 'u', 0, 0, "Use UDP"},
     {"ifname", 'i', "IFNAME", 0, "Network interface (If Ethernet)"},
     {"dst-addr", 'd', "MACADDR", 0, "Stream destination MAC address (If Ethernet)"},
     {"udp-port", 'p', "UDP_PORT", 0, "UDP Port to listen on (if UDP)"},
-    { 0 }
-};
+    {0}};
 
 static error_t parser(int key, char *arg, struct argp_state *state)
 {
@@ -76,9 +75,8 @@ static error_t parser(int key, char *arg, struct argp_state *state)
         strncpy(ifname, arg, sizeof(ifname) - 1);
         break;
     case 'd':
-        res = sscanf(arg, "%hhx:%hhx:%hhx:%hhx:%hhx:%hhx",
-                &macaddr[0], &macaddr[1], &macaddr[2],
-                &macaddr[3], &macaddr[4], &macaddr[5]);
+        res = sscanf(arg, "%hhx:%hhx:%hhx:%hhx:%hhx:%hhx", &macaddr[0], &macaddr[1], &macaddr[2],
+                     &macaddr[3], &macaddr[4], &macaddr[5]);
         if (res != 6) {
             fprintf(stderr, "Invalid MAC address\n");
             exit(EXIT_FAILURE);
@@ -89,7 +87,7 @@ static error_t parser(int key, char *arg, struct argp_state *state)
     return 0;
 }
 
-static struct argp argp = { options, parser, 0, 0};
+static struct argp argp = {options, parser, 0, 0};
 
 int main(int argc, char *argv[])
 {
@@ -135,29 +133,29 @@ int main(int argc, char *argv[])
         }
 
         // Check if the packet is a control format packet (i.e. NTSCF or TSCF)
-        subtype = Avtp_CommonHeader_GetSubtype((Avtp_CommonHeader_t*)cf_pdu);
-        if (subtype == AVTP_SUBTYPE_TSCF){
+        subtype = Avtp_CommonHeader_GetSubtype((Avtp_CommonHeader_t *)cf_pdu);
+        if (subtype == AVTP_SUBTYPE_TSCF) {
             proc_bytes += AVTP_TSCF_HEADER_LEN;
-            msg_length = Avtp_Tscf_GetStreamDataLength((Avtp_Tscf_t*)cf_pdu);
+            msg_length = Avtp_Tscf_GetStreamDataLength((Avtp_Tscf_t *)cf_pdu);
         } else {
             proc_bytes += AVTP_NTSCF_HEADER_LEN;
-            msg_length = Avtp_Ntscf_GetNtscfDataLength((Avtp_Ntscf_t*)cf_pdu);
+            msg_length = Avtp_Ntscf_GetNtscfDataLength((Avtp_Ntscf_t *)cf_pdu);
         }
 
         // Check if the control packet payload is a ACF GPC.
         acf_pdu = &pdu[proc_bytes];
-        acf_type = Avtp_AcfCommon_GetAcfMsgType((Avtp_AcfCommon_t*)acf_pdu);
+        acf_type = Avtp_AcfCommon_GetAcfMsgType((Avtp_AcfCommon_t *)acf_pdu);
         if (acf_type != AVTP_ACF_TYPE_GPC) {
-            fprintf(stderr, "ACF type mismatch: expected %"PRIu8", got %"PRIu8"\n",
+            fprintf(stderr, "ACF type mismatch: expected %" PRIu8 ", got %" PRIu8 "\n",
                     AVTP_ACF_TYPE_GPC, acf_type);
             continue;
         }
 
         // Parse the GPC Packet and print contents on the STDOUT
-        gpc_code = Avtp_Gpc_GetGpcMsgId((Avtp_Gpc_t*)acf_pdu);
-        acf_msg_length = Avtp_AcfCommon_GetAcfMsgLength((Avtp_AcfCommon_t*)acf_pdu);
+        gpc_code = Avtp_Gpc_GetGpcMsgId((Avtp_Gpc_t *)acf_pdu);
+        acf_msg_length = Avtp_AcfCommon_GetAcfMsgLength((Avtp_AcfCommon_t *)acf_pdu);
         if (acf_msg_length * 4 <= MAX_MSG_SIZE) {
-            recd_msg = (char *) acf_pdu + AVTP_GPC_HEADER_LEN;
+            recd_msg = (char *)acf_pdu + AVTP_GPC_HEADER_LEN;
             printf("%s : GPC Code %ld\n", recd_msg, gpc_code);
         }
     }
@@ -167,5 +165,4 @@ int main(int argc, char *argv[])
 err:
     close(sk_fd);
     return 1;
-
 }

--- a/examples/hello-world/hello-world-talker.c
+++ b/examples/hello-world/hello-world-talker.c
@@ -169,7 +169,7 @@ static int prepare_acf_packet(uint8_t *acf_pdu, uint64_t gpc_code, uint8_t *payl
     // Prepare ACF PDU for CAN
     Avtp_Gpc_Init(pdu);
     Avtp_Gpc_SetGpcMsgId(pdu, gpc_code);
-    Avtp_Gpc_SetAcfMsgLength(pdu, acf_length);
+    Avtp_AcfCommon_SetAcfMsgLength((Avtp_AcfCommon_t *)pdu, acf_length);
     memcpy(acf_pdu + AVTP_GPC_HEADER_LEN, payload, length);
     memset(acf_pdu + AVTP_GPC_HEADER_LEN + length, 0, acf_length * 4 - length);
 

--- a/include/avtp/acf/Abb.h
+++ b/include/avtp/acf/Abb.h
@@ -114,17 +114,6 @@ static const Avtp_FieldDescriptor_t Avtp_AbbFieldDesc[AVTP_ABB_FIELD_MAX] = {
 };
 
 /**
- * Return the value of the ACF message type field as specified in the IEEE 1722 Specification.
- *
- * @param pdu Pointer to the first bit of a 1722 ACF ABB PDU.
- * @returns Value of the ACF message type field.
- */
-OPEN1722_INLINE uint8_t Avtp_Abb_GetAcfMsgType(const Avtp_Abb_t *const pdu)
-{
-    return (uint8_t)GET_ABB_FIELD(AVTP_ABB_FIELD_ACF_MSG_TYPE);
-}
-
-/**
  * Return the value of the ACF message length field as specified in the IEEE 1722 Specification.
  * This returns the length in Quadlets as specified in the IEEE 1722 Specification.
  *
@@ -135,7 +124,7 @@ OPEN1722_INLINE uint8_t Avtp_Abb_GetAcfMsgType(const Avtp_Abb_t *const pdu)
  */
 OPEN1722_INLINE uint16_t Avtp_Abb_GetAcfMsgLength(const Avtp_Abb_t *const pdu)
 {
-    return (uint16_t)GET_ABB_FIELD(AVTP_ABB_FIELD_ACF_MSG_LENGTH);
+    return Avtp_AcfCommon_GetAcfMsgLength((const Avtp_AcfCommon_t *)pdu);
 }
 
 /**
@@ -146,18 +135,7 @@ OPEN1722_INLINE uint16_t Avtp_Abb_GetAcfMsgLength(const Avtp_Abb_t *const pdu)
  */
 OPEN1722_INLINE uint16_t Avtp_Abb_GetAcfMsgLengthInBytes(const Avtp_Abb_t *const pdu)
 {
-    return (uint16_t)GET_ABB_FIELD(AVTP_ABB_FIELD_ACF_MSG_LENGTH) * 4;
-}
-
-/**
- * Set the value of the ACF message type field as specified in the IEEE 1722 Specification.
- *
- * @param pdu Pointer to the first bit of a 1722 ACF ABB PDU.
- * @param value Value to set the ACF message type field to.
- */
-OPEN1722_INLINE void Avtp_Abb_SetAcfMsgType(Avtp_Abb_t *pdu, uint8_t value)
-{
-    SET_ABB_FIELD(AVTP_ABB_FIELD_ACF_MSG_TYPE, value);
+    return (uint16_t)Avtp_AcfCommon_GetAcfMsgLength((const Avtp_AcfCommon_t *)pdu) * 4;
 }
 
 /**
@@ -171,7 +149,7 @@ OPEN1722_INLINE void Avtp_Abb_SetAcfMsgType(Avtp_Abb_t *pdu, uint8_t value)
  */
 OPEN1722_INLINE void Avtp_Abb_SetAcfMsgLength(Avtp_Abb_t *pdu, uint16_t value)
 {
-    SET_ABB_FIELD(AVTP_ABB_FIELD_ACF_MSG_LENGTH, value);
+    Avtp_AcfCommon_SetAcfMsgLength((Avtp_AcfCommon_t *)pdu, value);
 }
 
 /**
@@ -531,7 +509,7 @@ OPEN1722_INLINE void Avtp_Abb_Init(Avtp_Abb_t *pdu)
 {
     if (pdu != NULL) {
         memset(pdu, 0, sizeof(Avtp_Abb_t));
-        Avtp_Abb_SetAcfMsgType(pdu, AVTP_ACF_TYPE_BYTE_BUS_BRIEF);
+        Avtp_AcfCommon_SetAcfMsgType((Avtp_AcfCommon_t *)pdu, AVTP_ACF_TYPE_BYTE_BUS_BRIEF);
     }
 }
 
@@ -583,7 +561,7 @@ OPEN1722_INLINE bool Avtp_Abb_IsValid(const Avtp_Abb_t *const pdu, size_t buffer
         return false;
     }
 
-    if (Avtp_Abb_GetAcfMsgType(pdu) != AVTP_ACF_TYPE_BYTE_BUS_BRIEF) {
+    if (Avtp_AcfCommon_GetAcfMsgType((const Avtp_AcfCommon_t *)pdu) != AVTP_ACF_TYPE_BYTE_BUS_BRIEF) {
         return false;
     }
 

--- a/include/avtp/acf/Abb.h
+++ b/include/avtp/acf/Abb.h
@@ -457,7 +457,8 @@ OPEN1722_INLINE void Avtp_Abb_SetPayloadLength(Avtp_Abb_t *pdu, uint16_t payload
 OPEN1722_INLINE uint8_t Avtp_Abb_GetPayloadLength(const Avtp_Abb_t *const pdu)
 {
     uint8_t pad_length = Avtp_Abb_GetPad(pdu);
-    uint16_t acf_length_bytes = Avtp_AcfCommon_GetAcfMsgLengthInBytes((const Avtp_AcfCommon_t *)pdu);
+    uint16_t acf_length_bytes =
+        Avtp_AcfCommon_GetAcfMsgLengthInBytes((const Avtp_AcfCommon_t *)pdu);
     return (uint8_t)(acf_length_bytes - AVTP_ABB_HEADER_LEN - pad_length);
 }
 
@@ -522,11 +523,13 @@ OPEN1722_INLINE bool Avtp_Abb_IsValid(const Avtp_Abb_t *const pdu, size_t buffer
         return false;
     }
 
-    if (Avtp_AcfCommon_GetAcfMsgType((const Avtp_AcfCommon_t *)pdu) != AVTP_ACF_TYPE_BYTE_BUS_BRIEF) {
+    if (Avtp_AcfCommon_GetAcfMsgType((const Avtp_AcfCommon_t *)pdu) !=
+        AVTP_ACF_TYPE_BYTE_BUS_BRIEF) {
         return false;
     }
 
-    uint16_t msg_length_bytes = Avtp_AcfCommon_GetAcfMsgLengthInBytes((const Avtp_AcfCommon_t *)pdu);
+    uint16_t msg_length_bytes =
+        Avtp_AcfCommon_GetAcfMsgLengthInBytes((const Avtp_AcfCommon_t *)pdu);
     if (msg_length_bytes > bufferSize) {
         return false;
     }

--- a/include/avtp/acf/Abb.h
+++ b/include/avtp/acf/Abb.h
@@ -114,45 +114,6 @@ static const Avtp_FieldDescriptor_t Avtp_AbbFieldDesc[AVTP_ABB_FIELD_MAX] = {
 };
 
 /**
- * Return the value of the ACF message length field as specified in the IEEE 1722 Specification.
- * This returns the length in Quadlets as specified in the IEEE 1722 Specification.
- *
- * You can use Avtp_Abb_GetPayloadLength to get the length in bytes without padding.
- *
- * @param pdu Pointer to the first bit of a 1722 ACF ABB PDU.
- * @returns Value of the ACF message length field.
- */
-OPEN1722_INLINE uint16_t Avtp_Abb_GetAcfMsgLength(const Avtp_Abb_t *const pdu)
-{
-    return Avtp_AcfCommon_GetAcfMsgLength((const Avtp_AcfCommon_t *)pdu);
-}
-
-/**
- * Return the ACF message length in bytes.
- *
- * @param pdu Pointer to the first bit of a 1722 ACF ABB PDU.
- * @returns Length of the ACF message in bytes.
- */
-OPEN1722_INLINE uint16_t Avtp_Abb_GetAcfMsgLengthInBytes(const Avtp_Abb_t *const pdu)
-{
-    return (uint16_t)Avtp_AcfCommon_GetAcfMsgLength((const Avtp_AcfCommon_t *)pdu) * 4;
-}
-
-/**
- * Set the value of the ACF message length field as specified in the IEEE 1722 Specification.
- * Note: the size is in Quadlets as specified in the IEEE 1722 Specification.
- * You can use Avtp_Abb_SetPayloadLength to set length in bytes and automatically set the
- * correct padding.
- *
- * @param pdu Pointer to the first bit of a 1722 ACF ABB PDU.
- * @param value Value to set the ACF message length field to.
- */
-OPEN1722_INLINE void Avtp_Abb_SetAcfMsgLength(Avtp_Abb_t *pdu, uint16_t value)
-{
-    Avtp_AcfCommon_SetAcfMsgLength((Avtp_AcfCommon_t *)pdu, value);
-}
-
-/**
  * Returns the pad field from an ACF_ABB message header.
  *
  * @param pdu Pointer to an ACF_ABB message.
@@ -479,7 +440,7 @@ OPEN1722_INLINE void Avtp_Abb_SetPayloadLength(Avtp_Abb_t *pdu, uint16_t payload
     }
     uint16_t msgLenQuadlets = (uint16_t)((msgLenBytes + pad) / 4);
     Avtp_Abb_SetPad(pdu, pad);
-    Avtp_Abb_SetAcfMsgLength(pdu, msgLenQuadlets);
+    Avtp_AcfCommon_SetAcfMsgLength((Avtp_AcfCommon_t *)pdu, msgLenQuadlets);
 }
 
 /**
@@ -496,7 +457,7 @@ OPEN1722_INLINE void Avtp_Abb_SetPayloadLength(Avtp_Abb_t *pdu, uint16_t payload
 OPEN1722_INLINE uint8_t Avtp_Abb_GetPayloadLength(const Avtp_Abb_t *const pdu)
 {
     uint8_t pad_length = Avtp_Abb_GetPad(pdu);
-    uint16_t acf_length_bytes = Avtp_Abb_GetAcfMsgLengthInBytes(pdu);
+    uint16_t acf_length_bytes = Avtp_AcfCommon_GetAcfMsgLengthInBytes((const Avtp_AcfCommon_t *)pdu);
     return (uint8_t)(acf_length_bytes - AVTP_ABB_HEADER_LEN - pad_length);
 }
 
@@ -565,8 +526,7 @@ OPEN1722_INLINE bool Avtp_Abb_IsValid(const Avtp_Abb_t *const pdu, size_t buffer
         return false;
     }
 
-    // Avtp_Abb_GetAcfMsgLength returns quadlets. Convert the length field to octets.
-    uint16_t msg_length_bytes = (uint16_t)Avtp_Abb_GetAcfMsgLength(pdu) * 4;
+    uint16_t msg_length_bytes = Avtp_AcfCommon_GetAcfMsgLengthInBytes((const Avtp_AcfCommon_t *)pdu);
     if (msg_length_bytes > bufferSize) {
         return false;
     }

--- a/include/avtp/acf/AcfCommon.h
+++ b/include/avtp/acf/AcfCommon.h
@@ -42,12 +42,13 @@
 extern "C" {
 #endif
 
-#define AVTP_ACF_COMMON_HEADER_LEN         (1 * AVTP_QUADLET_SIZE)
+#define AVTP_ACF_COMMON_HEADER_LEN (1 * AVTP_QUADLET_SIZE)
 
-#define GET_ACF_COMMON_FIELD(field) \
-        (Avtp_GetField(Avtp_AcfCommonFieldDesc, AVTP_ACF_COMMON_FIELD_MAX, (uint8_t*)pdu, field))
-#define SET_ACF_COMMON_FIELD(field, value) \
-        (Avtp_SetField(Avtp_AcfCommonFieldDesc, AVTP_ACF_COMMON_FIELD_MAX, (uint8_t*)pdu, field, value))
+#define GET_ACF_COMMON_FIELD(field)                                                                \
+    (Avtp_GetField(Avtp_AcfCommonFieldDesc, AVTP_ACF_COMMON_FIELD_MAX, (uint8_t *)pdu, field))
+#define SET_ACF_COMMON_FIELD(field, value)                                                         \
+    (Avtp_SetField(Avtp_AcfCommonFieldDesc, AVTP_ACF_COMMON_FIELD_MAX, (uint8_t *)pdu, field,      \
+                   value))
 
 typedef struct {
     uint8_t header[AVTP_ACF_COMMON_HEADER_LEN];
@@ -58,32 +59,32 @@ typedef struct {
  * AVTP message types. See IEEE Std 1722-2025 table 22.
  */
 typedef enum {
-    AVTP_ACF_TYPE_FLEXRAY           = 0x0,
-    AVTP_ACF_TYPE_CAN               = 0x1,
-    AVTP_ACF_TYPE_CAN_BRIEF         = 0x2,
-    AVTP_ACF_TYPE_LIN               = 0x3,
-    AVTP_ACF_TYPE_MOST              = 0x4,
-    AVTP_ACF_TYPE_GPC               = 0x5,
-    AVTP_ACF_TYPE_SERIAL            = 0x6,
-    AVTP_ACF_TYPE_PARALLEL          = 0x7,
-    AVTP_ACF_TYPE_SENSOR            = 0x8,
-    AVTP_ACF_TYPE_SENSOR_BRIEF      = 0x9,
-    AVTP_ACF_TYPE_AECP              = 0x0A,
-    AVTP_ACF_TYPE_ANCILLARY         = 0x0B,
-    AVTP_ACF_TYPE_GISF              = 0x0C,
-    AVTP_ACF_TYPE_BYTE_BUS          = 0x0D,
-    AVTP_ACF_TYPE_BYTE_BUS_BRIEF    = 0x0E,
-    AVTP_ACF_TYPE_I2C               = 0x0F,
-    AVTP_ACF_TYPE_I2C_BRIEF         = 0x10,
-    AVTP_ACF_TYPE_CAN_XL            = 0x11,
-    AVTP_ACF_TYPE_CAN_XL_BRIEF      = 0x12,
-    AVTP_ACF_TYPE_CAN_V2            = 0x21,
-    AVTP_ACF_TYPE_CAN_BRIEF_V2      = 0x22,
-    AVTP_ACF_TYPE_LIN_V2            = 0x23,
-    AVTP_ACF_TYPE_CHECKSUM          = 0x76,
-    AVTP_ACF_TYPE_CRC               = 0x77,
-    AVTP_ACF_TYPE_USER_FIRST        = 0x78,
-    AVTP_ACF_TYPE_USER_LAST         = 0x7F,
+    AVTP_ACF_TYPE_FLEXRAY = 0x0,
+    AVTP_ACF_TYPE_CAN = 0x1,
+    AVTP_ACF_TYPE_CAN_BRIEF = 0x2,
+    AVTP_ACF_TYPE_LIN = 0x3,
+    AVTP_ACF_TYPE_MOST = 0x4,
+    AVTP_ACF_TYPE_GPC = 0x5,
+    AVTP_ACF_TYPE_SERIAL = 0x6,
+    AVTP_ACF_TYPE_PARALLEL = 0x7,
+    AVTP_ACF_TYPE_SENSOR = 0x8,
+    AVTP_ACF_TYPE_SENSOR_BRIEF = 0x9,
+    AVTP_ACF_TYPE_AECP = 0x0A,
+    AVTP_ACF_TYPE_ANCILLARY = 0x0B,
+    AVTP_ACF_TYPE_GISF = 0x0C,
+    AVTP_ACF_TYPE_BYTE_BUS = 0x0D,
+    AVTP_ACF_TYPE_BYTE_BUS_BRIEF = 0x0E,
+    AVTP_ACF_TYPE_I2C = 0x0F,
+    AVTP_ACF_TYPE_I2C_BRIEF = 0x10,
+    AVTP_ACF_TYPE_CAN_XL = 0x11,
+    AVTP_ACF_TYPE_CAN_XL_BRIEF = 0x12,
+    AVTP_ACF_TYPE_CAN_V2 = 0x21,
+    AVTP_ACF_TYPE_CAN_BRIEF_V2 = 0x22,
+    AVTP_ACF_TYPE_LIN_V2 = 0x23,
+    AVTP_ACF_TYPE_CHECKSUM = 0x76,
+    AVTP_ACF_TYPE_CRC = 0x77,
+    AVTP_ACF_TYPE_USER_FIRST = 0x78,
+    AVTP_ACF_TYPE_USER_LAST = 0x7F,
 } Avtp_AcfMsgType_t;
 
 /**
@@ -101,20 +102,16 @@ typedef enum {
 /**
  * This table maps all IEEE 1722 ACF common header fields to a descriptor.
  */
-static const Avtp_FieldDescriptor_t Avtp_AcfCommonFieldDesc[AVTP_ACF_COMMON_FIELD_MAX] =
-{
+static const Avtp_FieldDescriptor_t Avtp_AcfCommonFieldDesc[AVTP_ACF_COMMON_FIELD_MAX] = {
     /* ACF common header */
-    [AVTP_ACF_FIELD_ACF_MSG_TYPE]            = { .quadlet = 0, .offset = 0, .bits = 7 },
-    [AVTP_ACF_FIELD_ACF_MSG_LENGTH]          = { .quadlet = 0, .offset = 7, .bits = 9 },
+    [AVTP_ACF_FIELD_ACF_MSG_TYPE] = {.quadlet = 0, .offset = 0, .bits = 7},
+    [AVTP_ACF_FIELD_ACF_MSG_LENGTH] = {.quadlet = 0, .offset = 7, .bits = 9},
 };
 
 /**
  * This enum defines the CAN variants supported by the ACF CAN PDU.
  */
-typedef enum {
-    AVTP_CAN_CLASSIC = 0,
-    AVTP_CAN_FD
-} Avtp_CanVariant_t;
+typedef enum { AVTP_CAN_CLASSIC = 0, AVTP_CAN_FD } Avtp_CanVariant_t;
 
 /**
  * Returns the value of an an ACF common header field as specified in the IEEE 1722 Specification.
@@ -123,40 +120,45 @@ typedef enum {
  * @param field Specifies the position of the data field to be read.
  * @returns Returns the field of the PDU.
  */
-OPEN1722_INLINE uint64_t Avtp_AcfCommon_GetField(const Avtp_AcfCommon_t* const pdu, Avtp_AcfCommonFields_t field) {
+OPEN1722_INLINE uint64_t Avtp_AcfCommon_GetField(const Avtp_AcfCommon_t *const pdu,
+                                                 Avtp_AcfCommonFields_t field)
+{
     return GET_ACF_COMMON_FIELD(field);
 }
 
-/** 
+/**
  * Returns the ACF message type field value.
- * 
+ *
  * @param pdu Pointer to the first bit of an 1722 ACF PDU.
  * @returns Returns the ACF message type field of the PDU.
  */
-OPEN1722_INLINE Avtp_AcfMsgType_t Avtp_AcfCommon_GetAcfMsgType(const Avtp_AcfCommon_t* const pdu) {
+OPEN1722_INLINE Avtp_AcfMsgType_t Avtp_AcfCommon_GetAcfMsgType(const Avtp_AcfCommon_t *const pdu)
+{
     return (Avtp_AcfMsgType_t)GET_ACF_COMMON_FIELD(AVTP_ACF_FIELD_ACF_MSG_TYPE);
 }
 
-/** 
+/**
  * Returns the ACF message length field value.
- * 
+ *
  * @param pdu Pointer to the first bit of an 1722 ACF PDU.
  * @returns Returns the ACF message length field of the PDU.
  */
-OPEN1722_INLINE uint16_t Avtp_AcfCommon_GetAcfMsgLength(const Avtp_AcfCommon_t* const pdu) {
-    return (uint16_t) GET_ACF_COMMON_FIELD(AVTP_ACF_FIELD_ACF_MSG_LENGTH);
+OPEN1722_INLINE uint16_t Avtp_AcfCommon_GetAcfMsgLength(const Avtp_AcfCommon_t *const pdu)
+{
+    return (uint16_t)GET_ACF_COMMON_FIELD(AVTP_ACF_FIELD_ACF_MSG_LENGTH);
 }
 
-/** 
+/**
  * Returns the ACF message length field value in bytes.
- * 
+ *
  * The ACF message length field is quadlet-encoded; this converts it to octets.
- * 
+ *
  * @param pdu Pointer to the first bit of an 1722 ACF PDU.
  * @returns Returns the ACF message length field of the PDU in bytes.
  */
-OPEN1722_INLINE uint16_t Avtp_AcfCommon_GetAcfMsgLengthInBytes(const Avtp_AcfCommon_t* const pdu) {
-    return (uint16_t) (Avtp_AcfCommon_GetAcfMsgLength(pdu) * AVTP_QUADLET_SIZE);
+OPEN1722_INLINE uint16_t Avtp_AcfCommon_GetAcfMsgLengthInBytes(const Avtp_AcfCommon_t *const pdu)
+{
+    return (uint16_t)(Avtp_AcfCommon_GetAcfMsgLength(pdu) * AVTP_QUADLET_SIZE);
 }
 
 /**
@@ -166,27 +168,31 @@ OPEN1722_INLINE uint16_t Avtp_AcfCommon_GetAcfMsgLengthInBytes(const Avtp_AcfCom
  * @param field Specifies the position of the data field to be read
  * @param value Pointer to location to store the value.
  */
-OPEN1722_INLINE void Avtp_AcfCommon_SetField(Avtp_AcfCommon_t* pdu, Avtp_AcfCommonFields_t field, uint64_t value) {
+OPEN1722_INLINE void Avtp_AcfCommon_SetField(Avtp_AcfCommon_t *pdu, Avtp_AcfCommonFields_t field,
+                                             uint64_t value)
+{
     SET_ACF_COMMON_FIELD(field, value);
 }
 
 /**
  * Sets the ACF message type field value as specified in the IEEE 1722 Specification.
- * 
+ *
  * @param pdu Pointer to the first bit of an 1722 ACF PDU.
  * @param value Value to set the ACF message type field to.
  */
-OPEN1722_INLINE void Avtp_AcfCommon_SetAcfMsgType(Avtp_AcfCommon_t* pdu, Avtp_AcfMsgType_t value) {
+OPEN1722_INLINE void Avtp_AcfCommon_SetAcfMsgType(Avtp_AcfCommon_t *pdu, Avtp_AcfMsgType_t value)
+{
     SET_ACF_COMMON_FIELD(AVTP_ACF_FIELD_ACF_MSG_TYPE, value);
 }
 
 /**
  * Sets the ACF message length field value as specified in the IEEE 1722 Specification.
- * 
+ *
  * @param pdu Pointer to the first bit of an 1722 ACF PDU.
  * @param value Value to set the ACF message length field to.
  */
-OPEN1722_INLINE void Avtp_AcfCommon_SetAcfMsgLength(Avtp_AcfCommon_t* pdu, uint16_t value) {
+OPEN1722_INLINE void Avtp_AcfCommon_SetAcfMsgLength(Avtp_AcfCommon_t *pdu, uint16_t value)
+{
     SET_ACF_COMMON_FIELD(AVTP_ACF_FIELD_ACF_MSG_LENGTH, value);
 }
 

--- a/include/avtp/acf/AcfCommon.h
+++ b/include/avtp/acf/AcfCommon.h
@@ -147,6 +147,18 @@ OPEN1722_INLINE uint16_t Avtp_AcfCommon_GetAcfMsgLength(const Avtp_AcfCommon_t* 
     return (uint16_t) GET_ACF_COMMON_FIELD(AVTP_ACF_FIELD_ACF_MSG_LENGTH);
 }
 
+/** 
+ * Returns the ACF message length field value in bytes.
+ * 
+ * The ACF message length field is quadlet-encoded; this converts it to octets.
+ * 
+ * @param pdu Pointer to the first bit of an 1722 ACF PDU.
+ * @returns Returns the ACF message length field of the PDU in bytes.
+ */
+OPEN1722_INLINE uint16_t Avtp_AcfCommon_GetAcfMsgLengthInBytes(const Avtp_AcfCommon_t* const pdu) {
+    return (uint16_t) (Avtp_AcfCommon_GetAcfMsgLength(pdu) * AVTP_QUADLET_SIZE);
+}
+
 /**
  * Sets the value of an an ACF common header field as specified in the IEEE 1722 Specification.
  *

--- a/include/avtp/acf/Can.h
+++ b/include/avtp/acf/Can.h
@@ -106,17 +106,6 @@ static const Avtp_FieldDescriptor_t Avtp_CanFieldDesc[AVTP_CAN_FIELD_MAX] = {
 };
 
 /**
- * Return the value of an an ACF message type field as specified in the IEEE 1722 Specification.
- *
- * @param pdu Pointer to the first bit of an 1722 ACF CAN PDU.
- * @returns Value of the ACF message type field.
- */
-OPEN1722_INLINE uint8_t Avtp_Can_GetAcfMsgType(const Avtp_Can_t *const pdu)
-{
-    return (uint8_t)GET_CAN_FIELD(AVTP_CAN_FIELD_ACF_MSG_TYPE);
-}
-
-/**
  * Return the value of an an ACF message length field as specified in the IEEE 1722 Specification.
  * This returns the length in Quadlets as specified in the IEEE 1722 Specification.
  *
@@ -127,7 +116,7 @@ OPEN1722_INLINE uint8_t Avtp_Can_GetAcfMsgType(const Avtp_Can_t *const pdu)
  */
 OPEN1722_INLINE uint16_t Avtp_Can_GetAcfMsgLength(const Avtp_Can_t *const pdu)
 {
-    return (uint16_t)GET_CAN_FIELD(AVTP_CAN_FIELD_ACF_MSG_LENGTH);
+    return Avtp_AcfCommon_GetAcfMsgLength((const Avtp_AcfCommon_t *)pdu);
 }
 
 /**
@@ -138,7 +127,7 @@ OPEN1722_INLINE uint16_t Avtp_Can_GetAcfMsgLength(const Avtp_Can_t *const pdu)
  */
 OPEN1722_INLINE uint16_t Avtp_Can_GetAcfMsgLengthInBytes(const Avtp_Can_t *const pdu)
 {
-    return (uint16_t)GET_CAN_FIELD(AVTP_CAN_FIELD_ACF_MSG_LENGTH) * 4;
+    return (uint16_t)Avtp_AcfCommon_GetAcfMsgLength((const Avtp_AcfCommon_t *)pdu) * 4;
 }
 
 /**
@@ -255,17 +244,6 @@ OPEN1722_INLINE uint32_t Avtp_Can_GetCanIdentifier(const Avtp_Can_t *const pdu)
 }
 
 /**
- * Set the value of an an ACF message type field as specified in the IEEE 1722 Specification.
- *
- * @param pdu Pointer to the first bit of an 1722 ACF CAN PDU.
- * @param value Value to set the ACF message type field to.
- */
-OPEN1722_INLINE void Avtp_Can_SetAcfMsgType(Avtp_Can_t *pdu, uint8_t value)
-{
-    SET_CAN_FIELD(AVTP_CAN_FIELD_ACF_MSG_TYPE, value);
-}
-
-/**
  * Set the value of an an ACF message length field as specified in the IEEE 1722 Specification.
  * Note: the size is in Quadlets as specified in the IEEE 1722 Specification.
  * You can use Avtp_Can_SetPayloadLength to set length in bytes and automatically set the
@@ -276,7 +254,7 @@ OPEN1722_INLINE void Avtp_Can_SetAcfMsgType(Avtp_Can_t *pdu, uint8_t value)
  */
 OPEN1722_INLINE void Avtp_Can_SetAcfMsgLength(Avtp_Can_t *pdu, uint16_t value)
 {
-    SET_CAN_FIELD(AVTP_CAN_FIELD_ACF_MSG_LENGTH, value);
+    Avtp_AcfCommon_SetAcfMsgLength((Avtp_AcfCommon_t *)pdu, value);
 }
 
 /**
@@ -465,7 +443,7 @@ OPEN1722_INLINE void Avtp_Can_Init(Avtp_Can_t *pdu)
 {
     if (pdu != NULL) {
         memset(pdu, 0, sizeof(Avtp_Can_t));
-        Avtp_Can_SetAcfMsgType(pdu, AVTP_ACF_TYPE_CAN);
+        Avtp_AcfCommon_SetAcfMsgType((Avtp_AcfCommon_t *)pdu, AVTP_ACF_TYPE_CAN);
     }
 }
 
@@ -521,7 +499,7 @@ OPEN1722_INLINE bool Avtp_Can_IsValid(const Avtp_Can_t *const pdu, size_t buffer
         return false;
     }
 
-    if (Avtp_Can_GetAcfMsgType(pdu) != AVTP_ACF_TYPE_CAN) {
+    if (Avtp_AcfCommon_GetAcfMsgType((const Avtp_AcfCommon_t *)pdu) != AVTP_ACF_TYPE_CAN) {
         return false;
     }
 

--- a/include/avtp/acf/Can.h
+++ b/include/avtp/acf/Can.h
@@ -106,31 +106,6 @@ static const Avtp_FieldDescriptor_t Avtp_CanFieldDesc[AVTP_CAN_FIELD_MAX] = {
 };
 
 /**
- * Return the value of an an ACF message length field as specified in the IEEE 1722 Specification.
- * This returns the length in Quadlets as specified in the IEEE 1722 Specification.
- *
- * You can use Avtp_Can_GetCanPayloadLength to get the length in bytes without padding.
- *
- * @param pdu Pointer to the first bit of an 1722 ACF CAN PDU.
- * @returns Value of the ACF message length field.
- */
-OPEN1722_INLINE uint16_t Avtp_Can_GetAcfMsgLength(const Avtp_Can_t *const pdu)
-{
-    return Avtp_AcfCommon_GetAcfMsgLength((const Avtp_AcfCommon_t *)pdu);
-}
-
-/**
- * Return the ACF message length
- *
- * @param pdu Pointer to the first bit of an 1722 ACF CAN PDU.
- * @returns Length of the ACF message in bytes.
- */
-OPEN1722_INLINE uint16_t Avtp_Can_GetAcfMsgLengthInBytes(const Avtp_Can_t *const pdu)
-{
-    return (uint16_t)Avtp_AcfCommon_GetAcfMsgLength((const Avtp_AcfCommon_t *)pdu) * 4;
-}
-
-/**
  * Return the value of an an ACF padding field as specified in the IEEE 1722 Specification.
  *
  * @param pdu Pointer to the first bit of an 1722 ACF CAN PDU.
@@ -241,20 +216,6 @@ OPEN1722_INLINE uint64_t Avtp_Can_GetMessageTimestamp(const Avtp_Can_t *const pd
 OPEN1722_INLINE uint32_t Avtp_Can_GetCanIdentifier(const Avtp_Can_t *const pdu)
 {
     return (uint32_t)GET_CAN_FIELD(AVTP_CAN_FIELD_CAN_IDENTIFIER);
-}
-
-/**
- * Set the value of an an ACF message length field as specified in the IEEE 1722 Specification.
- * Note: the size is in Quadlets as specified in the IEEE 1722 Specification.
- * You can use Avtp_Can_SetPayloadLength to set length in bytes and automatically set the
- * correct padding.
- *
- * @param pdu Pointer to the first bit of an 1722 ACF CAN PDU.
- * @param value Value to set the ACF message length field to.
- */
-OPEN1722_INLINE void Avtp_Can_SetAcfMsgLength(Avtp_Can_t *pdu, uint16_t value)
-{
-    Avtp_AcfCommon_SetAcfMsgLength((Avtp_AcfCommon_t *)pdu, value);
 }
 
 /**
@@ -411,7 +372,7 @@ OPEN1722_INLINE void Avtp_Can_SetPayloadLength(Avtp_Can_t *can_pdu, uint16_t pay
     }
     uint16_t msgLenQuadlets = (uint16_t)((msgLenBytes + pad) / 4);
     Avtp_Can_SetPad(can_pdu, pad);
-    Avtp_Can_SetAcfMsgLength(can_pdu, msgLenQuadlets);
+    Avtp_AcfCommon_SetAcfMsgLength((Avtp_AcfCommon_t *)can_pdu, msgLenQuadlets);
 }
 
 /**
@@ -430,7 +391,7 @@ OPEN1722_INLINE void Avtp_Can_SetPayloadLength(Avtp_Can_t *can_pdu, uint16_t pay
 OPEN1722_INLINE uint8_t Avtp_Can_GetPayloadLength(const Avtp_Can_t *const pdu)
 {
     uint8_t pad_length = Avtp_Can_GetPad(pdu);
-    uint16_t acf_length_bytes = Avtp_Can_GetAcfMsgLengthInBytes(pdu);
+    uint16_t acf_length_bytes = Avtp_AcfCommon_GetAcfMsgLengthInBytes((const Avtp_AcfCommon_t *)pdu);
     return (uint8_t)(acf_length_bytes - AVTP_CAN_HEADER_LEN - pad_length);
 }
 
@@ -503,8 +464,7 @@ OPEN1722_INLINE bool Avtp_Can_IsValid(const Avtp_Can_t *const pdu, size_t buffer
         return false;
     }
 
-    // Avtp_Can_GetAcfMsgLength returns quadlets. Convert the length field to octets.
-    uint16_t msg_length_bytes = (uint16_t)Avtp_Can_GetAcfMsgLength(pdu) * 4;
+    uint16_t msg_length_bytes = Avtp_AcfCommon_GetAcfMsgLengthInBytes((const Avtp_AcfCommon_t *)pdu);
     if (msg_length_bytes > bufferSize) {
         return false;
     }

--- a/include/avtp/acf/Can.h
+++ b/include/avtp/acf/Can.h
@@ -391,7 +391,8 @@ OPEN1722_INLINE void Avtp_Can_SetPayloadLength(Avtp_Can_t *can_pdu, uint16_t pay
 OPEN1722_INLINE uint8_t Avtp_Can_GetPayloadLength(const Avtp_Can_t *const pdu)
 {
     uint8_t pad_length = Avtp_Can_GetPad(pdu);
-    uint16_t acf_length_bytes = Avtp_AcfCommon_GetAcfMsgLengthInBytes((const Avtp_AcfCommon_t *)pdu);
+    uint16_t acf_length_bytes =
+        Avtp_AcfCommon_GetAcfMsgLengthInBytes((const Avtp_AcfCommon_t *)pdu);
     return (uint8_t)(acf_length_bytes - AVTP_CAN_HEADER_LEN - pad_length);
 }
 
@@ -464,7 +465,8 @@ OPEN1722_INLINE bool Avtp_Can_IsValid(const Avtp_Can_t *const pdu, size_t buffer
         return false;
     }
 
-    uint16_t msg_length_bytes = Avtp_AcfCommon_GetAcfMsgLengthInBytes((const Avtp_AcfCommon_t *)pdu);
+    uint16_t msg_length_bytes =
+        Avtp_AcfCommon_GetAcfMsgLengthInBytes((const Avtp_AcfCommon_t *)pdu);
     if (msg_length_bytes > bufferSize) {
         return false;
     }

--- a/include/avtp/acf/CanBrief.h
+++ b/include/avtp/acf/CanBrief.h
@@ -104,31 +104,6 @@ static const Avtp_FieldDescriptor_t Avtp_CanBriefFieldDesc[AVTP_CAN_BRIEF_FIELD_
 };
 
 /**
- * Return the value of an an ACF message length field as specified in the IEEE 1722 Specification.
- * This returns the length in Quadlets as specified in the IEEE 1722 Specification.
- *
- * You can use Avtp_CanBrief_GetPayloadLength to get the length in bytes without padding.
- *
- * @param pdu Pointer to the first bit of an 1722 ACF CAN Brief PDU.
- * @returns Value of the ACF message length field.
- */
-OPEN1722_INLINE uint16_t Avtp_CanBrief_GetAcfMsgLength(const Avtp_CanBrief_t *const pdu)
-{
-    return Avtp_AcfCommon_GetAcfMsgLength((const Avtp_AcfCommon_t *)pdu);
-}
-
-/**
- * Return the ACF message length in bytes.
- *
- * @param pdu Pointer to the first bit of an 1722 ACF CAN Brief PDU.
- * @returns Length of the ACF message in bytes.
- */
-OPEN1722_INLINE uint16_t Avtp_CanBrief_GetAcfMsgLengthInBytes(const Avtp_CanBrief_t *const pdu)
-{
-    return (uint16_t)Avtp_AcfCommon_GetAcfMsgLength((const Avtp_AcfCommon_t *)pdu) * 4;
-}
-
-/**
  * Return the value of an an ACF padding field as specified in the IEEE 1722 Specification.
  *
  * @param pdu Pointer to the first bit of an 1722 ACF CAN Brief PDU.
@@ -233,20 +208,6 @@ OPEN1722_INLINE uint8_t Avtp_CanBrief_GetCanBusId(const Avtp_CanBrief_t *const p
 OPEN1722_INLINE uint32_t Avtp_CanBrief_GetCanIdentifier(const Avtp_CanBrief_t *const pdu)
 {
     return (uint32_t)GET_CAN_BRIEF_FIELD(AVTP_CAN_BRIEF_FIELD_CAN_IDENTIFIER);
-}
-
-/**
- * Set the value of an an ACF message length field as specified in the IEEE 1722 Specification.
- * Note: the size is in Quadlets as specified in the IEEE 1722 Specification.
- * You can use Avtp_CanBrief_SetPayloadLength to set length in bytes and automatically set the
- * correct padding.
- *
- * @param pdu Pointer to the first bit of an 1722 ACF CAN Brief PDU.
- * @param value Value to set the ACF message length field to.
- */
-OPEN1722_INLINE void Avtp_CanBrief_SetAcfMsgLength(Avtp_CanBrief_t *pdu, uint16_t value)
-{
-    Avtp_AcfCommon_SetAcfMsgLength((Avtp_AcfCommon_t *)pdu, value);
 }
 
 /**
@@ -393,7 +354,7 @@ OPEN1722_INLINE void Avtp_CanBrief_SetPayloadLength(Avtp_CanBrief_t *can_pdu,
     }
     uint16_t msgLenQuadlets = (uint16_t)((msgLenBytes + pad) / 4);
     Avtp_CanBrief_SetPad(can_pdu, pad);
-    Avtp_CanBrief_SetAcfMsgLength(can_pdu, msgLenQuadlets);
+    Avtp_AcfCommon_SetAcfMsgLength((Avtp_AcfCommon_t *)can_pdu, msgLenQuadlets);
 }
 
 /**
@@ -412,7 +373,7 @@ OPEN1722_INLINE void Avtp_CanBrief_SetPayloadLength(Avtp_CanBrief_t *can_pdu,
 OPEN1722_INLINE uint8_t Avtp_CanBrief_GetPayloadLength(const Avtp_CanBrief_t *const pdu)
 {
     uint8_t pad_length = Avtp_CanBrief_GetPad(pdu);
-    uint16_t acf_length_bytes = Avtp_CanBrief_GetAcfMsgLengthInBytes(pdu);
+    uint16_t acf_length_bytes = Avtp_AcfCommon_GetAcfMsgLengthInBytes((const Avtp_AcfCommon_t *)pdu);
     return (uint8_t)(acf_length_bytes - AVTP_CAN_BRIEF_HEADER_LEN - pad_length);
 }
 
@@ -485,8 +446,7 @@ OPEN1722_INLINE bool Avtp_CanBrief_IsValid(const Avtp_CanBrief_t *const pdu, siz
         return false;
     }
 
-    // Avtp_CanBrief_GetAcfMsgLength returns quadlets. Convert the length field to octets.
-    uint16_t msg_length_bytes = (uint16_t)Avtp_CanBrief_GetAcfMsgLength(pdu) * 4;
+    uint16_t msg_length_bytes = Avtp_AcfCommon_GetAcfMsgLengthInBytes((const Avtp_AcfCommon_t *)pdu);
     if (msg_length_bytes > bufferSize) {
         return false;
     }

--- a/include/avtp/acf/CanBrief.h
+++ b/include/avtp/acf/CanBrief.h
@@ -373,7 +373,8 @@ OPEN1722_INLINE void Avtp_CanBrief_SetPayloadLength(Avtp_CanBrief_t *can_pdu,
 OPEN1722_INLINE uint8_t Avtp_CanBrief_GetPayloadLength(const Avtp_CanBrief_t *const pdu)
 {
     uint8_t pad_length = Avtp_CanBrief_GetPad(pdu);
-    uint16_t acf_length_bytes = Avtp_AcfCommon_GetAcfMsgLengthInBytes((const Avtp_AcfCommon_t *)pdu);
+    uint16_t acf_length_bytes =
+        Avtp_AcfCommon_GetAcfMsgLengthInBytes((const Avtp_AcfCommon_t *)pdu);
     return (uint8_t)(acf_length_bytes - AVTP_CAN_BRIEF_HEADER_LEN - pad_length);
 }
 
@@ -446,7 +447,8 @@ OPEN1722_INLINE bool Avtp_CanBrief_IsValid(const Avtp_CanBrief_t *const pdu, siz
         return false;
     }
 
-    uint16_t msg_length_bytes = Avtp_AcfCommon_GetAcfMsgLengthInBytes((const Avtp_AcfCommon_t *)pdu);
+    uint16_t msg_length_bytes =
+        Avtp_AcfCommon_GetAcfMsgLengthInBytes((const Avtp_AcfCommon_t *)pdu);
     if (msg_length_bytes > bufferSize) {
         return false;
     }

--- a/include/avtp/acf/CanBrief.h
+++ b/include/avtp/acf/CanBrief.h
@@ -104,17 +104,6 @@ static const Avtp_FieldDescriptor_t Avtp_CanBriefFieldDesc[AVTP_CAN_BRIEF_FIELD_
 };
 
 /**
- * Return the value of an an ACF message type field as specified in the IEEE 1722 Specification.
- *
- * @param pdu Pointer to the first bit of an 1722 ACF CAN Brief PDU.
- * @returns Value of the ACF message type field.
- */
-OPEN1722_INLINE uint8_t Avtp_CanBrief_GetAcfMsgType(const Avtp_CanBrief_t *const pdu)
-{
-    return (uint8_t)GET_CAN_BRIEF_FIELD(AVTP_CAN_BRIEF_FIELD_ACF_MSG_TYPE);
-}
-
-/**
  * Return the value of an an ACF message length field as specified in the IEEE 1722 Specification.
  * This returns the length in Quadlets as specified in the IEEE 1722 Specification.
  *
@@ -125,7 +114,7 @@ OPEN1722_INLINE uint8_t Avtp_CanBrief_GetAcfMsgType(const Avtp_CanBrief_t *const
  */
 OPEN1722_INLINE uint16_t Avtp_CanBrief_GetAcfMsgLength(const Avtp_CanBrief_t *const pdu)
 {
-    return (uint16_t)GET_CAN_BRIEF_FIELD(AVTP_CAN_BRIEF_FIELD_ACF_MSG_LENGTH);
+    return Avtp_AcfCommon_GetAcfMsgLength((const Avtp_AcfCommon_t *)pdu);
 }
 
 /**
@@ -136,7 +125,7 @@ OPEN1722_INLINE uint16_t Avtp_CanBrief_GetAcfMsgLength(const Avtp_CanBrief_t *co
  */
 OPEN1722_INLINE uint16_t Avtp_CanBrief_GetAcfMsgLengthInBytes(const Avtp_CanBrief_t *const pdu)
 {
-    return (uint16_t)GET_CAN_BRIEF_FIELD(AVTP_CAN_BRIEF_FIELD_ACF_MSG_LENGTH) * 4;
+    return (uint16_t)Avtp_AcfCommon_GetAcfMsgLength((const Avtp_AcfCommon_t *)pdu) * 4;
 }
 
 /**
@@ -247,17 +236,6 @@ OPEN1722_INLINE uint32_t Avtp_CanBrief_GetCanIdentifier(const Avtp_CanBrief_t *c
 }
 
 /**
- * Set the value of an an ACF message type field as specified in the IEEE 1722 Specification.
- *
- * @param pdu Pointer to the first bit of an 1722 ACF CAN Brief PDU.
- * @param value Value to set the ACF message type field to.
- */
-OPEN1722_INLINE void Avtp_CanBrief_SetAcfMsgType(Avtp_CanBrief_t *pdu, uint8_t value)
-{
-    SET_CAN_BRIEF_FIELD(AVTP_CAN_BRIEF_FIELD_ACF_MSG_TYPE, value);
-}
-
-/**
  * Set the value of an an ACF message length field as specified in the IEEE 1722 Specification.
  * Note: the size is in Quadlets as specified in the IEEE 1722 Specification.
  * You can use Avtp_CanBrief_SetPayloadLength to set length in bytes and automatically set the
@@ -268,7 +246,7 @@ OPEN1722_INLINE void Avtp_CanBrief_SetAcfMsgType(Avtp_CanBrief_t *pdu, uint8_t v
  */
 OPEN1722_INLINE void Avtp_CanBrief_SetAcfMsgLength(Avtp_CanBrief_t *pdu, uint16_t value)
 {
-    SET_CAN_BRIEF_FIELD(AVTP_CAN_BRIEF_FIELD_ACF_MSG_LENGTH, value);
+    Avtp_AcfCommon_SetAcfMsgLength((Avtp_AcfCommon_t *)pdu, value);
 }
 
 /**
@@ -447,7 +425,7 @@ OPEN1722_INLINE void Avtp_CanBrief_Init(Avtp_CanBrief_t *pdu)
 {
     if (pdu != NULL) {
         memset(pdu, 0, sizeof(Avtp_CanBrief_t));
-        Avtp_CanBrief_SetAcfMsgType(pdu, AVTP_ACF_TYPE_CAN_BRIEF);
+        Avtp_AcfCommon_SetAcfMsgType((Avtp_AcfCommon_t *)pdu, AVTP_ACF_TYPE_CAN_BRIEF);
     }
 }
 
@@ -503,7 +481,7 @@ OPEN1722_INLINE bool Avtp_CanBrief_IsValid(const Avtp_CanBrief_t *const pdu, siz
         return false;
     }
 
-    if (Avtp_CanBrief_GetAcfMsgType(pdu) != AVTP_ACF_TYPE_CAN_BRIEF) {
+    if (Avtp_AcfCommon_GetAcfMsgType((const Avtp_AcfCommon_t *)pdu) != AVTP_ACF_TYPE_CAN_BRIEF) {
         return false;
     }
 

--- a/include/avtp/acf/CanBriefV2.h
+++ b/include/avtp/acf/CanBriefV2.h
@@ -108,45 +108,6 @@ static const Avtp_FieldDescriptor_t Avtp_CanBriefV2FieldDesc[AVTP_CAN_BRIEF_V2_F
 };
 
 /**
- * Return the value of the ACF message length field as specified in the IEEE 1722 Specification.
- * This returns the length in Quadlets as specified in the IEEE 1722 Specification.
- *
- * You can use Avtp_CanBriefV2_GetPayloadLength to get the length in bytes without padding.
- *
- * @param pdu Pointer to the first bit of a 1722 ACF CAN Brief V2 PDU.
- * @returns Value of the ACF message length field.
- */
-OPEN1722_INLINE uint16_t Avtp_CanBriefV2_GetAcfMsgLength(const Avtp_CanBriefV2_t *const pdu)
-{
-    return Avtp_AcfCommon_GetAcfMsgLength((const Avtp_AcfCommon_t *)pdu);
-}
-
-/**
- * Return the ACF message length in bytes.
- *
- * @param pdu Pointer to the first bit of a 1722 ACF CAN Brief V2 PDU.
- * @returns Length of the ACF message in bytes.
- */
-OPEN1722_INLINE uint16_t Avtp_CanBriefV2_GetAcfMsgLengthInBytes(const Avtp_CanBriefV2_t *const pdu)
-{
-    return (uint16_t)Avtp_AcfCommon_GetAcfMsgLength((const Avtp_AcfCommon_t *)pdu) * 4;
-}
-
-/**
- * Set the value of the ACF message length field as specified in the IEEE 1722 Specification.
- * Note: the size is in Quadlets as specified in the IEEE 1722 Specification.
- * You can use Avtp_CanBriefV2_SetPayloadLength to set length in bytes and automatically set the
- * correct padding.
- *
- * @param pdu Pointer to the first bit of a 1722 ACF CAN Brief V2 PDU.
- * @param value Value to set the ACF message length field to.
- */
-OPEN1722_INLINE void Avtp_CanBriefV2_SetAcfMsgLength(Avtp_CanBriefV2_t *pdu, uint16_t value)
-{
-    Avtp_AcfCommon_SetAcfMsgLength((Avtp_AcfCommon_t *)pdu, value);
-}
-
-/**
  * Returns the pad field from an ACF_CAN_BRIEF_V2 message header.
  *
  * @param pdu Pointer to an ACF_CAN_BRIEF_V2 message.
@@ -388,7 +349,7 @@ OPEN1722_INLINE void Avtp_CanBriefV2_SetPayloadLength(Avtp_CanBriefV2_t *pdu,
     }
     uint16_t msgLenQuadlets = (uint16_t)((msgLenBytes + pad) / 4);
     Avtp_CanBriefV2_SetPad(pdu, pad);
-    Avtp_CanBriefV2_SetAcfMsgLength(pdu, msgLenQuadlets);
+    Avtp_AcfCommon_SetAcfMsgLength((Avtp_AcfCommon_t *)pdu, msgLenQuadlets);
 }
 
 /**
@@ -407,7 +368,7 @@ OPEN1722_INLINE void Avtp_CanBriefV2_SetPayloadLength(Avtp_CanBriefV2_t *pdu,
 OPEN1722_INLINE uint8_t Avtp_CanBriefV2_GetPayloadLength(const Avtp_CanBriefV2_t *const pdu)
 {
     uint8_t pad_length = Avtp_CanBriefV2_GetPad(pdu);
-    uint16_t acf_length_bytes = Avtp_CanBriefV2_GetAcfMsgLengthInBytes(pdu);
+    uint16_t acf_length_bytes = Avtp_AcfCommon_GetAcfMsgLengthInBytes((const Avtp_AcfCommon_t *)pdu);
     return (uint8_t)(acf_length_bytes - AVTP_CAN_BRIEF_V2_HEADER_LEN - pad_length);
 }
 
@@ -483,8 +444,7 @@ OPEN1722_INLINE bool Avtp_CanBriefV2_IsValid(const Avtp_CanBriefV2_t *const pdu,
         return false;
     }
 
-    // Avtp_CanBriefV2_GetAcfMsgLength returns quadlets. Convert the length field to octets.
-    uint16_t msg_length_bytes = (uint16_t)Avtp_CanBriefV2_GetAcfMsgLength(pdu) * 4;
+    uint16_t msg_length_bytes = Avtp_AcfCommon_GetAcfMsgLengthInBytes((const Avtp_AcfCommon_t *)pdu);
     if (msg_length_bytes > bufferSize) {
         return false;
     }

--- a/include/avtp/acf/CanBriefV2.h
+++ b/include/avtp/acf/CanBriefV2.h
@@ -368,7 +368,8 @@ OPEN1722_INLINE void Avtp_CanBriefV2_SetPayloadLength(Avtp_CanBriefV2_t *pdu,
 OPEN1722_INLINE uint8_t Avtp_CanBriefV2_GetPayloadLength(const Avtp_CanBriefV2_t *const pdu)
 {
     uint8_t pad_length = Avtp_CanBriefV2_GetPad(pdu);
-    uint16_t acf_length_bytes = Avtp_AcfCommon_GetAcfMsgLengthInBytes((const Avtp_AcfCommon_t *)pdu);
+    uint16_t acf_length_bytes =
+        Avtp_AcfCommon_GetAcfMsgLengthInBytes((const Avtp_AcfCommon_t *)pdu);
     return (uint8_t)(acf_length_bytes - AVTP_CAN_BRIEF_V2_HEADER_LEN - pad_length);
 }
 
@@ -444,7 +445,8 @@ OPEN1722_INLINE bool Avtp_CanBriefV2_IsValid(const Avtp_CanBriefV2_t *const pdu,
         return false;
     }
 
-    uint16_t msg_length_bytes = Avtp_AcfCommon_GetAcfMsgLengthInBytes((const Avtp_AcfCommon_t *)pdu);
+    uint16_t msg_length_bytes =
+        Avtp_AcfCommon_GetAcfMsgLengthInBytes((const Avtp_AcfCommon_t *)pdu);
     if (msg_length_bytes > bufferSize) {
         return false;
     }

--- a/include/avtp/acf/CanBriefV2.h
+++ b/include/avtp/acf/CanBriefV2.h
@@ -108,17 +108,6 @@ static const Avtp_FieldDescriptor_t Avtp_CanBriefV2FieldDesc[AVTP_CAN_BRIEF_V2_F
 };
 
 /**
- * Return the value of the ACF message type field as specified in the IEEE 1722 Specification.
- *
- * @param pdu Pointer to the first bit of a 1722 ACF CAN Brief V2 PDU.
- * @returns Value of the ACF message type field.
- */
-OPEN1722_INLINE uint8_t Avtp_CanBriefV2_GetAcfMsgType(const Avtp_CanBriefV2_t *const pdu)
-{
-    return (uint8_t)GET_CAN_BRIEF_V2_FIELD(AVTP_CAN_BRIEF_V2_FIELD_ACF_MSG_TYPE);
-}
-
-/**
  * Return the value of the ACF message length field as specified in the IEEE 1722 Specification.
  * This returns the length in Quadlets as specified in the IEEE 1722 Specification.
  *
@@ -129,7 +118,7 @@ OPEN1722_INLINE uint8_t Avtp_CanBriefV2_GetAcfMsgType(const Avtp_CanBriefV2_t *c
  */
 OPEN1722_INLINE uint16_t Avtp_CanBriefV2_GetAcfMsgLength(const Avtp_CanBriefV2_t *const pdu)
 {
-    return (uint16_t)GET_CAN_BRIEF_V2_FIELD(AVTP_CAN_BRIEF_V2_FIELD_ACF_MSG_LENGTH);
+    return Avtp_AcfCommon_GetAcfMsgLength((const Avtp_AcfCommon_t *)pdu);
 }
 
 /**
@@ -140,18 +129,7 @@ OPEN1722_INLINE uint16_t Avtp_CanBriefV2_GetAcfMsgLength(const Avtp_CanBriefV2_t
  */
 OPEN1722_INLINE uint16_t Avtp_CanBriefV2_GetAcfMsgLengthInBytes(const Avtp_CanBriefV2_t *const pdu)
 {
-    return (uint16_t)GET_CAN_BRIEF_V2_FIELD(AVTP_CAN_BRIEF_V2_FIELD_ACF_MSG_LENGTH) * 4;
-}
-
-/**
- * Set the value of the ACF message type field as specified in the IEEE 1722 Specification.
- *
- * @param pdu Pointer to the first bit of a 1722 ACF CAN Brief V2 PDU.
- * @param value Value to set the ACF message type field to.
- */
-OPEN1722_INLINE void Avtp_CanBriefV2_SetAcfMsgType(Avtp_CanBriefV2_t *pdu, uint8_t value)
-{
-    SET_CAN_BRIEF_V2_FIELD(AVTP_CAN_BRIEF_V2_FIELD_ACF_MSG_TYPE, value);
+    return (uint16_t)Avtp_AcfCommon_GetAcfMsgLength((const Avtp_AcfCommon_t *)pdu) * 4;
 }
 
 /**
@@ -165,7 +143,7 @@ OPEN1722_INLINE void Avtp_CanBriefV2_SetAcfMsgType(Avtp_CanBriefV2_t *pdu, uint8
  */
 OPEN1722_INLINE void Avtp_CanBriefV2_SetAcfMsgLength(Avtp_CanBriefV2_t *pdu, uint16_t value)
 {
-    SET_CAN_BRIEF_V2_FIELD(AVTP_CAN_BRIEF_V2_FIELD_ACF_MSG_LENGTH, value);
+    Avtp_AcfCommon_SetAcfMsgLength((Avtp_AcfCommon_t *)pdu, value);
 }
 
 /**
@@ -442,7 +420,7 @@ OPEN1722_INLINE void Avtp_CanBriefV2_Init(Avtp_CanBriefV2_t *pdu)
 {
     if (pdu != NULL) {
         memset(pdu, 0, sizeof(Avtp_CanBriefV2_t));
-        Avtp_CanBriefV2_SetAcfMsgType(pdu, AVTP_ACF_TYPE_CAN_BRIEF_V2);
+        Avtp_AcfCommon_SetAcfMsgType((Avtp_AcfCommon_t *)pdu, AVTP_ACF_TYPE_CAN_BRIEF_V2);
     }
 }
 
@@ -501,7 +479,7 @@ OPEN1722_INLINE bool Avtp_CanBriefV2_IsValid(const Avtp_CanBriefV2_t *const pdu,
         return false;
     }
 
-    if (Avtp_CanBriefV2_GetAcfMsgType(pdu) != AVTP_ACF_TYPE_CAN_BRIEF_V2) {
+    if (Avtp_AcfCommon_GetAcfMsgType((const Avtp_AcfCommon_t *)pdu) != AVTP_ACF_TYPE_CAN_BRIEF_V2) {
         return false;
     }
 

--- a/include/avtp/acf/CanV2.h
+++ b/include/avtp/acf/CanV2.h
@@ -110,45 +110,6 @@ static const Avtp_FieldDescriptor_t Avtp_CanV2FieldDesc[AVTP_CAN_V2_FIELD_MAX] =
 };
 
 /**
- * Return the value of the ACF message length field as specified in the IEEE 1722 Specification.
- * This returns the length in Quadlets as specified in the IEEE 1722 Specification.
- *
- * You can use Avtp_CanV2_GetPayloadLength to get the length in bytes without padding.
- *
- * @param pdu Pointer to the first bit of a 1722 ACF CAN V2 PDU.
- * @returns Value of the ACF message length field.
- */
-OPEN1722_INLINE uint16_t Avtp_CanV2_GetAcfMsgLength(const Avtp_CanV2_t *const pdu)
-{
-    return Avtp_AcfCommon_GetAcfMsgLength((const Avtp_AcfCommon_t *)pdu);
-}
-
-/**
- * Return the ACF message length in bytes.
- *
- * @param pdu Pointer to the first bit of a 1722 ACF CAN V2 PDU.
- * @returns Length of the ACF message in bytes.
- */
-OPEN1722_INLINE uint16_t Avtp_CanV2_GetAcfMsgLengthInBytes(const Avtp_CanV2_t *const pdu)
-{
-    return (uint16_t)Avtp_AcfCommon_GetAcfMsgLength((const Avtp_AcfCommon_t *)pdu) * 4;
-}
-
-/**
- * Set the value of the ACF message length field as specified in the IEEE 1722 Specification.
- * Note: the size is in Quadlets as specified in the IEEE 1722 Specification.
- * You can use Avtp_CanV2_SetPayloadLength to set length in bytes and automatically set the
- * correct padding.
- *
- * @param pdu Pointer to the first bit of a 1722 ACF CAN V2 PDU.
- * @param value Value to set the ACF message length field to.
- */
-OPEN1722_INLINE void Avtp_CanV2_SetAcfMsgLength(Avtp_CanV2_t *pdu, uint16_t value)
-{
-    Avtp_AcfCommon_SetAcfMsgLength((Avtp_AcfCommon_t *)pdu, value);
-}
-
-/**
  * Returns the pad field from an ACF_CAN_V2 message header.
  *
  * @param pdu Pointer to an ACF_CAN_V2 message.
@@ -410,7 +371,7 @@ OPEN1722_INLINE void Avtp_CanV2_SetPayloadLength(Avtp_CanV2_t *pdu, uint16_t pay
     }
     uint16_t msgLenQuadlets = (uint16_t)((msgLenBytes + pad) / 4);
     Avtp_CanV2_SetPad(pdu, pad);
-    Avtp_CanV2_SetAcfMsgLength(pdu, msgLenQuadlets);
+    Avtp_AcfCommon_SetAcfMsgLength((Avtp_AcfCommon_t *)pdu, msgLenQuadlets);
 }
 
 /**
@@ -429,7 +390,7 @@ OPEN1722_INLINE void Avtp_CanV2_SetPayloadLength(Avtp_CanV2_t *pdu, uint16_t pay
 OPEN1722_INLINE uint8_t Avtp_CanV2_GetPayloadLength(const Avtp_CanV2_t *const pdu)
 {
     uint8_t pad_length = Avtp_CanV2_GetPad(pdu);
-    uint16_t acf_length_bytes = Avtp_CanV2_GetAcfMsgLengthInBytes(pdu);
+    uint16_t acf_length_bytes = Avtp_AcfCommon_GetAcfMsgLengthInBytes((const Avtp_AcfCommon_t *)pdu);
     return (uint8_t)(acf_length_bytes - AVTP_CAN_V2_HEADER_LEN - pad_length);
 }
 
@@ -502,8 +463,7 @@ OPEN1722_INLINE bool Avtp_CanV2_IsValid(const Avtp_CanV2_t *const pdu, size_t bu
         return false;
     }
 
-    // Avtp_CanV2_GetAcfMsgLength returns quadlets. Convert the length field to octets.
-    uint16_t msg_length_bytes = (uint16_t)Avtp_CanV2_GetAcfMsgLength(pdu) * 4;
+    uint16_t msg_length_bytes = Avtp_AcfCommon_GetAcfMsgLengthInBytes((const Avtp_AcfCommon_t *)pdu);
     if (msg_length_bytes > bufferSize) {
         return false;
     }

--- a/include/avtp/acf/CanV2.h
+++ b/include/avtp/acf/CanV2.h
@@ -110,17 +110,6 @@ static const Avtp_FieldDescriptor_t Avtp_CanV2FieldDesc[AVTP_CAN_V2_FIELD_MAX] =
 };
 
 /**
- * Return the value of the ACF message type field as specified in the IEEE 1722 Specification.
- *
- * @param pdu Pointer to the first bit of a 1722 ACF CAN V2 PDU.
- * @returns Value of the ACF message type field.
- */
-OPEN1722_INLINE uint8_t Avtp_CanV2_GetAcfMsgType(const Avtp_CanV2_t *const pdu)
-{
-    return (uint8_t)GET_CAN_V2_FIELD(AVTP_CAN_V2_FIELD_ACF_MSG_TYPE);
-}
-
-/**
  * Return the value of the ACF message length field as specified in the IEEE 1722 Specification.
  * This returns the length in Quadlets as specified in the IEEE 1722 Specification.
  *
@@ -131,7 +120,7 @@ OPEN1722_INLINE uint8_t Avtp_CanV2_GetAcfMsgType(const Avtp_CanV2_t *const pdu)
  */
 OPEN1722_INLINE uint16_t Avtp_CanV2_GetAcfMsgLength(const Avtp_CanV2_t *const pdu)
 {
-    return (uint16_t)GET_CAN_V2_FIELD(AVTP_CAN_V2_FIELD_ACF_MSG_LENGTH);
+    return Avtp_AcfCommon_GetAcfMsgLength((const Avtp_AcfCommon_t *)pdu);
 }
 
 /**
@@ -142,18 +131,7 @@ OPEN1722_INLINE uint16_t Avtp_CanV2_GetAcfMsgLength(const Avtp_CanV2_t *const pd
  */
 OPEN1722_INLINE uint16_t Avtp_CanV2_GetAcfMsgLengthInBytes(const Avtp_CanV2_t *const pdu)
 {
-    return (uint16_t)GET_CAN_V2_FIELD(AVTP_CAN_V2_FIELD_ACF_MSG_LENGTH) * 4;
-}
-
-/**
- * Set the value of the ACF message type field as specified in the IEEE 1722 Specification.
- *
- * @param pdu Pointer to the first bit of a 1722 ACF CAN V2 PDU.
- * @param value Value to set the ACF message type field to.
- */
-OPEN1722_INLINE void Avtp_CanV2_SetAcfMsgType(Avtp_CanV2_t *pdu, uint8_t value)
-{
-    SET_CAN_V2_FIELD(AVTP_CAN_V2_FIELD_ACF_MSG_TYPE, value);
+    return (uint16_t)Avtp_AcfCommon_GetAcfMsgLength((const Avtp_AcfCommon_t *)pdu) * 4;
 }
 
 /**
@@ -167,7 +145,7 @@ OPEN1722_INLINE void Avtp_CanV2_SetAcfMsgType(Avtp_CanV2_t *pdu, uint8_t value)
  */
 OPEN1722_INLINE void Avtp_CanV2_SetAcfMsgLength(Avtp_CanV2_t *pdu, uint16_t value)
 {
-    SET_CAN_V2_FIELD(AVTP_CAN_V2_FIELD_ACF_MSG_LENGTH, value);
+    Avtp_AcfCommon_SetAcfMsgLength((Avtp_AcfCommon_t *)pdu, value);
 }
 
 /**
@@ -464,7 +442,7 @@ OPEN1722_INLINE void Avtp_CanV2_Init(Avtp_CanV2_t *pdu)
 {
     if (pdu != NULL) {
         memset(pdu, 0, sizeof(Avtp_CanV2_t));
-        Avtp_CanV2_SetAcfMsgType(pdu, AVTP_ACF_TYPE_CAN_V2);
+        Avtp_AcfCommon_SetAcfMsgType((Avtp_AcfCommon_t *)pdu, AVTP_ACF_TYPE_CAN_V2);
     }
 }
 
@@ -520,7 +498,7 @@ OPEN1722_INLINE bool Avtp_CanV2_IsValid(const Avtp_CanV2_t *const pdu, size_t bu
         return false;
     }
 
-    if (Avtp_CanV2_GetAcfMsgType(pdu) != AVTP_ACF_TYPE_CAN_V2) {
+    if (Avtp_AcfCommon_GetAcfMsgType((const Avtp_AcfCommon_t *)pdu) != AVTP_ACF_TYPE_CAN_V2) {
         return false;
     }
 

--- a/include/avtp/acf/CanV2.h
+++ b/include/avtp/acf/CanV2.h
@@ -390,7 +390,8 @@ OPEN1722_INLINE void Avtp_CanV2_SetPayloadLength(Avtp_CanV2_t *pdu, uint16_t pay
 OPEN1722_INLINE uint8_t Avtp_CanV2_GetPayloadLength(const Avtp_CanV2_t *const pdu)
 {
     uint8_t pad_length = Avtp_CanV2_GetPad(pdu);
-    uint16_t acf_length_bytes = Avtp_AcfCommon_GetAcfMsgLengthInBytes((const Avtp_AcfCommon_t *)pdu);
+    uint16_t acf_length_bytes =
+        Avtp_AcfCommon_GetAcfMsgLengthInBytes((const Avtp_AcfCommon_t *)pdu);
     return (uint8_t)(acf_length_bytes - AVTP_CAN_V2_HEADER_LEN - pad_length);
 }
 
@@ -463,7 +464,8 @@ OPEN1722_INLINE bool Avtp_CanV2_IsValid(const Avtp_CanV2_t *const pdu, size_t bu
         return false;
     }
 
-    uint16_t msg_length_bytes = Avtp_AcfCommon_GetAcfMsgLengthInBytes((const Avtp_AcfCommon_t *)pdu);
+    uint16_t msg_length_bytes =
+        Avtp_AcfCommon_GetAcfMsgLengthInBytes((const Avtp_AcfCommon_t *)pdu);
     if (msg_length_bytes > bufferSize) {
         return false;
     }

--- a/include/avtp/acf/CanXl.h
+++ b/include/avtp/acf/CanXl.h
@@ -116,17 +116,6 @@ static const Avtp_FieldDescriptor_t Avtp_CanXlFieldDesc[AVTP_CANXL_FIELD_MAX] = 
 };
 
 /**
- * Return the value of the ACF message type field as specified in the IEEE 1722 Specification.
- *
- * @param pdu Pointer to the first bit of a 1722 ACF CANXL PDU.
- * @returns Value of the ACF message type field.
- */
-OPEN1722_INLINE uint8_t Avtp_CanXl_GetAcfMsgType(const Avtp_CanXl_t *const pdu)
-{
-    return (uint8_t)GET_CANXL_FIELD(AVTP_CANXL_FIELD_ACF_MSG_TYPE);
-}
-
-/**
  * Return the value of the ACF message length field as specified in the IEEE 1722 Specification.
  * This returns the length in Quadlets as specified in the IEEE 1722 Specification.
  *
@@ -137,7 +126,7 @@ OPEN1722_INLINE uint8_t Avtp_CanXl_GetAcfMsgType(const Avtp_CanXl_t *const pdu)
  */
 OPEN1722_INLINE uint16_t Avtp_CanXl_GetAcfMsgLength(const Avtp_CanXl_t *const pdu)
 {
-    return (uint16_t)GET_CANXL_FIELD(AVTP_CANXL_FIELD_ACF_MSG_LENGTH);
+    return Avtp_AcfCommon_GetAcfMsgLength((const Avtp_AcfCommon_t *)pdu);
 }
 
 /**
@@ -148,18 +137,7 @@ OPEN1722_INLINE uint16_t Avtp_CanXl_GetAcfMsgLength(const Avtp_CanXl_t *const pd
  */
 OPEN1722_INLINE uint16_t Avtp_CanXl_GetAcfMsgLengthInBytes(const Avtp_CanXl_t *const pdu)
 {
-    return (uint16_t)GET_CANXL_FIELD(AVTP_CANXL_FIELD_ACF_MSG_LENGTH) * 4;
-}
-
-/**
- * Set the value of the ACF message type field as specified in the IEEE 1722 Specification.
- *
- * @param pdu Pointer to the first bit of a 1722 ACF CANXL PDU.
- * @param value Value to set the ACF message type field to.
- */
-OPEN1722_INLINE void Avtp_CanXl_SetAcfMsgType(Avtp_CanXl_t *pdu, uint8_t value)
-{
-    SET_CANXL_FIELD(AVTP_CANXL_FIELD_ACF_MSG_TYPE, value);
+    return (uint16_t)Avtp_AcfCommon_GetAcfMsgLength((const Avtp_AcfCommon_t *)pdu) * 4;
 }
 
 /**
@@ -173,7 +151,7 @@ OPEN1722_INLINE void Avtp_CanXl_SetAcfMsgType(Avtp_CanXl_t *pdu, uint8_t value)
  */
 OPEN1722_INLINE void Avtp_CanXl_SetAcfMsgLength(Avtp_CanXl_t *pdu, uint16_t value)
 {
-    SET_CANXL_FIELD(AVTP_CANXL_FIELD_ACF_MSG_LENGTH, value);
+    Avtp_AcfCommon_SetAcfMsgLength((Avtp_AcfCommon_t *)pdu, value);
 }
 
 /**
@@ -534,7 +512,7 @@ OPEN1722_INLINE void Avtp_CanXl_Init(Avtp_CanXl_t *pdu)
 {
     if (pdu != NULL) {
         memset(pdu, 0, sizeof(Avtp_CanXl_t));
-        Avtp_CanXl_SetAcfMsgType(pdu, AVTP_ACF_TYPE_CAN_XL);
+        Avtp_AcfCommon_SetAcfMsgType((Avtp_AcfCommon_t *)pdu, AVTP_ACF_TYPE_CAN_XL);
     }
 }
 
@@ -586,7 +564,7 @@ OPEN1722_INLINE bool Avtp_CanXl_IsValid(const Avtp_CanXl_t *const pdu, size_t bu
         return false;
     }
 
-    if (Avtp_CanXl_GetAcfMsgType(pdu) != AVTP_ACF_TYPE_CAN_XL) {
+    if (Avtp_AcfCommon_GetAcfMsgType((const Avtp_AcfCommon_t *)pdu) != AVTP_ACF_TYPE_CAN_XL) {
         return false;
     }
 

--- a/include/avtp/acf/CanXl.h
+++ b/include/avtp/acf/CanXl.h
@@ -116,45 +116,6 @@ static const Avtp_FieldDescriptor_t Avtp_CanXlFieldDesc[AVTP_CANXL_FIELD_MAX] = 
 };
 
 /**
- * Return the value of the ACF message length field as specified in the IEEE 1722 Specification.
- * This returns the length in Quadlets as specified in the IEEE 1722 Specification.
- *
- * You can use Avtp_CanXl_GetPayloadLength to get the length in bytes without padding.
- *
- * @param pdu Pointer to the first bit of a 1722 ACF CANXL PDU.
- * @returns Value of the ACF message length field.
- */
-OPEN1722_INLINE uint16_t Avtp_CanXl_GetAcfMsgLength(const Avtp_CanXl_t *const pdu)
-{
-    return Avtp_AcfCommon_GetAcfMsgLength((const Avtp_AcfCommon_t *)pdu);
-}
-
-/**
- * Return the ACF message length in bytes.
- *
- * @param pdu Pointer to the first bit of a 1722 ACF CANXL PDU.
- * @returns Length of the ACF message in bytes.
- */
-OPEN1722_INLINE uint16_t Avtp_CanXl_GetAcfMsgLengthInBytes(const Avtp_CanXl_t *const pdu)
-{
-    return (uint16_t)Avtp_AcfCommon_GetAcfMsgLength((const Avtp_AcfCommon_t *)pdu) * 4;
-}
-
-/**
- * Set the value of the ACF message length field as specified in the IEEE 1722 Specification.
- * Note: the size is in Quadlets as specified in the IEEE 1722 Specification.
- * You can use Avtp_CanXl_SetPayloadLength to set length in bytes and automatically set the
- * correct padding.
- *
- * @param pdu Pointer to the first bit of a 1722 ACF CANXL PDU.
- * @param value Value to set the ACF message length field to.
- */
-OPEN1722_INLINE void Avtp_CanXl_SetAcfMsgLength(Avtp_CanXl_t *pdu, uint16_t value)
-{
-    Avtp_AcfCommon_SetAcfMsgLength((Avtp_AcfCommon_t *)pdu, value);
-}
-
-/**
  * Returns the pad field from an ACF_CANXL message header.
  *
  * @param pdu Pointer to an ACF_CANXL message.
@@ -482,7 +443,7 @@ OPEN1722_INLINE void Avtp_CanXl_SetPayloadLength(Avtp_CanXl_t *pdu, uint16_t pay
     }
     uint16_t msgLenQuadlets = (uint16_t)((msgLenBytes + pad) / 4);
     Avtp_CanXl_SetPad(pdu, pad);
-    Avtp_CanXl_SetAcfMsgLength(pdu, msgLenQuadlets);
+    Avtp_AcfCommon_SetAcfMsgLength((Avtp_AcfCommon_t *)pdu, msgLenQuadlets);
 }
 
 /**
@@ -499,7 +460,7 @@ OPEN1722_INLINE void Avtp_CanXl_SetPayloadLength(Avtp_CanXl_t *pdu, uint16_t pay
 OPEN1722_INLINE uint8_t Avtp_CanXl_GetPayloadLength(const Avtp_CanXl_t *const pdu)
 {
     uint8_t pad_length = Avtp_CanXl_GetPad(pdu);
-    uint16_t acf_length_bytes = Avtp_CanXl_GetAcfMsgLengthInBytes(pdu);
+    uint16_t acf_length_bytes = Avtp_AcfCommon_GetAcfMsgLengthInBytes((const Avtp_AcfCommon_t *)pdu);
     return (uint8_t)(acf_length_bytes - AVTP_CANXL_HEADER_LEN - pad_length);
 }
 
@@ -568,8 +529,7 @@ OPEN1722_INLINE bool Avtp_CanXl_IsValid(const Avtp_CanXl_t *const pdu, size_t bu
         return false;
     }
 
-    // Avtp_CanXl_GetAcfMsgLength returns quadlets. Convert the length field to octets.
-    uint16_t msg_length_bytes = (uint16_t)Avtp_CanXl_GetAcfMsgLength(pdu) * 4;
+    uint16_t msg_length_bytes = Avtp_AcfCommon_GetAcfMsgLengthInBytes((const Avtp_AcfCommon_t *)pdu);
     if (msg_length_bytes > bufferSize) {
         return false;
     }

--- a/include/avtp/acf/CanXl.h
+++ b/include/avtp/acf/CanXl.h
@@ -460,7 +460,8 @@ OPEN1722_INLINE void Avtp_CanXl_SetPayloadLength(Avtp_CanXl_t *pdu, uint16_t pay
 OPEN1722_INLINE uint8_t Avtp_CanXl_GetPayloadLength(const Avtp_CanXl_t *const pdu)
 {
     uint8_t pad_length = Avtp_CanXl_GetPad(pdu);
-    uint16_t acf_length_bytes = Avtp_AcfCommon_GetAcfMsgLengthInBytes((const Avtp_AcfCommon_t *)pdu);
+    uint16_t acf_length_bytes =
+        Avtp_AcfCommon_GetAcfMsgLengthInBytes((const Avtp_AcfCommon_t *)pdu);
     return (uint8_t)(acf_length_bytes - AVTP_CANXL_HEADER_LEN - pad_length);
 }
 
@@ -529,7 +530,8 @@ OPEN1722_INLINE bool Avtp_CanXl_IsValid(const Avtp_CanXl_t *const pdu, size_t bu
         return false;
     }
 
-    uint16_t msg_length_bytes = Avtp_AcfCommon_GetAcfMsgLengthInBytes((const Avtp_AcfCommon_t *)pdu);
+    uint16_t msg_length_bytes =
+        Avtp_AcfCommon_GetAcfMsgLengthInBytes((const Avtp_AcfCommon_t *)pdu);
     if (msg_length_bytes > bufferSize) {
         return false;
     }

--- a/include/avtp/acf/CanXlBrief.h
+++ b/include/avtp/acf/CanXlBrief.h
@@ -115,17 +115,6 @@ static const Avtp_FieldDescriptor_t Avtp_CanXlBriefFieldDesc[AVTP_CANXL_BRIEF_FI
 };
 
 /**
- * Return the value of the ACF message type field as specified in the IEEE 1722 Specification.
- *
- * @param pdu Pointer to the first bit of a 1722 ACF CAN XL Brief PDU.
- * @returns Value of the ACF message type field.
- */
-OPEN1722_INLINE uint8_t Avtp_CanXlBrief_GetAcfMsgType(const Avtp_CanXlBrief_t *const pdu)
-{
-    return (uint8_t)GET_CANXL_BRIEF_FIELD(AVTP_CANXL_BRIEF_FIELD_ACF_MSG_TYPE);
-}
-
-/**
  * Return the value of the ACF message length field as specified in the IEEE 1722 Specification.
  * This returns the length in Quadlets as specified in the IEEE 1722 Specification.
  *
@@ -136,7 +125,7 @@ OPEN1722_INLINE uint8_t Avtp_CanXlBrief_GetAcfMsgType(const Avtp_CanXlBrief_t *c
  */
 OPEN1722_INLINE uint16_t Avtp_CanXlBrief_GetAcfMsgLength(const Avtp_CanXlBrief_t *const pdu)
 {
-    return (uint16_t)GET_CANXL_BRIEF_FIELD(AVTP_CANXL_BRIEF_FIELD_ACF_MSG_LENGTH);
+    return Avtp_AcfCommon_GetAcfMsgLength((const Avtp_AcfCommon_t *)pdu);
 }
 
 /**
@@ -147,18 +136,7 @@ OPEN1722_INLINE uint16_t Avtp_CanXlBrief_GetAcfMsgLength(const Avtp_CanXlBrief_t
  */
 OPEN1722_INLINE uint16_t Avtp_CanXlBrief_GetAcfMsgLengthInBytes(const Avtp_CanXlBrief_t *const pdu)
 {
-    return (uint16_t)GET_CANXL_BRIEF_FIELD(AVTP_CANXL_BRIEF_FIELD_ACF_MSG_LENGTH) * 4;
-}
-
-/**
- * Set the value of the ACF message type field as specified in the IEEE 1722 Specification.
- *
- * @param pdu Pointer to the first bit of a 1722 ACF CAN XL Brief PDU.
- * @param value Value to set the ACF message type field to.
- */
-OPEN1722_INLINE void Avtp_CanXlBrief_SetAcfMsgType(Avtp_CanXlBrief_t *pdu, uint8_t value)
-{
-    SET_CANXL_BRIEF_FIELD(AVTP_CANXL_BRIEF_FIELD_ACF_MSG_TYPE, value);
+    return (uint16_t)Avtp_AcfCommon_GetAcfMsgLength((const Avtp_AcfCommon_t *)pdu) * 4;
 }
 
 /**
@@ -172,7 +150,7 @@ OPEN1722_INLINE void Avtp_CanXlBrief_SetAcfMsgType(Avtp_CanXlBrief_t *pdu, uint8
  */
 OPEN1722_INLINE void Avtp_CanXlBrief_SetAcfMsgLength(Avtp_CanXlBrief_t *pdu, uint16_t value)
 {
-    SET_CANXL_BRIEF_FIELD(AVTP_CANXL_BRIEF_FIELD_ACF_MSG_LENGTH, value);
+    Avtp_AcfCommon_SetAcfMsgLength((Avtp_AcfCommon_t *)pdu, value);
 }
 
 /**
@@ -514,7 +492,7 @@ OPEN1722_INLINE void Avtp_CanXlBrief_Init(Avtp_CanXlBrief_t *pdu)
 {
     if (pdu != NULL) {
         memset(pdu, 0, sizeof(Avtp_CanXlBrief_t));
-        Avtp_CanXlBrief_SetAcfMsgType(pdu, AVTP_ACF_TYPE_CAN_XL_BRIEF);
+        Avtp_AcfCommon_SetAcfMsgType((Avtp_AcfCommon_t *)pdu, AVTP_ACF_TYPE_CAN_XL_BRIEF);
     }
 }
 
@@ -566,7 +544,7 @@ OPEN1722_INLINE bool Avtp_CanXlBrief_IsValid(const Avtp_CanXlBrief_t *const pdu,
         return false;
     }
 
-    if (Avtp_CanXlBrief_GetAcfMsgType(pdu) != AVTP_ACF_TYPE_CAN_XL_BRIEF) {
+    if (Avtp_AcfCommon_GetAcfMsgType((const Avtp_AcfCommon_t *)pdu) != AVTP_ACF_TYPE_CAN_XL_BRIEF) {
         return false;
     }
 

--- a/include/avtp/acf/CanXlBrief.h
+++ b/include/avtp/acf/CanXlBrief.h
@@ -115,45 +115,6 @@ static const Avtp_FieldDescriptor_t Avtp_CanXlBriefFieldDesc[AVTP_CANXL_BRIEF_FI
 };
 
 /**
- * Return the value of the ACF message length field as specified in the IEEE 1722 Specification.
- * This returns the length in Quadlets as specified in the IEEE 1722 Specification.
- *
- * You can use Avtp_CanXlBrief_GetPayloadLength to get the length in bytes without padding.
- *
- * @param pdu Pointer to the first bit of a 1722 ACF CAN XL Brief PDU.
- * @returns Value of the ACF message length field.
- */
-OPEN1722_INLINE uint16_t Avtp_CanXlBrief_GetAcfMsgLength(const Avtp_CanXlBrief_t *const pdu)
-{
-    return Avtp_AcfCommon_GetAcfMsgLength((const Avtp_AcfCommon_t *)pdu);
-}
-
-/**
- * Return the ACF message length in bytes.
- *
- * @param pdu Pointer to the first bit of a 1722 ACF CAN XL Brief PDU.
- * @returns Length of the ACF message in bytes.
- */
-OPEN1722_INLINE uint16_t Avtp_CanXlBrief_GetAcfMsgLengthInBytes(const Avtp_CanXlBrief_t *const pdu)
-{
-    return (uint16_t)Avtp_AcfCommon_GetAcfMsgLength((const Avtp_AcfCommon_t *)pdu) * 4;
-}
-
-/**
- * Set the value of the ACF message length field as specified in the IEEE 1722 Specification.
- * Note: the size is in Quadlets as specified in the IEEE 1722 Specification.
- * You can use Avtp_CanXlBrief_SetPayloadLength to set length in bytes and automatically set the
- * correct padding.
- *
- * @param pdu Pointer to the first bit of a 1722 ACF CAN XL Brief PDU.
- * @param value Value to set the ACF message length field to.
- */
-OPEN1722_INLINE void Avtp_CanXlBrief_SetAcfMsgLength(Avtp_CanXlBrief_t *pdu, uint16_t value)
-{
-    Avtp_AcfCommon_SetAcfMsgLength((Avtp_AcfCommon_t *)pdu, value);
-}
-
-/**
  * Returns the pad field from an ACF_CAN_XL_BRIEF message header.
  *
  * @param pdu Pointer to an ACF_CAN_XL_BRIEF message.
@@ -462,7 +423,7 @@ OPEN1722_INLINE void Avtp_CanXlBrief_SetPayloadLength(Avtp_CanXlBrief_t *pdu,
     }
     uint16_t msgLenQuadlets = (uint16_t)((msgLenBytes + pad) / 4);
     Avtp_CanXlBrief_SetPad(pdu, pad);
-    Avtp_CanXlBrief_SetAcfMsgLength(pdu, msgLenQuadlets);
+    Avtp_AcfCommon_SetAcfMsgLength((Avtp_AcfCommon_t *)pdu, msgLenQuadlets);
 }
 
 /**
@@ -479,7 +440,7 @@ OPEN1722_INLINE void Avtp_CanXlBrief_SetPayloadLength(Avtp_CanXlBrief_t *pdu,
 OPEN1722_INLINE uint8_t Avtp_CanXlBrief_GetPayloadLength(const Avtp_CanXlBrief_t *const pdu)
 {
     uint8_t pad_length = Avtp_CanXlBrief_GetPad(pdu);
-    uint16_t acf_length_bytes = Avtp_CanXlBrief_GetAcfMsgLengthInBytes(pdu);
+    uint16_t acf_length_bytes = Avtp_AcfCommon_GetAcfMsgLengthInBytes((const Avtp_AcfCommon_t *)pdu);
     return (uint8_t)(acf_length_bytes - AVTP_CANXL_BRIEF_HEADER_LEN - pad_length);
 }
 
@@ -548,8 +509,7 @@ OPEN1722_INLINE bool Avtp_CanXlBrief_IsValid(const Avtp_CanXlBrief_t *const pdu,
         return false;
     }
 
-    // Avtp_CanXlBrief_GetAcfMsgLength returns quadlets. Convert the length field to octets.
-    uint16_t msg_length_bytes = (uint16_t)Avtp_CanXlBrief_GetAcfMsgLength(pdu) * 4;
+    uint16_t msg_length_bytes = Avtp_AcfCommon_GetAcfMsgLengthInBytes((const Avtp_AcfCommon_t *)pdu);
     if (msg_length_bytes > bufferSize) {
         return false;
     }

--- a/include/avtp/acf/CanXlBrief.h
+++ b/include/avtp/acf/CanXlBrief.h
@@ -440,7 +440,8 @@ OPEN1722_INLINE void Avtp_CanXlBrief_SetPayloadLength(Avtp_CanXlBrief_t *pdu,
 OPEN1722_INLINE uint8_t Avtp_CanXlBrief_GetPayloadLength(const Avtp_CanXlBrief_t *const pdu)
 {
     uint8_t pad_length = Avtp_CanXlBrief_GetPad(pdu);
-    uint16_t acf_length_bytes = Avtp_AcfCommon_GetAcfMsgLengthInBytes((const Avtp_AcfCommon_t *)pdu);
+    uint16_t acf_length_bytes =
+        Avtp_AcfCommon_GetAcfMsgLengthInBytes((const Avtp_AcfCommon_t *)pdu);
     return (uint8_t)(acf_length_bytes - AVTP_CANXL_BRIEF_HEADER_LEN - pad_length);
 }
 
@@ -509,7 +510,8 @@ OPEN1722_INLINE bool Avtp_CanXlBrief_IsValid(const Avtp_CanXlBrief_t *const pdu,
         return false;
     }
 
-    uint16_t msg_length_bytes = Avtp_AcfCommon_GetAcfMsgLengthInBytes((const Avtp_AcfCommon_t *)pdu);
+    uint16_t msg_length_bytes =
+        Avtp_AcfCommon_GetAcfMsgLengthInBytes((const Avtp_AcfCommon_t *)pdu);
     if (msg_length_bytes > bufferSize) {
         return false;
     }

--- a/include/avtp/acf/FlexRay.h
+++ b/include/avtp/acf/FlexRay.h
@@ -111,17 +111,6 @@ static const Avtp_FieldDescriptor_t Avtp_FlexRayFieldDesc[AVTP_FLEXRAY_FIELD_MAX
 };
 
 /**
- * Return the value of an an ACF message length field as specified in the IEEE 1722 Specification.
- *
- * @param pdu Pointer to the first bit of an 1722 ACF FlexRay PDU.
- * @returns Value of the ACF message length field.
- */
-OPEN1722_INLINE uint16_t Avtp_FlexRay_GetAcfMsgLength(const Avtp_FlexRay_t *const pdu)
-{
-    return Avtp_AcfCommon_GetAcfMsgLength((const Avtp_AcfCommon_t *)pdu);
-}
-
-/**
  * Return the value of an an ACF FlexRay PDU padding field as specified in the IEEE 1722
  * Specification.
  *
@@ -249,17 +238,6 @@ OPEN1722_INLINE uint8_t Avtp_FlexRay_GetCycle(const Avtp_FlexRay_t *const pdu)
 }
 
 /**
- * Set the value of an an ACF message length field as specified in the IEEE 1722 Specification.
- *
- * @param pdu Pointer to the first bit of an 1722 ACF FlexRay PDU.
- * @param value Value to set the ACF message length field to.
- */
-OPEN1722_INLINE void Avtp_FlexRay_SetAcfMsgLength(Avtp_FlexRay_t *pdu, uint16_t value)
-{
-    Avtp_AcfCommon_SetAcfMsgLength((Avtp_AcfCommon_t *)pdu, value);
-}
-
-/**
  * Set the value of an an ACF FlexRay PDU padding field as specified in the IEEE 1722 Specification.
  *
  * @param pdu Pointer to the first bit of an 1722 ACF FlexRay PDU.
@@ -384,17 +362,6 @@ OPEN1722_INLINE void Avtp_FlexRay_SetCycle(Avtp_FlexRay_t *pdu, uint8_t value)
 }
 
 /**
- * Return the ACF message length in bytes.
- *
- * @param pdu Pointer to the first bit of an 1722 ACF FlexRay PDU.
- * @returns Length of the ACF message in bytes.
- */
-OPEN1722_INLINE uint16_t Avtp_FlexRay_GetAcfMsgLengthInBytes(const Avtp_FlexRay_t *const pdu)
-{
-    return (uint16_t)Avtp_AcfCommon_GetAcfMsgLength((const Avtp_AcfCommon_t *)pdu) * 4;
-}
-
-/**
  * Returns pointer to payload of an ACF FlexRay frame.
  *
  * @param pdu Pointer to the first bit of an 1722 ACF FlexRay PDU.
@@ -435,7 +402,7 @@ OPEN1722_INLINE void Avtp_FlexRay_SetPayloadLength(Avtp_FlexRay_t *pdu, uint16_t
     }
     uint16_t msgLenQuadlets = (uint16_t)((msgLenBytes + pad) / 4);
     Avtp_FlexRay_SetPad(pdu, pad);
-    Avtp_FlexRay_SetAcfMsgLength(pdu, msgLenQuadlets);
+    Avtp_AcfCommon_SetAcfMsgLength((Avtp_AcfCommon_t *)pdu, msgLenQuadlets);
 }
 
 /**
@@ -452,7 +419,7 @@ OPEN1722_INLINE void Avtp_FlexRay_SetPayloadLength(Avtp_FlexRay_t *pdu, uint16_t
 OPEN1722_INLINE uint8_t Avtp_FlexRay_GetPayloadLength(const Avtp_FlexRay_t *const pdu)
 {
     uint8_t pad_length = Avtp_FlexRay_GetPad(pdu);
-    uint16_t acf_length_bytes = Avtp_FlexRay_GetAcfMsgLengthInBytes(pdu);
+    uint16_t acf_length_bytes = Avtp_AcfCommon_GetAcfMsgLengthInBytes((const Avtp_AcfCommon_t *)pdu);
     return (uint8_t)(acf_length_bytes - AVTP_FLEXRAY_HEADER_LEN - pad_length);
 }
 
@@ -520,8 +487,7 @@ OPEN1722_INLINE bool Avtp_FlexRay_IsValid(const Avtp_FlexRay_t *const pdu, size_
         return false;
     }
 
-    // Avtp_FlexRay_GetAcfMsgLength returns quadlets. Convert the length field to octets.
-    uint16_t msg_length_bytes = (uint16_t)Avtp_FlexRay_GetAcfMsgLength(pdu) * 4;
+    uint16_t msg_length_bytes = Avtp_AcfCommon_GetAcfMsgLengthInBytes((const Avtp_AcfCommon_t *)pdu);
     if (msg_length_bytes > bufferSize) {
         return false;
     }

--- a/include/avtp/acf/FlexRay.h
+++ b/include/avtp/acf/FlexRay.h
@@ -419,7 +419,8 @@ OPEN1722_INLINE void Avtp_FlexRay_SetPayloadLength(Avtp_FlexRay_t *pdu, uint16_t
 OPEN1722_INLINE uint8_t Avtp_FlexRay_GetPayloadLength(const Avtp_FlexRay_t *const pdu)
 {
     uint8_t pad_length = Avtp_FlexRay_GetPad(pdu);
-    uint16_t acf_length_bytes = Avtp_AcfCommon_GetAcfMsgLengthInBytes((const Avtp_AcfCommon_t *)pdu);
+    uint16_t acf_length_bytes =
+        Avtp_AcfCommon_GetAcfMsgLengthInBytes((const Avtp_AcfCommon_t *)pdu);
     return (uint8_t)(acf_length_bytes - AVTP_FLEXRAY_HEADER_LEN - pad_length);
 }
 
@@ -487,7 +488,8 @@ OPEN1722_INLINE bool Avtp_FlexRay_IsValid(const Avtp_FlexRay_t *const pdu, size_
         return false;
     }
 
-    uint16_t msg_length_bytes = Avtp_AcfCommon_GetAcfMsgLengthInBytes((const Avtp_AcfCommon_t *)pdu);
+    uint16_t msg_length_bytes =
+        Avtp_AcfCommon_GetAcfMsgLengthInBytes((const Avtp_AcfCommon_t *)pdu);
     if (msg_length_bytes > bufferSize) {
         return false;
     }

--- a/include/avtp/acf/FlexRay.h
+++ b/include/avtp/acf/FlexRay.h
@@ -111,17 +111,6 @@ static const Avtp_FieldDescriptor_t Avtp_FlexRayFieldDesc[AVTP_FLEXRAY_FIELD_MAX
 };
 
 /**
- * Return the value of an an ACF message type field as specified in the IEEE 1722 Specification.
- *
- * @param pdu Pointer to the first bit of an 1722 ACF FlexRay PDU.
- * @returns Value of the ACF message type field.
- */
-OPEN1722_INLINE uint8_t Avtp_FlexRay_GetAcfMsgType(const Avtp_FlexRay_t *const pdu)
-{
-    return (uint8_t)GET_FLEXRAY_FIELD(AVTP_FLEXRAY_FIELD_ACF_MSG_TYPE);
-}
-
-/**
  * Return the value of an an ACF message length field as specified in the IEEE 1722 Specification.
  *
  * @param pdu Pointer to the first bit of an 1722 ACF FlexRay PDU.
@@ -129,7 +118,7 @@ OPEN1722_INLINE uint8_t Avtp_FlexRay_GetAcfMsgType(const Avtp_FlexRay_t *const p
  */
 OPEN1722_INLINE uint16_t Avtp_FlexRay_GetAcfMsgLength(const Avtp_FlexRay_t *const pdu)
 {
-    return (uint16_t)GET_FLEXRAY_FIELD(AVTP_FLEXRAY_FIELD_ACF_MSG_LENGTH);
+    return Avtp_AcfCommon_GetAcfMsgLength((const Avtp_AcfCommon_t *)pdu);
 }
 
 /**
@@ -260,17 +249,6 @@ OPEN1722_INLINE uint8_t Avtp_FlexRay_GetCycle(const Avtp_FlexRay_t *const pdu)
 }
 
 /**
- * Set the value of an an ACF message type field as specified in the IEEE 1722 Specification.
- *
- * @param pdu Pointer to the first bit of an 1722 ACF FlexRay PDU.
- * @param value Value to set the ACF message type field to.
- */
-OPEN1722_INLINE void Avtp_FlexRay_SetAcfMsgType(Avtp_FlexRay_t *pdu, uint8_t value)
-{
-    SET_FLEXRAY_FIELD(AVTP_FLEXRAY_FIELD_ACF_MSG_TYPE, value);
-}
-
-/**
  * Set the value of an an ACF message length field as specified in the IEEE 1722 Specification.
  *
  * @param pdu Pointer to the first bit of an 1722 ACF FlexRay PDU.
@@ -278,7 +256,7 @@ OPEN1722_INLINE void Avtp_FlexRay_SetAcfMsgType(Avtp_FlexRay_t *pdu, uint8_t val
  */
 OPEN1722_INLINE void Avtp_FlexRay_SetAcfMsgLength(Avtp_FlexRay_t *pdu, uint16_t value)
 {
-    SET_FLEXRAY_FIELD(AVTP_FLEXRAY_FIELD_ACF_MSG_LENGTH, value);
+    Avtp_AcfCommon_SetAcfMsgLength((Avtp_AcfCommon_t *)pdu, value);
 }
 
 /**
@@ -413,7 +391,7 @@ OPEN1722_INLINE void Avtp_FlexRay_SetCycle(Avtp_FlexRay_t *pdu, uint8_t value)
  */
 OPEN1722_INLINE uint16_t Avtp_FlexRay_GetAcfMsgLengthInBytes(const Avtp_FlexRay_t *const pdu)
 {
-    return (uint16_t)GET_FLEXRAY_FIELD(AVTP_FLEXRAY_FIELD_ACF_MSG_LENGTH) * 4;
+    return (uint16_t)Avtp_AcfCommon_GetAcfMsgLength((const Avtp_AcfCommon_t *)pdu) * 4;
 }
 
 /**
@@ -487,7 +465,7 @@ OPEN1722_INLINE void Avtp_FlexRay_Init(Avtp_FlexRay_t *pdu)
 {
     if (pdu != NULL) {
         memset(pdu, 0, sizeof(Avtp_FlexRay_t));
-        Avtp_FlexRay_SetAcfMsgType(pdu, AVTP_ACF_TYPE_FLEXRAY);
+        Avtp_AcfCommon_SetAcfMsgType((Avtp_AcfCommon_t *)pdu, AVTP_ACF_TYPE_FLEXRAY);
     }
 }
 
@@ -538,7 +516,7 @@ OPEN1722_INLINE bool Avtp_FlexRay_IsValid(const Avtp_FlexRay_t *const pdu, size_
         return false;
     }
 
-    if (Avtp_FlexRay_GetAcfMsgType(pdu) != AVTP_ACF_TYPE_FLEXRAY) {
+    if (Avtp_AcfCommon_GetAcfMsgType((const Avtp_AcfCommon_t *)pdu) != AVTP_ACF_TYPE_FLEXRAY) {
         return false;
     }
 

--- a/include/avtp/acf/Gbb.h
+++ b/include/avtp/acf/Gbb.h
@@ -481,7 +481,8 @@ OPEN1722_INLINE void Avtp_Gbb_SetPayloadLength(Avtp_Gbb_t *pdu, uint16_t payload
 OPEN1722_INLINE uint8_t Avtp_Gbb_GetPayloadLength(const Avtp_Gbb_t *const pdu)
 {
     uint8_t pad_length = Avtp_Gbb_GetPad(pdu);
-    uint16_t acf_length_bytes = Avtp_AcfCommon_GetAcfMsgLengthInBytes((const Avtp_AcfCommon_t *)pdu);
+    uint16_t acf_length_bytes =
+        Avtp_AcfCommon_GetAcfMsgLengthInBytes((const Avtp_AcfCommon_t *)pdu);
     return (uint8_t)(acf_length_bytes - AVTP_GBB_HEADER_LEN - pad_length);
 }
 
@@ -550,7 +551,8 @@ OPEN1722_INLINE bool Avtp_Gbb_IsValid(const Avtp_Gbb_t *const pdu, size_t buffer
         return false;
     }
 
-    uint16_t msg_length_bytes = Avtp_AcfCommon_GetAcfMsgLengthInBytes((const Avtp_AcfCommon_t *)pdu);
+    uint16_t msg_length_bytes =
+        Avtp_AcfCommon_GetAcfMsgLengthInBytes((const Avtp_AcfCommon_t *)pdu);
     if (msg_length_bytes > bufferSize) {
         return false;
     }

--- a/include/avtp/acf/Gbb.h
+++ b/include/avtp/acf/Gbb.h
@@ -116,17 +116,6 @@ static const Avtp_FieldDescriptor_t Avtp_GbbFieldDesc[AVTP_GBB_FIELD_MAX] = {
 };
 
 /**
- * Return the value of the ACF message type field as specified in the IEEE 1722 Specification.
- *
- * @param pdu Pointer to the first bit of a 1722 ACF GBB PDU.
- * @returns Value of the ACF message type field.
- */
-OPEN1722_INLINE uint8_t Avtp_Gbb_GetAcfMsgType(const Avtp_Gbb_t *const pdu)
-{
-    return (uint8_t)GET_GBB_FIELD(AVTP_GBB_FIELD_ACF_MSG_TYPE);
-}
-
-/**
  * Return the value of the ACF message length field as specified in the IEEE 1722 Specification.
  * This returns the length in Quadlets as specified in the IEEE 1722 Specification.
  *
@@ -137,7 +126,7 @@ OPEN1722_INLINE uint8_t Avtp_Gbb_GetAcfMsgType(const Avtp_Gbb_t *const pdu)
  */
 OPEN1722_INLINE uint16_t Avtp_Gbb_GetAcfMsgLength(const Avtp_Gbb_t *const pdu)
 {
-    return (uint16_t)GET_GBB_FIELD(AVTP_GBB_FIELD_ACF_MSG_LENGTH);
+    return Avtp_AcfCommon_GetAcfMsgLength((const Avtp_AcfCommon_t *)pdu);
 }
 
 /**
@@ -148,18 +137,7 @@ OPEN1722_INLINE uint16_t Avtp_Gbb_GetAcfMsgLength(const Avtp_Gbb_t *const pdu)
  */
 OPEN1722_INLINE uint16_t Avtp_Gbb_GetAcfMsgLengthInBytes(const Avtp_Gbb_t *const pdu)
 {
-    return (uint16_t)GET_GBB_FIELD(AVTP_GBB_FIELD_ACF_MSG_LENGTH) * 4;
-}
-
-/**
- * Set the value of the ACF message type field as specified in the IEEE 1722 Specification.
- *
- * @param pdu Pointer to the first bit of a 1722 ACF GBB PDU.
- * @param value Value to set the ACF message type field to.
- */
-OPEN1722_INLINE void Avtp_Gbb_SetAcfMsgType(Avtp_Gbb_t *pdu, uint8_t value)
-{
-    SET_GBB_FIELD(AVTP_GBB_FIELD_ACF_MSG_TYPE, value);
+    return (uint16_t)Avtp_AcfCommon_GetAcfMsgLength((const Avtp_AcfCommon_t *)pdu) * 4;
 }
 
 /**
@@ -173,7 +151,7 @@ OPEN1722_INLINE void Avtp_Gbb_SetAcfMsgType(Avtp_Gbb_t *pdu, uint8_t value)
  */
 OPEN1722_INLINE void Avtp_Gbb_SetAcfMsgLength(Avtp_Gbb_t *pdu, uint16_t value)
 {
-    SET_GBB_FIELD(AVTP_GBB_FIELD_ACF_MSG_LENGTH, value);
+    Avtp_AcfCommon_SetAcfMsgLength((Avtp_AcfCommon_t *)pdu, value);
 }
 
 /**
@@ -555,7 +533,7 @@ OPEN1722_INLINE void Avtp_Gbb_Init(Avtp_Gbb_t *pdu)
 {
     if (pdu != NULL) {
         memset(pdu, 0, sizeof(Avtp_Gbb_t));
-        Avtp_Gbb_SetAcfMsgType(pdu, AVTP_ACF_TYPE_BYTE_BUS);
+        Avtp_AcfCommon_SetAcfMsgType((Avtp_AcfCommon_t *)pdu, AVTP_ACF_TYPE_BYTE_BUS);
     }
 }
 
@@ -607,7 +585,7 @@ OPEN1722_INLINE bool Avtp_Gbb_IsValid(const Avtp_Gbb_t *const pdu, size_t buffer
         return false;
     }
 
-    if (Avtp_Gbb_GetAcfMsgType(pdu) != AVTP_ACF_TYPE_BYTE_BUS) {
+    if (Avtp_AcfCommon_GetAcfMsgType((const Avtp_AcfCommon_t *)pdu) != AVTP_ACF_TYPE_BYTE_BUS) {
         return false;
     }
 

--- a/include/avtp/acf/Gbb.h
+++ b/include/avtp/acf/Gbb.h
@@ -116,45 +116,6 @@ static const Avtp_FieldDescriptor_t Avtp_GbbFieldDesc[AVTP_GBB_FIELD_MAX] = {
 };
 
 /**
- * Return the value of the ACF message length field as specified in the IEEE 1722 Specification.
- * This returns the length in Quadlets as specified in the IEEE 1722 Specification.
- *
- * You can use Avtp_Gbb_GetPayloadLength to get the length in bytes without padding.
- *
- * @param pdu Pointer to the first bit of a 1722 ACF GBB PDU.
- * @returns Value of the ACF message length field.
- */
-OPEN1722_INLINE uint16_t Avtp_Gbb_GetAcfMsgLength(const Avtp_Gbb_t *const pdu)
-{
-    return Avtp_AcfCommon_GetAcfMsgLength((const Avtp_AcfCommon_t *)pdu);
-}
-
-/**
- * Return the ACF message length in bytes.
- *
- * @param pdu Pointer to the first bit of a 1722 ACF GBB PDU.
- * @returns Length of the ACF message in bytes.
- */
-OPEN1722_INLINE uint16_t Avtp_Gbb_GetAcfMsgLengthInBytes(const Avtp_Gbb_t *const pdu)
-{
-    return (uint16_t)Avtp_AcfCommon_GetAcfMsgLength((const Avtp_AcfCommon_t *)pdu) * 4;
-}
-
-/**
- * Set the value of the ACF message length field as specified in the IEEE 1722 Specification.
- * Note: the size is in Quadlets as specified in the IEEE 1722 Specification.
- * You can use Avtp_Gbb_SetPayloadLength to set length in bytes and automatically set the
- * correct padding.
- *
- * @param pdu Pointer to the first bit of a 1722 ACF GBB PDU.
- * @param value Value to set the ACF message length field to.
- */
-OPEN1722_INLINE void Avtp_Gbb_SetAcfMsgLength(Avtp_Gbb_t *pdu, uint16_t value)
-{
-    Avtp_AcfCommon_SetAcfMsgLength((Avtp_AcfCommon_t *)pdu, value);
-}
-
-/**
  * Returns the pad field from an ACF_GBB message header.
  *
  * @param pdu Pointer to an ACF_GBB message.
@@ -503,7 +464,7 @@ OPEN1722_INLINE void Avtp_Gbb_SetPayloadLength(Avtp_Gbb_t *pdu, uint16_t payload
     }
     uint16_t msgLenQuadlets = (uint16_t)((msgLenBytes + pad) / 4);
     Avtp_Gbb_SetPad(pdu, pad);
-    Avtp_Gbb_SetAcfMsgLength(pdu, msgLenQuadlets);
+    Avtp_AcfCommon_SetAcfMsgLength((Avtp_AcfCommon_t *)pdu, msgLenQuadlets);
 }
 
 /**
@@ -520,7 +481,7 @@ OPEN1722_INLINE void Avtp_Gbb_SetPayloadLength(Avtp_Gbb_t *pdu, uint16_t payload
 OPEN1722_INLINE uint8_t Avtp_Gbb_GetPayloadLength(const Avtp_Gbb_t *const pdu)
 {
     uint8_t pad_length = Avtp_Gbb_GetPad(pdu);
-    uint16_t acf_length_bytes = Avtp_Gbb_GetAcfMsgLengthInBytes(pdu);
+    uint16_t acf_length_bytes = Avtp_AcfCommon_GetAcfMsgLengthInBytes((const Avtp_AcfCommon_t *)pdu);
     return (uint8_t)(acf_length_bytes - AVTP_GBB_HEADER_LEN - pad_length);
 }
 
@@ -589,8 +550,7 @@ OPEN1722_INLINE bool Avtp_Gbb_IsValid(const Avtp_Gbb_t *const pdu, size_t buffer
         return false;
     }
 
-    // Avtp_Gbb_GetAcfMsgLength returns quadlets. Convert the length field to octets.
-    uint16_t msg_length_bytes = (uint16_t)Avtp_Gbb_GetAcfMsgLength(pdu) * 4;
+    uint16_t msg_length_bytes = Avtp_AcfCommon_GetAcfMsgLengthInBytes((const Avtp_AcfCommon_t *)pdu);
     if (msg_length_bytes > bufferSize) {
         return false;
     }

--- a/include/avtp/acf/Gisf.h
+++ b/include/avtp/acf/Gisf.h
@@ -116,17 +116,6 @@ static const Avtp_FieldDescriptor_t Avtp_GisfFieldDesc[AVTP_GISF_FIELD_MAX] = {
 };
 
 /**
- * Return the value of the ACF message type field as specified in the IEEE 1722 Specification.
- *
- * @param pdu Pointer to the first bit of a 1722 ACF GISF PDU.
- * @returns Value of the ACF message type field.
- */
-OPEN1722_INLINE uint8_t Avtp_Gisf_GetAcfMsgType(const Avtp_Gisf_t *const pdu)
-{
-    return (uint8_t)GET_GISF_FIELD(AVTP_GISF_FIELD_ACF_MSG_TYPE);
-}
-
-/**
  * Return the value of the ACF message length field as specified in the IEEE 1722 Specification.
  * This returns the length in Quadlets as specified in the IEEE 1722 Specification.
  *
@@ -137,7 +126,7 @@ OPEN1722_INLINE uint8_t Avtp_Gisf_GetAcfMsgType(const Avtp_Gisf_t *const pdu)
  */
 OPEN1722_INLINE uint16_t Avtp_Gisf_GetAcfMsgLength(const Avtp_Gisf_t *const pdu)
 {
-    return (uint16_t)GET_GISF_FIELD(AVTP_GISF_FIELD_ACF_MSG_LENGTH);
+    return Avtp_AcfCommon_GetAcfMsgLength((const Avtp_AcfCommon_t *)pdu);
 }
 
 /**
@@ -148,18 +137,7 @@ OPEN1722_INLINE uint16_t Avtp_Gisf_GetAcfMsgLength(const Avtp_Gisf_t *const pdu)
  */
 OPEN1722_INLINE uint16_t Avtp_Gisf_GetAcfMsgLengthInBytes(const Avtp_Gisf_t *const pdu)
 {
-    return (uint16_t)GET_GISF_FIELD(AVTP_GISF_FIELD_ACF_MSG_LENGTH) * 4;
-}
-
-/**
- * Set the value of the ACF message type field as specified in the IEEE 1722 Specification.
- *
- * @param pdu Pointer to the first bit of a 1722 ACF GISF PDU.
- * @param value Value to set the ACF message type field to.
- */
-OPEN1722_INLINE void Avtp_Gisf_SetAcfMsgType(Avtp_Gisf_t *pdu, uint8_t value)
-{
-    SET_GISF_FIELD(AVTP_GISF_FIELD_ACF_MSG_TYPE, value);
+    return (uint16_t)Avtp_AcfCommon_GetAcfMsgLength((const Avtp_AcfCommon_t *)pdu) * 4;
 }
 
 /**
@@ -173,7 +151,7 @@ OPEN1722_INLINE void Avtp_Gisf_SetAcfMsgType(Avtp_Gisf_t *pdu, uint8_t value)
  */
 OPEN1722_INLINE void Avtp_Gisf_SetAcfMsgLength(Avtp_Gisf_t *pdu, uint16_t value)
 {
-    SET_GISF_FIELD(AVTP_GISF_FIELD_ACF_MSG_LENGTH, value);
+    Avtp_AcfCommon_SetAcfMsgLength((Avtp_AcfCommon_t *)pdu, value);
 }
 
 /**
@@ -535,7 +513,7 @@ OPEN1722_INLINE void Avtp_Gisf_Init(Avtp_Gisf_t *pdu)
 {
     if (pdu != NULL) {
         memset(pdu, 0, sizeof(Avtp_Gisf_t));
-        Avtp_Gisf_SetAcfMsgType(pdu, AVTP_ACF_TYPE_GISF);
+        Avtp_AcfCommon_SetAcfMsgType((Avtp_AcfCommon_t *)pdu, AVTP_ACF_TYPE_GISF);
     }
 }
 
@@ -583,7 +561,7 @@ OPEN1722_INLINE bool Avtp_Gisf_IsValid(const Avtp_Gisf_t *const pdu, size_t buff
         return false;
     }
 
-    if (Avtp_Gisf_GetAcfMsgType(pdu) != AVTP_ACF_TYPE_GISF) {
+    if (Avtp_AcfCommon_GetAcfMsgType((const Avtp_AcfCommon_t *)pdu) != AVTP_ACF_TYPE_GISF) {
         return false;
     }
 

--- a/include/avtp/acf/Gisf.h
+++ b/include/avtp/acf/Gisf.h
@@ -116,45 +116,6 @@ static const Avtp_FieldDescriptor_t Avtp_GisfFieldDesc[AVTP_GISF_FIELD_MAX] = {
 };
 
 /**
- * Return the value of the ACF message length field as specified in the IEEE 1722 Specification.
- * This returns the length in Quadlets as specified in the IEEE 1722 Specification.
- *
- * You can use Avtp_Gisf_GetPayloadLength to get the length in bytes without padding.
- *
- * @param pdu Pointer to the first bit of a 1722 ACF GISF PDU.
- * @returns Value of the ACF message length field.
- */
-OPEN1722_INLINE uint16_t Avtp_Gisf_GetAcfMsgLength(const Avtp_Gisf_t *const pdu)
-{
-    return Avtp_AcfCommon_GetAcfMsgLength((const Avtp_AcfCommon_t *)pdu);
-}
-
-/**
- * Return the ACF message length in bytes.
- *
- * @param pdu Pointer to the first bit of a 1722 ACF GISF PDU.
- * @returns Length of the ACF message in bytes.
- */
-OPEN1722_INLINE uint16_t Avtp_Gisf_GetAcfMsgLengthInBytes(const Avtp_Gisf_t *const pdu)
-{
-    return (uint16_t)Avtp_AcfCommon_GetAcfMsgLength((const Avtp_AcfCommon_t *)pdu) * 4;
-}
-
-/**
- * Set the value of the ACF message length field as specified in the IEEE 1722 Specification.
- * Note: the size is in Quadlets as specified in the IEEE 1722 Specification.
- * You can use Avtp_Gisf_SetPayloadLength to set length in bytes and automatically set the
- * correct padding.
- *
- * @param pdu Pointer to the first bit of a 1722 ACF GISF PDU.
- * @param value Value to set the ACF message length field to.
- */
-OPEN1722_INLINE void Avtp_Gisf_SetAcfMsgLength(Avtp_Gisf_t *pdu, uint16_t value)
-{
-    Avtp_AcfCommon_SetAcfMsgLength((Avtp_AcfCommon_t *)pdu, value);
-}
-
-/**
  * Returns the pad field from an ACF_GISF message header.
  *
  * @param pdu Pointer to an ACF_GISF message.
@@ -483,7 +444,7 @@ OPEN1722_INLINE void Avtp_Gisf_SetPayloadLength(Avtp_Gisf_t *pdu, uint16_t paylo
     }
     uint16_t msgLenQuadlets = (uint16_t)((msgLenBytes + pad) / 4);
     Avtp_Gisf_SetPad(pdu, pad);
-    Avtp_Gisf_SetAcfMsgLength(pdu, msgLenQuadlets);
+    Avtp_AcfCommon_SetAcfMsgLength((Avtp_AcfCommon_t *)pdu, msgLenQuadlets);
 }
 
 /**
@@ -500,7 +461,7 @@ OPEN1722_INLINE void Avtp_Gisf_SetPayloadLength(Avtp_Gisf_t *pdu, uint16_t paylo
 OPEN1722_INLINE uint16_t Avtp_Gisf_GetPayloadLength(const Avtp_Gisf_t *const pdu)
 {
     uint8_t pad_length = Avtp_Gisf_GetPad(pdu);
-    uint16_t acf_length_bytes = Avtp_Gisf_GetAcfMsgLengthInBytes(pdu);
+    uint16_t acf_length_bytes = Avtp_AcfCommon_GetAcfMsgLengthInBytes((const Avtp_AcfCommon_t *)pdu);
     return (uint16_t)(acf_length_bytes - AVTP_GISF_HEADER_LEN - pad_length);
 }
 
@@ -565,8 +526,7 @@ OPEN1722_INLINE bool Avtp_Gisf_IsValid(const Avtp_Gisf_t *const pdu, size_t buff
         return false;
     }
 
-    // Avtp_Gisf_GetAcfMsgLength returns quadlets. Convert the length field to octets.
-    uint16_t msg_length_bytes = (uint16_t)Avtp_Gisf_GetAcfMsgLength(pdu) * 4;
+    uint16_t msg_length_bytes = Avtp_AcfCommon_GetAcfMsgLengthInBytes((const Avtp_AcfCommon_t *)pdu);
     if (msg_length_bytes > bufferSize) {
         return false;
     }

--- a/include/avtp/acf/Gisf.h
+++ b/include/avtp/acf/Gisf.h
@@ -461,7 +461,8 @@ OPEN1722_INLINE void Avtp_Gisf_SetPayloadLength(Avtp_Gisf_t *pdu, uint16_t paylo
 OPEN1722_INLINE uint16_t Avtp_Gisf_GetPayloadLength(const Avtp_Gisf_t *const pdu)
 {
     uint8_t pad_length = Avtp_Gisf_GetPad(pdu);
-    uint16_t acf_length_bytes = Avtp_AcfCommon_GetAcfMsgLengthInBytes((const Avtp_AcfCommon_t *)pdu);
+    uint16_t acf_length_bytes =
+        Avtp_AcfCommon_GetAcfMsgLengthInBytes((const Avtp_AcfCommon_t *)pdu);
     return (uint16_t)(acf_length_bytes - AVTP_GISF_HEADER_LEN - pad_length);
 }
 
@@ -526,7 +527,8 @@ OPEN1722_INLINE bool Avtp_Gisf_IsValid(const Avtp_Gisf_t *const pdu, size_t buff
         return false;
     }
 
-    uint16_t msg_length_bytes = Avtp_AcfCommon_GetAcfMsgLengthInBytes((const Avtp_AcfCommon_t *)pdu);
+    uint16_t msg_length_bytes =
+        Avtp_AcfCommon_GetAcfMsgLengthInBytes((const Avtp_AcfCommon_t *)pdu);
     if (msg_length_bytes > bufferSize) {
         return false;
     }

--- a/include/avtp/acf/Gpc.h
+++ b/include/avtp/acf/Gpc.h
@@ -226,7 +226,8 @@ OPEN1722_INLINE bool Avtp_Gpc_IsValid(const Avtp_Gpc_t *const pdu, size_t buffer
         return false;
     }
 
-    uint16_t msg_length_bytes = Avtp_AcfCommon_GetAcfMsgLengthInBytes((const Avtp_AcfCommon_t *)pdu);
+    uint16_t msg_length_bytes =
+        Avtp_AcfCommon_GetAcfMsgLengthInBytes((const Avtp_AcfCommon_t *)pdu);
     if (msg_length_bytes > bufferSize) {
         return false;
     }

--- a/include/avtp/acf/Gpc.h
+++ b/include/avtp/acf/Gpc.h
@@ -88,17 +88,6 @@ static const Avtp_FieldDescriptor_t Avtp_GpcFieldDesc[AVTP_GPC_FIELD_MAX] = {
 };
 
 /**
- * Return the value of the ACF Message Type Field as specified in the IEEE 1722 Specification.
- *
- * @param pdu Pointer to the first bit of an 1722 ACF GPC PDU.
- * @returns The value of the ACF Message Type Field.
- */
-OPEN1722_INLINE uint8_t Avtp_Gpc_GetAcfMsgType(const Avtp_Gpc_t *const pdu)
-{
-    return (uint8_t)GET_GPC_FIELD(AVTP_GPC_FIELD_ACF_MSG_TYPE);
-}
-
-/**
  * Return the value of the ACF Message Length Field as specified in the IEEE 1722 Specification.
  *
  * @param pdu Pointer to the first bit of an 1722 ACF GPC PDU.
@@ -106,7 +95,7 @@ OPEN1722_INLINE uint8_t Avtp_Gpc_GetAcfMsgType(const Avtp_Gpc_t *const pdu)
  */
 OPEN1722_INLINE uint16_t Avtp_Gpc_GetAcfMsgLength(const Avtp_Gpc_t *const pdu)
 {
-    return (uint16_t)GET_GPC_FIELD(AVTP_GPC_FIELD_ACF_MSG_LENGTH);
+    return Avtp_AcfCommon_GetAcfMsgLength((const Avtp_AcfCommon_t *)pdu);
 }
 
 /**
@@ -117,7 +106,7 @@ OPEN1722_INLINE uint16_t Avtp_Gpc_GetAcfMsgLength(const Avtp_Gpc_t *const pdu)
  */
 OPEN1722_INLINE uint16_t Avtp_Gpc_GetAcfMsgLengthInBytes(const Avtp_Gpc_t *const pdu)
 {
-    return (uint16_t)GET_GPC_FIELD(AVTP_GPC_FIELD_ACF_MSG_LENGTH) * 4;
+    return (uint16_t)Avtp_AcfCommon_GetAcfMsgLength((const Avtp_AcfCommon_t *)pdu) * 4;
 }
 
 /**
@@ -132,17 +121,6 @@ OPEN1722_INLINE uint64_t Avtp_Gpc_GetGpcMsgId(const Avtp_Gpc_t *const pdu)
 }
 
 /**
- * Set the value of an ACF Message Type field as specified in the IEEE 1722 Specification.
- *
- * @param pdu Pointer to the first bit of an 1722 ACF GPC PDU.
- * @param value Value to set the ACF Message Type field to.
- */
-OPEN1722_INLINE void Avtp_Gpc_SetAcfMsgType(Avtp_Gpc_t *pdu, uint8_t value)
-{
-    SET_GPC_FIELD(AVTP_GPC_FIELD_ACF_MSG_TYPE, value);
-}
-
-/**
  * Set the value of an ACF Message Length field as specified in the IEEE 1722 Specification.
  *
  * @param pdu Pointer to the first bit of an 1722 ACF GPC PDU.
@@ -150,7 +128,7 @@ OPEN1722_INLINE void Avtp_Gpc_SetAcfMsgType(Avtp_Gpc_t *pdu, uint8_t value)
  */
 OPEN1722_INLINE void Avtp_Gpc_SetAcfMsgLength(Avtp_Gpc_t *pdu, uint16_t value)
 {
-    SET_GPC_FIELD(AVTP_GPC_FIELD_ACF_MSG_LENGTH, value);
+    Avtp_AcfCommon_SetAcfMsgLength((Avtp_AcfCommon_t *)pdu, value);
 }
 
 /**
@@ -230,7 +208,7 @@ OPEN1722_INLINE void Avtp_Gpc_Init(Avtp_Gpc_t *pdu)
 {
     if (pdu != NULL) {
         memset(pdu, 0, sizeof(Avtp_Gpc_t));
-        Avtp_Gpc_SetAcfMsgType(pdu, AVTP_ACF_TYPE_GPC);
+        Avtp_AcfCommon_SetAcfMsgType((Avtp_AcfCommon_t *)pdu, AVTP_ACF_TYPE_GPC);
     }
 }
 
@@ -277,7 +255,7 @@ OPEN1722_INLINE bool Avtp_Gpc_IsValid(const Avtp_Gpc_t *const pdu, size_t buffer
         return false;
     }
 
-    if (Avtp_Gpc_GetAcfMsgType(pdu) != AVTP_ACF_TYPE_GPC) {
+    if (Avtp_AcfCommon_GetAcfMsgType((const Avtp_AcfCommon_t *)pdu) != AVTP_ACF_TYPE_GPC) {
         return false;
     }
 

--- a/include/avtp/acf/Gpc.h
+++ b/include/avtp/acf/Gpc.h
@@ -88,28 +88,6 @@ static const Avtp_FieldDescriptor_t Avtp_GpcFieldDesc[AVTP_GPC_FIELD_MAX] = {
 };
 
 /**
- * Return the value of the ACF Message Length Field as specified in the IEEE 1722 Specification.
- *
- * @param pdu Pointer to the first bit of an 1722 ACF GPC PDU.
- * @returns The value of the ACF Message Length Field.
- */
-OPEN1722_INLINE uint16_t Avtp_Gpc_GetAcfMsgLength(const Avtp_Gpc_t *const pdu)
-{
-    return Avtp_AcfCommon_GetAcfMsgLength((const Avtp_AcfCommon_t *)pdu);
-}
-
-/**
- * Return the ACF message length in bytes.
- *
- * @param pdu Pointer to the first bit of an 1722 ACF GPC PDU.
- * @returns Length of the ACF message in bytes.
- */
-OPEN1722_INLINE uint16_t Avtp_Gpc_GetAcfMsgLengthInBytes(const Avtp_Gpc_t *const pdu)
-{
-    return (uint16_t)Avtp_AcfCommon_GetAcfMsgLength((const Avtp_AcfCommon_t *)pdu) * 4;
-}
-
-/**
  * Return the value of the GPC Message ID Field as specified in the IEEE 1722 Specification.
  *
  * @param pdu Pointer to the first bit of an 1722 ACF GPC PDU.
@@ -118,17 +96,6 @@ OPEN1722_INLINE uint16_t Avtp_Gpc_GetAcfMsgLengthInBytes(const Avtp_Gpc_t *const
 OPEN1722_INLINE uint64_t Avtp_Gpc_GetGpcMsgId(const Avtp_Gpc_t *const pdu)
 {
     return (uint64_t)GET_GPC_FIELD(AVTP_GPC_FIELD_GPC_MSG_ID);
-}
-
-/**
- * Set the value of an ACF Message Length field as specified in the IEEE 1722 Specification.
- *
- * @param pdu Pointer to the first bit of an 1722 ACF GPC PDU.
- * @param value Value to set the ACF Message Length field to.
- */
-OPEN1722_INLINE void Avtp_Gpc_SetAcfMsgLength(Avtp_Gpc_t *pdu, uint16_t value)
-{
-    Avtp_AcfCommon_SetAcfMsgLength((Avtp_AcfCommon_t *)pdu, value);
 }
 
 /**
@@ -185,7 +152,7 @@ OPEN1722_INLINE void Avtp_Gpc_SetPayloadLength(Avtp_Gpc_t *pdu, uint16_t payload
         memset(pdu->payload + payload_length, 0, pad);
     }
     uint16_t msgLenQuadlets = (uint16_t)((msgLenBytes + pad) / 4);
-    Avtp_Gpc_SetAcfMsgLength(pdu, msgLenQuadlets);
+    Avtp_AcfCommon_SetAcfMsgLength((Avtp_AcfCommon_t *)pdu, msgLenQuadlets);
 }
 
 /*
@@ -259,8 +226,7 @@ OPEN1722_INLINE bool Avtp_Gpc_IsValid(const Avtp_Gpc_t *const pdu, size_t buffer
         return false;
     }
 
-    // Avtp_Gpc_GetAcfMsgLength returns quadlets. Convert the length field to octets.
-    uint16_t msg_length_bytes = (uint16_t)Avtp_Gpc_GetAcfMsgLength(pdu) * 4;
+    uint16_t msg_length_bytes = Avtp_AcfCommon_GetAcfMsgLengthInBytes((const Avtp_AcfCommon_t *)pdu);
     if (msg_length_bytes > bufferSize) {
         return false;
     }

--- a/include/avtp/acf/Lin.h
+++ b/include/avtp/acf/Lin.h
@@ -268,7 +268,8 @@ OPEN1722_INLINE void Avtp_Lin_SetPayloadLength(Avtp_Lin_t *lin_pdu, uint16_t pay
 OPEN1722_INLINE uint8_t Avtp_Lin_GetPayloadLength(const Avtp_Lin_t *const pdu)
 {
     uint8_t pad_length = Avtp_Lin_GetPad(pdu);
-    uint16_t acf_length_bytes = Avtp_AcfCommon_GetAcfMsgLengthInBytes((const Avtp_AcfCommon_t *)pdu);
+    uint16_t acf_length_bytes =
+        Avtp_AcfCommon_GetAcfMsgLengthInBytes((const Avtp_AcfCommon_t *)pdu);
     return (uint8_t)(acf_length_bytes - AVTP_LIN_HEADER_LEN - pad_length);
 }
 
@@ -338,7 +339,8 @@ OPEN1722_INLINE bool Avtp_Lin_IsValid(const Avtp_Lin_t *const pdu, size_t buffer
         return false;
     }
 
-    uint16_t msg_length_bytes = Avtp_AcfCommon_GetAcfMsgLengthInBytes((const Avtp_AcfCommon_t *)pdu);
+    uint16_t msg_length_bytes =
+        Avtp_AcfCommon_GetAcfMsgLengthInBytes((const Avtp_AcfCommon_t *)pdu);
     if (msg_length_bytes > bufferSize) {
         return false;
     }

--- a/include/avtp/acf/Lin.h
+++ b/include/avtp/acf/Lin.h
@@ -95,17 +95,6 @@ static const Avtp_FieldDescriptor_t Avtp_LinFieldDesc[AVTP_LIN_FIELD_MAX] = {
 };
 
 /**
- * Returns the value of an an ACF Message type field as specified in the IEEE 1722 Specification.
- *
- * @param pdu Pointer to the first bit of an 1722 ACF Lin PDU.
- * @returns The value of the ACF Message Type field.
- */
-OPEN1722_INLINE uint8_t Avtp_Lin_GetAcfMsgType(const Avtp_Lin_t *const pdu)
-{
-    return (uint8_t)GET_LIN_FIELD(AVTP_LIN_FIELD_ACF_MSG_TYPE);
-}
-
-/**
  * Returns the value of an an ACF Message Length field as specified in the IEEE 1722 Specification.
  *
  * @param pdu Pointer to the first bit of an 1722 ACF Lin PDU.
@@ -113,7 +102,7 @@ OPEN1722_INLINE uint8_t Avtp_Lin_GetAcfMsgType(const Avtp_Lin_t *const pdu)
  */
 OPEN1722_INLINE uint16_t Avtp_Lin_GetAcfMsgLength(const Avtp_Lin_t *const pdu)
 {
-    return (uint16_t)GET_LIN_FIELD(AVTP_LIN_FIELD_ACF_MSG_LENGTH);
+    return Avtp_AcfCommon_GetAcfMsgLength((const Avtp_AcfCommon_t *)pdu);
 }
 
 /**
@@ -175,17 +164,6 @@ OPEN1722_INLINE uint64_t Avtp_Lin_GetMessageTimestamp(const Avtp_Lin_t *const pd
 }
 
 /**
- * Sets the value of an an ACF Message type field as specified in the IEEE 1722 Specification.
- *
- * @param pdu Pointer to the first bit of an 1722 ACF Lin PDU.
- * @param value Value to set the ACF Message Type field to.
- */
-OPEN1722_INLINE void Avtp_Lin_SetAcfMsgType(Avtp_Lin_t *pdu, uint8_t value)
-{
-    SET_LIN_FIELD(AVTP_LIN_FIELD_ACF_MSG_TYPE, value);
-}
-
-/**
  * Sets the value of an an ACF Message Length field as specified in the IEEE 1722 Specification.
  *
  * @param pdu Pointer to the first bit of an 1722 ACF Lin PDU.
@@ -193,7 +171,7 @@ OPEN1722_INLINE void Avtp_Lin_SetAcfMsgType(Avtp_Lin_t *pdu, uint8_t value)
  */
 OPEN1722_INLINE void Avtp_Lin_SetAcfMsgLength(Avtp_Lin_t *pdu, uint16_t value)
 {
-    SET_LIN_FIELD(AVTP_LIN_FIELD_ACF_MSG_LENGTH, value);
+    Avtp_AcfCommon_SetAcfMsgLength((Avtp_AcfCommon_t *)pdu, value);
 }
 
 /**
@@ -261,7 +239,7 @@ OPEN1722_INLINE void Avtp_Lin_SetMessageTimestamp(Avtp_Lin_t *pdu, uint64_t valu
  */
 OPEN1722_INLINE uint16_t Avtp_Lin_GetAcfMsgLengthInBytes(const Avtp_Lin_t *const pdu)
 {
-    return (uint16_t)GET_LIN_FIELD(AVTP_LIN_FIELD_ACF_MSG_LENGTH) * 4;
+    return (uint16_t)Avtp_AcfCommon_GetAcfMsgLength((const Avtp_AcfCommon_t *)pdu) * 4;
 }
 
 /**
@@ -336,7 +314,7 @@ OPEN1722_INLINE void Avtp_Lin_Init(Avtp_Lin_t *pdu)
 {
     if (pdu != NULL) {
         memset(pdu, 0, sizeof(Avtp_Lin_t));
-        Avtp_Lin_SetAcfMsgType(pdu, AVTP_ACF_TYPE_LIN);
+        Avtp_AcfCommon_SetAcfMsgType((Avtp_AcfCommon_t *)pdu, AVTP_ACF_TYPE_LIN);
     }
 }
 
@@ -389,7 +367,7 @@ OPEN1722_INLINE bool Avtp_Lin_IsValid(const Avtp_Lin_t *const pdu, size_t buffer
         return false;
     }
 
-    if (Avtp_Lin_GetAcfMsgType(pdu) != AVTP_ACF_TYPE_LIN) {
+    if (Avtp_AcfCommon_GetAcfMsgType((const Avtp_AcfCommon_t *)pdu) != AVTP_ACF_TYPE_LIN) {
         return false;
     }
 

--- a/include/avtp/acf/Lin.h
+++ b/include/avtp/acf/Lin.h
@@ -95,17 +95,6 @@ static const Avtp_FieldDescriptor_t Avtp_LinFieldDesc[AVTP_LIN_FIELD_MAX] = {
 };
 
 /**
- * Returns the value of an an ACF Message Length field as specified in the IEEE 1722 Specification.
- *
- * @param pdu Pointer to the first bit of an 1722 ACF Lin PDU.
- * @returns The value of the ACF Message Length field.
- */
-OPEN1722_INLINE uint16_t Avtp_Lin_GetAcfMsgLength(const Avtp_Lin_t *const pdu)
-{
-    return Avtp_AcfCommon_GetAcfMsgLength((const Avtp_AcfCommon_t *)pdu);
-}
-
-/**
  * Returns the value of an an ACF Lin PDU Pad field as specified in the IEEE 1722 Specification.
  *
  * @param pdu Pointer to the first bit of an 1722 ACF Lin PDU.
@@ -161,17 +150,6 @@ OPEN1722_INLINE uint8_t Avtp_Lin_GetLinIdentifier(const Avtp_Lin_t *const pdu)
 OPEN1722_INLINE uint64_t Avtp_Lin_GetMessageTimestamp(const Avtp_Lin_t *const pdu)
 {
     return (uint64_t)GET_LIN_FIELD(AVTP_LIN_FIELD_MESSAGE_TIMESTAMP);
-}
-
-/**
- * Sets the value of an an ACF Message Length field as specified in the IEEE 1722 Specification.
- *
- * @param pdu Pointer to the first bit of an 1722 ACF Lin PDU.
- * @param value Value to set the ACF Message Length field to.
- */
-OPEN1722_INLINE void Avtp_Lin_SetAcfMsgLength(Avtp_Lin_t *pdu, uint16_t value)
-{
-    Avtp_AcfCommon_SetAcfMsgLength((Avtp_AcfCommon_t *)pdu, value);
 }
 
 /**
@@ -232,17 +210,6 @@ OPEN1722_INLINE void Avtp_Lin_SetMessageTimestamp(Avtp_Lin_t *pdu, uint64_t valu
 }
 
 /**
- * Return the ACF message length in bytes.
- *
- * @param pdu Pointer to the first bit of an 1722 ACF Lin PDU.
- * @returns Length of the ACF message in bytes.
- */
-OPEN1722_INLINE uint16_t Avtp_Lin_GetAcfMsgLengthInBytes(const Avtp_Lin_t *const pdu)
-{
-    return (uint16_t)Avtp_AcfCommon_GetAcfMsgLength((const Avtp_AcfCommon_t *)pdu) * 4;
-}
-
-/**
  * Returns pointer to payload of an ACF Lin frame.
  *
  * @param lin_pdu Pointer to the first bit of an 1722 ACF Lin PDU.
@@ -283,7 +250,7 @@ OPEN1722_INLINE void Avtp_Lin_SetPayloadLength(Avtp_Lin_t *lin_pdu, uint16_t pay
     }
     uint16_t msgLenQuadlets = (uint16_t)((msgLenBytes + pad) / 4);
     Avtp_Lin_SetPad(lin_pdu, pad);
-    Avtp_Lin_SetAcfMsgLength(lin_pdu, msgLenQuadlets);
+    Avtp_AcfCommon_SetAcfMsgLength((Avtp_AcfCommon_t *)lin_pdu, msgLenQuadlets);
 }
 
 /**
@@ -301,7 +268,7 @@ OPEN1722_INLINE void Avtp_Lin_SetPayloadLength(Avtp_Lin_t *lin_pdu, uint16_t pay
 OPEN1722_INLINE uint8_t Avtp_Lin_GetPayloadLength(const Avtp_Lin_t *const pdu)
 {
     uint8_t pad_length = Avtp_Lin_GetPad(pdu);
-    uint16_t acf_length_bytes = Avtp_Lin_GetAcfMsgLengthInBytes(pdu);
+    uint16_t acf_length_bytes = Avtp_AcfCommon_GetAcfMsgLengthInBytes((const Avtp_AcfCommon_t *)pdu);
     return (uint8_t)(acf_length_bytes - AVTP_LIN_HEADER_LEN - pad_length);
 }
 
@@ -371,8 +338,7 @@ OPEN1722_INLINE bool Avtp_Lin_IsValid(const Avtp_Lin_t *const pdu, size_t buffer
         return false;
     }
 
-    // Avtp_Lin_GetAcfMsgLength returns quadlets. Convert the length field to octets.
-    uint16_t msg_length_bytes = (uint16_t)Avtp_Lin_GetAcfMsgLength(pdu) * 4;
+    uint16_t msg_length_bytes = Avtp_AcfCommon_GetAcfMsgLengthInBytes((const Avtp_AcfCommon_t *)pdu);
     if (msg_length_bytes > bufferSize) {
         return false;
     }

--- a/include/avtp/acf/Most.h
+++ b/include/avtp/acf/Most.h
@@ -368,7 +368,8 @@ OPEN1722_INLINE void Avtp_Most_SetPayloadLength(Avtp_Most_t *pdu, uint16_t paylo
 OPEN1722_INLINE uint8_t Avtp_Most_GetPayloadLength(const Avtp_Most_t *const pdu)
 {
     uint8_t pad_length = Avtp_Most_GetPad(pdu);
-    uint16_t acf_length_bytes = Avtp_AcfCommon_GetAcfMsgLengthInBytes((const Avtp_AcfCommon_t *)pdu);
+    uint16_t acf_length_bytes =
+        Avtp_AcfCommon_GetAcfMsgLengthInBytes((const Avtp_AcfCommon_t *)pdu);
     return (uint8_t)(acf_length_bytes - AVTP_MOST_HEADER_LEN - pad_length);
 }
 
@@ -443,7 +444,8 @@ OPEN1722_INLINE bool Avtp_Most_IsValid(const Avtp_Most_t *const pdu, size_t buff
         return false;
     }
 
-    uint16_t msg_length_bytes = Avtp_AcfCommon_GetAcfMsgLengthInBytes((const Avtp_AcfCommon_t *)pdu);
+    uint16_t msg_length_bytes =
+        Avtp_AcfCommon_GetAcfMsgLengthInBytes((const Avtp_AcfCommon_t *)pdu);
     if (msg_length_bytes > bufferSize) {
         return false;
     }

--- a/include/avtp/acf/Most.h
+++ b/include/avtp/acf/Most.h
@@ -107,17 +107,6 @@ static const Avtp_FieldDescriptor_t Avtp_MostFieldDesc[AVTP_MOST_FIELD_MAX] = {
 };
 
 /**
- * Return the value of an an ACF message type field as specified in the IEEE 1722 Specification.
- *
- * @param pdu Pointer to the first bit of an 1722 ACF Most PDU.
- * @returns Value of the ACF message type field.
- */
-OPEN1722_INLINE uint8_t Avtp_Most_GetAcfMsgType(const Avtp_Most_t *const pdu)
-{
-    return (uint8_t)GET_MOST_FIELD(AVTP_MOST_FIELD_ACF_MSG_TYPE);
-}
-
-/**
  * Return the value of an an ACF message length field as specified in the IEEE 1722 Specification.
  *
  * @param pdu Pointer to the first bit of an 1722 ACF Most PDU.
@@ -125,7 +114,7 @@ OPEN1722_INLINE uint8_t Avtp_Most_GetAcfMsgType(const Avtp_Most_t *const pdu)
  */
 OPEN1722_INLINE uint16_t Avtp_Most_GetAcfMsgLength(const Avtp_Most_t *const pdu)
 {
-    return (uint16_t)GET_MOST_FIELD(AVTP_MOST_FIELD_ACF_MSG_LENGTH);
+    return Avtp_AcfCommon_GetAcfMsgLength((const Avtp_AcfCommon_t *)pdu);
 }
 
 /**
@@ -232,17 +221,6 @@ OPEN1722_INLINE uint8_t Avtp_Most_GetOpType(const Avtp_Most_t *const pdu)
 }
 
 /**
- * Set the value of an an ACF message type field as specified in the IEEE 1722 Specification.
- *
- * @param pdu Pointer to the first bit of an 1722 ACF Most PDU.
- * @param value Value to set the ACF message type field to.
- */
-OPEN1722_INLINE void Avtp_Most_SetAcfMsgType(Avtp_Most_t *pdu, uint8_t value)
-{
-    SET_MOST_FIELD(AVTP_MOST_FIELD_ACF_MSG_TYPE, value);
-}
-
-/**
  * Set the value of an an ACF message length field as specified in the IEEE 1722 Specification.
  *
  * @param pdu Pointer to the first bit of an 1722 ACF Most PDU.
@@ -250,7 +228,7 @@ OPEN1722_INLINE void Avtp_Most_SetAcfMsgType(Avtp_Most_t *pdu, uint8_t value)
  */
 OPEN1722_INLINE void Avtp_Most_SetAcfMsgLength(Avtp_Most_t *pdu, uint16_t value)
 {
-    SET_MOST_FIELD(AVTP_MOST_FIELD_ACF_MSG_LENGTH, value);
+    Avtp_AcfCommon_SetAcfMsgLength((Avtp_AcfCommon_t *)pdu, value);
 }
 
 /**
@@ -362,7 +340,7 @@ OPEN1722_INLINE void Avtp_Most_SetOpType(Avtp_Most_t *pdu, uint8_t value)
  */
 OPEN1722_INLINE uint16_t Avtp_Most_GetAcfMsgLengthInBytes(const Avtp_Most_t *const pdu)
 {
-    return (uint16_t)GET_MOST_FIELD(AVTP_MOST_FIELD_ACF_MSG_LENGTH) * 4;
+    return (uint16_t)Avtp_AcfCommon_GetAcfMsgLength((const Avtp_AcfCommon_t *)pdu) * 4;
 }
 
 /**
@@ -436,7 +414,7 @@ OPEN1722_INLINE void Avtp_Most_Init(Avtp_Most_t *pdu)
 {
     if (pdu != NULL) {
         memset(pdu, 0, sizeof(Avtp_Most_t));
-        Avtp_Most_SetAcfMsgType(pdu, AVTP_ACF_TYPE_MOST);
+        Avtp_AcfCommon_SetAcfMsgType((Avtp_AcfCommon_t *)pdu, AVTP_ACF_TYPE_MOST);
     }
 }
 
@@ -494,7 +472,7 @@ OPEN1722_INLINE bool Avtp_Most_IsValid(const Avtp_Most_t *const pdu, size_t buff
         return false;
     }
 
-    if (Avtp_Most_GetAcfMsgType(pdu) != AVTP_ACF_TYPE_MOST) {
+    if (Avtp_AcfCommon_GetAcfMsgType((const Avtp_AcfCommon_t *)pdu) != AVTP_ACF_TYPE_MOST) {
         return false;
     }
 

--- a/include/avtp/acf/Most.h
+++ b/include/avtp/acf/Most.h
@@ -107,17 +107,6 @@ static const Avtp_FieldDescriptor_t Avtp_MostFieldDesc[AVTP_MOST_FIELD_MAX] = {
 };
 
 /**
- * Return the value of an an ACF message length field as specified in the IEEE 1722 Specification.
- *
- * @param pdu Pointer to the first bit of an 1722 ACF Most PDU.
- * @returns Value of the ACF message length field.
- */
-OPEN1722_INLINE uint16_t Avtp_Most_GetAcfMsgLength(const Avtp_Most_t *const pdu)
-{
-    return Avtp_AcfCommon_GetAcfMsgLength((const Avtp_AcfCommon_t *)pdu);
-}
-
-/**
  * Return the value of an an ACF Most PDU padding field as specified in the IEEE 1722 Specification.
  *
  * @param pdu Pointer to the first bit of an 1722 ACF Most PDU.
@@ -218,17 +207,6 @@ OPEN1722_INLINE uint16_t Avtp_Most_GetFuncId(const Avtp_Most_t *const pdu)
 OPEN1722_INLINE uint8_t Avtp_Most_GetOpType(const Avtp_Most_t *const pdu)
 {
     return (uint8_t)GET_MOST_FIELD(AVTP_MOST_FIELD_OP_TYPE);
-}
-
-/**
- * Set the value of an an ACF message length field as specified in the IEEE 1722 Specification.
- *
- * @param pdu Pointer to the first bit of an 1722 ACF Most PDU.
- * @param value Value to set the ACF message length field to.
- */
-OPEN1722_INLINE void Avtp_Most_SetAcfMsgLength(Avtp_Most_t *pdu, uint16_t value)
-{
-    Avtp_AcfCommon_SetAcfMsgLength((Avtp_AcfCommon_t *)pdu, value);
 }
 
 /**
@@ -333,17 +311,6 @@ OPEN1722_INLINE void Avtp_Most_SetOpType(Avtp_Most_t *pdu, uint8_t value)
 }
 
 /**
- * Return the ACF message length in bytes.
- *
- * @param pdu Pointer to the first bit of an 1722 ACF Most PDU.
- * @returns Length of the ACF message in bytes.
- */
-OPEN1722_INLINE uint16_t Avtp_Most_GetAcfMsgLengthInBytes(const Avtp_Most_t *const pdu)
-{
-    return (uint16_t)Avtp_AcfCommon_GetAcfMsgLength((const Avtp_AcfCommon_t *)pdu) * 4;
-}
-
-/**
  * Returns pointer to payload of an ACF Most frame.
  *
  * @param pdu Pointer to the first bit of an 1722 ACF Most PDU.
@@ -384,7 +351,7 @@ OPEN1722_INLINE void Avtp_Most_SetPayloadLength(Avtp_Most_t *pdu, uint16_t paylo
     }
     uint16_t msgLenQuadlets = (uint16_t)((msgLenBytes + pad) / 4);
     Avtp_Most_SetPad(pdu, pad);
-    Avtp_Most_SetAcfMsgLength(pdu, msgLenQuadlets);
+    Avtp_AcfCommon_SetAcfMsgLength((Avtp_AcfCommon_t *)pdu, msgLenQuadlets);
 }
 
 /**
@@ -401,7 +368,7 @@ OPEN1722_INLINE void Avtp_Most_SetPayloadLength(Avtp_Most_t *pdu, uint16_t paylo
 OPEN1722_INLINE uint8_t Avtp_Most_GetPayloadLength(const Avtp_Most_t *const pdu)
 {
     uint8_t pad_length = Avtp_Most_GetPad(pdu);
-    uint16_t acf_length_bytes = Avtp_Most_GetAcfMsgLengthInBytes(pdu);
+    uint16_t acf_length_bytes = Avtp_AcfCommon_GetAcfMsgLengthInBytes((const Avtp_AcfCommon_t *)pdu);
     return (uint8_t)(acf_length_bytes - AVTP_MOST_HEADER_LEN - pad_length);
 }
 
@@ -476,8 +443,7 @@ OPEN1722_INLINE bool Avtp_Most_IsValid(const Avtp_Most_t *const pdu, size_t buff
         return false;
     }
 
-    // Avtp_Most_GetAcfMsgLength returns quadlets. Convert the length field to octets.
-    uint16_t msg_length_bytes = (uint16_t)Avtp_Most_GetAcfMsgLength(pdu) * 4;
+    uint16_t msg_length_bytes = Avtp_AcfCommon_GetAcfMsgLengthInBytes((const Avtp_AcfCommon_t *)pdu);
     if (msg_length_bytes > bufferSize) {
         return false;
     }

--- a/include/avtp/acf/Sensor.h
+++ b/include/avtp/acf/Sensor.h
@@ -350,7 +350,8 @@ OPEN1722_INLINE bool Avtp_Sensor_IsValid(const Avtp_Sensor_t *const pdu, size_t 
         return false;
     }
 
-    uint16_t msg_length_bytes = Avtp_AcfCommon_GetAcfMsgLengthInBytes((const Avtp_AcfCommon_t *)pdu);
+    uint16_t msg_length_bytes =
+        Avtp_AcfCommon_GetAcfMsgLengthInBytes((const Avtp_AcfCommon_t *)pdu);
     if (msg_length_bytes > bufferSize) {
         return false;
     }

--- a/include/avtp/acf/Sensor.h
+++ b/include/avtp/acf/Sensor.h
@@ -96,28 +96,6 @@ static const Avtp_FieldDescriptor_t Avtp_SensorFieldDesc[AVTP_SENSOR_FIELD_MAX] 
 };
 
 /**
- * Return the value of the ACF message length field as specified in the IEEE 1722 Specification.
- *
- * @param pdu Pointer to the first bit of an 1722 ACF Sensor PDU.
- * @returns Value of the ACF message length field.
- */
-OPEN1722_INLINE uint16_t Avtp_Sensor_GetAcfMsgLength(const Avtp_Sensor_t *const pdu)
-{
-    return Avtp_AcfCommon_GetAcfMsgLength((const Avtp_AcfCommon_t *)pdu);
-}
-
-/**
- * Return the ACF message length in bytes.
- *
- * @param pdu Pointer to the first bit of an 1722 ACF Sensor PDU.
- * @returns Length of the ACF message in bytes.
- */
-OPEN1722_INLINE uint16_t Avtp_Sensor_GetAcfMsgLengthInBytes(const Avtp_Sensor_t *const pdu)
-{
-    return (uint16_t)Avtp_AcfCommon_GetAcfMsgLength((const Avtp_AcfCommon_t *)pdu) * 4;
-}
-
-/**
  * Return the value of the ACF Sensor MTV field as specified in the IEEE 1722 Specification.
  *
  * @param pdu Pointer to the first bit of an 1722 ACF Sensor PDU.
@@ -172,17 +150,6 @@ OPEN1722_INLINE uint8_t Avtp_Sensor_GetSensorGroup(const Avtp_Sensor_t *const pd
 OPEN1722_INLINE uint64_t Avtp_Sensor_GetMessageTimestamp(const Avtp_Sensor_t *const pdu)
 {
     return (uint64_t)GET_SENSOR_FIELD(AVTP_SENSOR_FIELD_MESSAGE_TIMESTAMP);
-}
-
-/**
- * Set the value of the ACF message length field as specified in the IEEE 1722 Specification.
- *
- * @param pdu Pointer to the first bit of an 1722 ACF Sensor PDU.
- * @param value Value to set the ACF message length field.
- */
-OPEN1722_INLINE void Avtp_Sensor_SetAcfMsgLength(Avtp_Sensor_t *pdu, uint16_t value)
-{
-    Avtp_AcfCommon_SetAcfMsgLength((Avtp_AcfCommon_t *)pdu, value);
 }
 
 /**
@@ -291,7 +258,7 @@ OPEN1722_INLINE void Avtp_Sensor_SetPayloadLength(Avtp_Sensor_t *pdu, uint16_t p
         memset(pdu->payload + payload_length, 0, pad);
     }
     uint16_t msgLenQuadlets = (uint16_t)((msgLenBytes + pad) / 4);
-    Avtp_Sensor_SetAcfMsgLength(pdu, msgLenQuadlets);
+    Avtp_AcfCommon_SetAcfMsgLength((Avtp_AcfCommon_t *)pdu, msgLenQuadlets);
 }
 
 /**
@@ -383,8 +350,7 @@ OPEN1722_INLINE bool Avtp_Sensor_IsValid(const Avtp_Sensor_t *const pdu, size_t 
         return false;
     }
 
-    // Avtp_Sensor_GetAcfMsgLength returns quadlets. Convert the length field to octets.
-    uint16_t msg_length_bytes = (uint16_t)Avtp_Sensor_GetAcfMsgLength(pdu) * 4;
+    uint16_t msg_length_bytes = Avtp_AcfCommon_GetAcfMsgLengthInBytes((const Avtp_AcfCommon_t *)pdu);
     if (msg_length_bytes > bufferSize) {
         return false;
     }

--- a/include/avtp/acf/Sensor.h
+++ b/include/avtp/acf/Sensor.h
@@ -96,17 +96,6 @@ static const Avtp_FieldDescriptor_t Avtp_SensorFieldDesc[AVTP_SENSOR_FIELD_MAX] 
 };
 
 /**
- * Return the value of the ACF message type field as specified in the IEEE 1722 Specification.
- *
- * @param pdu Pointer to the first bit of an 1722 ACF Sensor PDU.
- * @returns Value of the ACF message type field.
- */
-OPEN1722_INLINE uint8_t Avtp_Sensor_GetAcfMsgType(const Avtp_Sensor_t *const pdu)
-{
-    return (uint8_t)GET_SENSOR_FIELD(AVTP_SENSOR_FIELD_ACF_MSG_TYPE);
-}
-
-/**
  * Return the value of the ACF message length field as specified in the IEEE 1722 Specification.
  *
  * @param pdu Pointer to the first bit of an 1722 ACF Sensor PDU.
@@ -114,7 +103,7 @@ OPEN1722_INLINE uint8_t Avtp_Sensor_GetAcfMsgType(const Avtp_Sensor_t *const pdu
  */
 OPEN1722_INLINE uint16_t Avtp_Sensor_GetAcfMsgLength(const Avtp_Sensor_t *const pdu)
 {
-    return (uint16_t)GET_SENSOR_FIELD(AVTP_SENSOR_FIELD_ACF_MSG_LENGTH);
+    return Avtp_AcfCommon_GetAcfMsgLength((const Avtp_AcfCommon_t *)pdu);
 }
 
 /**
@@ -125,7 +114,7 @@ OPEN1722_INLINE uint16_t Avtp_Sensor_GetAcfMsgLength(const Avtp_Sensor_t *const 
  */
 OPEN1722_INLINE uint16_t Avtp_Sensor_GetAcfMsgLengthInBytes(const Avtp_Sensor_t *const pdu)
 {
-    return (uint16_t)GET_SENSOR_FIELD(AVTP_SENSOR_FIELD_ACF_MSG_LENGTH) * 4;
+    return (uint16_t)Avtp_AcfCommon_GetAcfMsgLength((const Avtp_AcfCommon_t *)pdu) * 4;
 }
 
 /**
@@ -186,17 +175,6 @@ OPEN1722_INLINE uint64_t Avtp_Sensor_GetMessageTimestamp(const Avtp_Sensor_t *co
 }
 
 /**
- * Set the value of the ACF message type field as specified in the IEEE 1722 Specification.
- *
- * @param pdu Pointer to the first bit of an 1722 ACF Sensor PDU.
- * @param value Value to set the ACF message type field.
- */
-OPEN1722_INLINE void Avtp_Sensor_SetAcfMsgType(Avtp_Sensor_t *pdu, uint8_t value)
-{
-    SET_SENSOR_FIELD(AVTP_SENSOR_FIELD_ACF_MSG_TYPE, value);
-}
-
-/**
  * Set the value of the ACF message length field as specified in the IEEE 1722 Specification.
  *
  * @param pdu Pointer to the first bit of an 1722 ACF Sensor PDU.
@@ -204,7 +182,7 @@ OPEN1722_INLINE void Avtp_Sensor_SetAcfMsgType(Avtp_Sensor_t *pdu, uint8_t value
  */
 OPEN1722_INLINE void Avtp_Sensor_SetAcfMsgLength(Avtp_Sensor_t *pdu, uint16_t value)
 {
-    SET_SENSOR_FIELD(AVTP_SENSOR_FIELD_ACF_MSG_LENGTH, value);
+    Avtp_AcfCommon_SetAcfMsgLength((Avtp_AcfCommon_t *)pdu, value);
 }
 
 /**
@@ -350,7 +328,7 @@ OPEN1722_INLINE void Avtp_Sensor_Init(Avtp_Sensor_t *pdu)
 {
     if (pdu != NULL) {
         memset(pdu, 0, sizeof(Avtp_Sensor_t));
-        Avtp_Sensor_SetAcfMsgType(pdu, AVTP_ACF_TYPE_SENSOR);
+        Avtp_AcfCommon_SetAcfMsgType((Avtp_AcfCommon_t *)pdu, AVTP_ACF_TYPE_SENSOR);
     }
 }
 
@@ -401,7 +379,7 @@ OPEN1722_INLINE bool Avtp_Sensor_IsValid(const Avtp_Sensor_t *const pdu, size_t 
         return false;
     }
 
-    if (Avtp_Sensor_GetAcfMsgType(pdu) != AVTP_ACF_TYPE_SENSOR) {
+    if (Avtp_AcfCommon_GetAcfMsgType((const Avtp_AcfCommon_t *)pdu) != AVTP_ACF_TYPE_SENSOR) {
         return false;
     }
 

--- a/include/avtp/acf/SensorBrief.h
+++ b/include/avtp/acf/SensorBrief.h
@@ -93,17 +93,6 @@ static const Avtp_FieldDescriptor_t Avtp_SensorBriefFieldDesc[AVTP_SENSOR_BRIEF_
 };
 
 /**
- * Return the value of the ACF message type field as specified in the IEEE 1722 Specification.
- *
- * @param pdu Pointer to the first bit of an 1722 ACF SensorBrief PDU.
- * @returns Value of the ACF message type field.
- */
-OPEN1722_INLINE uint8_t Avtp_SensorBrief_GetAcfMsgType(const Avtp_SensorBrief_t *const pdu)
-{
-    return (uint8_t)GET_SENSOR_BRIEF_FIELD(AVTP_SENSOR_BRIEF_FIELD_ACF_MSG_TYPE);
-}
-
-/**
  * Return the value of the ACF message length field as specified in the IEEE 1722 Specification.
  *
  * @param pdu Pointer to the first bit of an 1722 ACF SensorBrief PDU.
@@ -111,7 +100,7 @@ OPEN1722_INLINE uint8_t Avtp_SensorBrief_GetAcfMsgType(const Avtp_SensorBrief_t 
  */
 OPEN1722_INLINE uint16_t Avtp_SensorBrief_GetAcfMsgLength(const Avtp_SensorBrief_t *const pdu)
 {
-    return (uint16_t)GET_SENSOR_BRIEF_FIELD(AVTP_SENSOR_BRIEF_FIELD_ACF_MSG_LENGTH);
+    return Avtp_AcfCommon_GetAcfMsgLength((const Avtp_AcfCommon_t *)pdu);
 }
 
 /**
@@ -123,7 +112,7 @@ OPEN1722_INLINE uint16_t Avtp_SensorBrief_GetAcfMsgLength(const Avtp_SensorBrief
 OPEN1722_INLINE uint16_t
 Avtp_SensorBrief_GetAcfMsgLengthInBytes(const Avtp_SensorBrief_t *const pdu)
 {
-    return (uint16_t)GET_SENSOR_BRIEF_FIELD(AVTP_SENSOR_BRIEF_FIELD_ACF_MSG_LENGTH) * 4;
+    return (uint16_t)Avtp_AcfCommon_GetAcfMsgLength((const Avtp_AcfCommon_t *)pdu) * 4;
 }
 
 /**
@@ -173,17 +162,6 @@ OPEN1722_INLINE uint8_t Avtp_SensorBrief_GetSensorGroup(const Avtp_SensorBrief_t
 }
 
 /**
- * Sets the value of the ACF message type field as specified in the IEEE 1722 Specification.
- *
- * @param pdu Pointer to the first bit of an 1722 ACF SensorBrief PDU.
- * @param value Value to set the ACF message type field to.
- */
-OPEN1722_INLINE void Avtp_SensorBrief_SetAcfMsgType(Avtp_SensorBrief_t *pdu, uint8_t value)
-{
-    SET_SENSOR_BRIEF_FIELD(AVTP_SENSOR_BRIEF_FIELD_ACF_MSG_TYPE, value);
-}
-
-/**
  * Sets the value of the ACF message length field as specified in the IEEE 1722 Specification.
  *
  * @param pdu Pointer to the first bit of an 1722 ACF SensorBrief PDU.
@@ -191,7 +169,7 @@ OPEN1722_INLINE void Avtp_SensorBrief_SetAcfMsgType(Avtp_SensorBrief_t *pdu, uin
  */
 OPEN1722_INLINE void Avtp_SensorBrief_SetAcfMsgLength(Avtp_SensorBrief_t *pdu, uint16_t value)
 {
-    SET_SENSOR_BRIEF_FIELD(AVTP_SENSOR_BRIEF_FIELD_ACF_MSG_LENGTH, value);
+    Avtp_AcfCommon_SetAcfMsgLength((Avtp_AcfCommon_t *)pdu, value);
 }
 
 /**
@@ -328,7 +306,7 @@ OPEN1722_INLINE void Avtp_SensorBrief_Init(Avtp_SensorBrief_t *pdu)
 {
     if (pdu != NULL) {
         memset(pdu, 0, sizeof(Avtp_SensorBrief_t));
-        Avtp_SensorBrief_SetAcfMsgType(pdu, AVTP_ACF_TYPE_SENSOR_BRIEF);
+        Avtp_AcfCommon_SetAcfMsgType((Avtp_AcfCommon_t *)pdu, AVTP_ACF_TYPE_SENSOR_BRIEF);
     }
 }
 
@@ -380,7 +358,7 @@ OPEN1722_INLINE bool Avtp_SensorBrief_IsValid(const Avtp_SensorBrief_t *const pd
         return false;
     }
 
-    if (Avtp_SensorBrief_GetAcfMsgType(pdu) != AVTP_ACF_TYPE_SENSOR_BRIEF) {
+    if (Avtp_AcfCommon_GetAcfMsgType((const Avtp_AcfCommon_t *)pdu) != AVTP_ACF_TYPE_SENSOR_BRIEF) {
         return false;
     }
 

--- a/include/avtp/acf/SensorBrief.h
+++ b/include/avtp/acf/SensorBrief.h
@@ -93,29 +93,6 @@ static const Avtp_FieldDescriptor_t Avtp_SensorBriefFieldDesc[AVTP_SENSOR_BRIEF_
 };
 
 /**
- * Return the value of the ACF message length field as specified in the IEEE 1722 Specification.
- *
- * @param pdu Pointer to the first bit of an 1722 ACF SensorBrief PDU.
- * @returns Value of the ACF message length field.
- */
-OPEN1722_INLINE uint16_t Avtp_SensorBrief_GetAcfMsgLength(const Avtp_SensorBrief_t *const pdu)
-{
-    return Avtp_AcfCommon_GetAcfMsgLength((const Avtp_AcfCommon_t *)pdu);
-}
-
-/**
- * Return the ACF message length in bytes.
- *
- * @param pdu Pointer to the first bit of an 1722 ACF SensorBrief PDU.
- * @returns Length of the ACF message in bytes.
- */
-OPEN1722_INLINE uint16_t
-Avtp_SensorBrief_GetAcfMsgLengthInBytes(const Avtp_SensorBrief_t *const pdu)
-{
-    return (uint16_t)Avtp_AcfCommon_GetAcfMsgLength((const Avtp_AcfCommon_t *)pdu) * 4;
-}
-
-/**
  * Return the value of the ACF SensorBrief MTV field as specified in the IEEE 1722 Specification.
  *
  * @param pdu Pointer to the first bit of an 1722 ACF SensorBrief PDU.
@@ -159,17 +136,6 @@ OPEN1722_INLINE uint8_t Avtp_SensorBrief_GetSz(const Avtp_SensorBrief_t *const p
 OPEN1722_INLINE uint8_t Avtp_SensorBrief_GetSensorGroup(const Avtp_SensorBrief_t *const pdu)
 {
     return (uint8_t)GET_SENSOR_BRIEF_FIELD(AVTP_SENSOR_BRIEF_FIELD_SENSOR_GROUP);
-}
-
-/**
- * Sets the value of the ACF message length field as specified in the IEEE 1722 Specification.
- *
- * @param pdu Pointer to the first bit of an 1722 ACF SensorBrief PDU.
- * @param value Value to set the ACF message length field to.
- */
-OPEN1722_INLINE void Avtp_SensorBrief_SetAcfMsgLength(Avtp_SensorBrief_t *pdu, uint16_t value)
-{
-    Avtp_AcfCommon_SetAcfMsgLength((Avtp_AcfCommon_t *)pdu, value);
 }
 
 /**
@@ -269,7 +235,7 @@ OPEN1722_INLINE void Avtp_SensorBrief_SetPayloadLength(Avtp_SensorBrief_t *pdu,
         memset(pdu->payload + payload_length, 0, pad);
     }
     uint16_t msgLenQuadlets = (uint16_t)((msgLenBytes + pad) / 4);
-    Avtp_SensorBrief_SetAcfMsgLength(pdu, msgLenQuadlets);
+    Avtp_AcfCommon_SetAcfMsgLength((Avtp_AcfCommon_t *)pdu, msgLenQuadlets);
 }
 
 /**
@@ -362,8 +328,7 @@ OPEN1722_INLINE bool Avtp_SensorBrief_IsValid(const Avtp_SensorBrief_t *const pd
         return false;
     }
 
-    // Avtp_SensorBrief_GetAcfMsgLength returns quadlets. Convert the length field to octets.
-    uint16_t msg_length_bytes = (uint16_t)Avtp_SensorBrief_GetAcfMsgLength(pdu) * 4;
+    uint16_t msg_length_bytes = Avtp_AcfCommon_GetAcfMsgLengthInBytes((const Avtp_AcfCommon_t *)pdu);
     if (msg_length_bytes > bufferSize) {
         return false;
     }

--- a/include/avtp/acf/SensorBrief.h
+++ b/include/avtp/acf/SensorBrief.h
@@ -328,7 +328,8 @@ OPEN1722_INLINE bool Avtp_SensorBrief_IsValid(const Avtp_SensorBrief_t *const pd
         return false;
     }
 
-    uint16_t msg_length_bytes = Avtp_AcfCommon_GetAcfMsgLengthInBytes((const Avtp_AcfCommon_t *)pdu);
+    uint16_t msg_length_bytes =
+        Avtp_AcfCommon_GetAcfMsgLengthInBytes((const Avtp_AcfCommon_t *)pdu);
     if (msg_length_bytes > bufferSize) {
         return false;
     }

--- a/include/avtp/acf/custom/Vss.h
+++ b/include/avtp/acf/custom/Vss.h
@@ -242,7 +242,6 @@ void Avtp_Vss_SetField(Avtp_Vss_t *pdu, Avtp_VssFields_t field, uint64_t value);
 void Avtp_Vss_SetPayloadLength(Avtp_Vss_t *pdu, uint16_t payload_length);
 
 /* Getter and Setter Functions*/
-uint16_t Avtp_Vss_GetAcfMsgLength(const Avtp_Vss_t *const pdu);
 uint8_t Avtp_Vss_GetPad(const Avtp_Vss_t *const pdu);
 bool Avtp_Vss_IsMtv(const Avtp_Vss_t *const pdu);
 Vss_AddrMode_t Avtp_Vss_GetAddrMode(const Avtp_Vss_t *const pdu);
@@ -255,7 +254,6 @@ uint16_t Avtp_Vss_GetVSSDataStringArrayLength(const VssDataStringArray_t *str_ar
 uint16_t Avtp_Vss_CalcVssPathLength(const Avtp_Vss_t *const pdu);
 void Avtp_Vss_DeserializeStringArray(const VssDataStringArray_t *const vss_data_string_array,
                                      VssDataString_t *strings[], uint16_t num_strings);
-void Avtp_Vss_SetAcfMsgLength(Avtp_Vss_t *pdu, uint16_t val);
 void Avtp_Vss_SetPad(Avtp_Vss_t *pdu, uint8_t val);
 void Avtp_Vss_SetMtv(Avtp_Vss_t *pdu, bool mtv);
 void Avtp_Vss_SetAddrMode(Avtp_Vss_t *pdu, Vss_AddrMode_t val);

--- a/include/avtp/acf/custom/Vss.h
+++ b/include/avtp/acf/custom/Vss.h
@@ -242,7 +242,6 @@ void Avtp_Vss_SetField(Avtp_Vss_t *pdu, Avtp_VssFields_t field, uint64_t value);
 void Avtp_Vss_SetPayloadLength(Avtp_Vss_t *pdu, uint16_t payload_length);
 
 /* Getter and Setter Functions*/
-Avtp_AcfMsgType_t Avtp_Vss_GetAcfMsgType(const Avtp_Vss_t *const pdu);
 uint16_t Avtp_Vss_GetAcfMsgLength(const Avtp_Vss_t *const pdu);
 uint8_t Avtp_Vss_GetPad(const Avtp_Vss_t *const pdu);
 bool Avtp_Vss_IsMtv(const Avtp_Vss_t *const pdu);
@@ -256,7 +255,6 @@ uint16_t Avtp_Vss_GetVSSDataStringArrayLength(const VssDataStringArray_t *str_ar
 uint16_t Avtp_Vss_CalcVssPathLength(const Avtp_Vss_t *const pdu);
 void Avtp_Vss_DeserializeStringArray(const VssDataStringArray_t *const vss_data_string_array,
                                      VssDataString_t *strings[], uint16_t num_strings);
-void Avtp_Vss_SetAcfMsgType(Avtp_Vss_t *pdu, Avtp_AcfMsgType_t val);
 void Avtp_Vss_SetAcfMsgLength(Avtp_Vss_t *pdu, uint16_t val);
 void Avtp_Vss_SetPad(Avtp_Vss_t *pdu, uint8_t val);
 void Avtp_Vss_SetMtv(Avtp_Vss_t *pdu, bool mtv);

--- a/src/avtp/acf/custom/Vss.c
+++ b/src/avtp/acf/custom/Vss.c
@@ -166,11 +166,6 @@ void Avtp_Vss_SetPayloadLength(Avtp_Vss_t *vss_pdu, uint16_t payload_length)
     Avtp_Vss_SetField(vss_pdu, AVTP_VSS_FIELD_PAD, padSize);
 }
 
-Avtp_AcfMsgType_t Avtp_Vss_GetAcfMsgType(const Avtp_Vss_t *const pdu)
-{
-    return GET_FIELD(AVTP_VSS_FIELD_ACF_MSG_TYPE);
-}
-
 uint16_t Avtp_Vss_GetAcfMsgLength(const Avtp_Vss_t *const pdu)
 {
     return (uint16_t)GET_FIELD(AVTP_VSS_FIELD_ACF_MSG_LENGTH);
@@ -513,11 +508,6 @@ void Avtp_Vss_GetVssData(const Avtp_Vss_t *const pdu, VssData_t *val)
     default:
         break;
     }
-}
-
-void Avtp_Vss_SetAcfMsgType(Avtp_Vss_t *pdu, Avtp_AcfMsgType_t val)
-{
-    SET_FIELD(AVTP_VSS_FIELD_ACF_MSG_TYPE, val);
 }
 
 void Avtp_Vss_SetAcfMsgLength(Avtp_Vss_t *pdu, uint16_t val)

--- a/src/avtp/acf/custom/Vss.c
+++ b/src/avtp/acf/custom/Vss.c
@@ -67,7 +67,7 @@ static const Avtp_FieldDescriptor_t Avtp_VssFieldDesc[AVTP_VSS_FIELD_MAX] = {
  * past the PDU start. */
 static uint16_t vss_read_clamped_length(const Avtp_Vss_t *pdu, const uint8_t *ptr)
 {
-    uint16_t declared = (uint16_t)Avtp_Vss_GetAcfMsgLength(pdu) * AVTP_QUADLET_SIZE;
+    uint16_t declared = Avtp_AcfCommon_GetAcfMsgLengthInBytes((const Avtp_AcfCommon_t *)pdu);
     uint32_t offset = (uint32_t)(ptr - (const uint8_t *)pdu);
 
     /* The 2‑byte length prefix must fit within the declared PDU. */
@@ -95,7 +95,7 @@ static uint16_t vss_read_clamped_length(const Avtp_Vss_t *pdu, const uint8_t *pt
  * frame.  */
 static uint16_t vss_get_clamped_path_length(const Avtp_Vss_t *pdu)
 {
-    uint16_t declared = (uint16_t)Avtp_Vss_GetAcfMsgLength(pdu) * AVTP_QUADLET_SIZE;
+    uint16_t declared = Avtp_AcfCommon_GetAcfMsgLengthInBytes((const Avtp_AcfCommon_t *)pdu);
     Vss_AddrMode_t mode = Avtp_Vss_GetAddrMode(pdu);
 
     if (mode == VSS_STATIC_ID_MODE) {
@@ -119,7 +119,7 @@ static uint16_t vss_get_clamped_path_length(const Avtp_Vss_t *pdu)
  * GetVssData when the data pointer sits at or past the frame end. */
 static bool vss_has_bytes(const Avtp_Vss_t *pdu, const uint8_t *ptr, uint16_t num_bytes)
 {
-    uint16_t declared = (uint16_t)Avtp_Vss_GetAcfMsgLength(pdu) * AVTP_QUADLET_SIZE;
+    uint16_t declared = Avtp_AcfCommon_GetAcfMsgLengthInBytes((const Avtp_AcfCommon_t *)pdu);
     return (uint32_t)(ptr - (const uint8_t *)pdu) + num_bytes <= declared;
 }
 
@@ -164,11 +164,6 @@ void Avtp_Vss_SetPayloadLength(Avtp_Vss_t *vss_pdu, uint16_t payload_length)
     Avtp_Vss_SetField(vss_pdu, AVTP_VSS_FIELD_ACF_MSG_LENGTH,
                       (uint64_t)(padded_length / AVTP_QUADLET_SIZE));
     Avtp_Vss_SetField(vss_pdu, AVTP_VSS_FIELD_PAD, padSize);
-}
-
-uint16_t Avtp_Vss_GetAcfMsgLength(const Avtp_Vss_t *const pdu)
-{
-    return (uint16_t)GET_FIELD(AVTP_VSS_FIELD_ACF_MSG_LENGTH);
 }
 
 uint8_t Avtp_Vss_GetPad(const Avtp_Vss_t *const pdu)
@@ -508,11 +503,6 @@ void Avtp_Vss_GetVssData(const Avtp_Vss_t *const pdu, VssData_t *val)
     default:
         break;
     }
-}
-
-void Avtp_Vss_SetAcfMsgLength(Avtp_Vss_t *pdu, uint16_t val)
-{
-    SET_FIELD(AVTP_VSS_FIELD_ACF_MSG_LENGTH, val);
 }
 
 void Avtp_Vss_SetPad(Avtp_Vss_t *pdu, uint8_t val)

--- a/unit/test-abb.c
+++ b/unit/test-abb.c
@@ -366,7 +366,8 @@ static void Test_Abb_CreateAcfMessage(void **state)
 
     Avtp_Abb_CreateAcfMessage(abb, 0x5FF, true, 0xBF, payload, sizeof(payload));
 
-    assert_int_equal(Avtp_AcfCommon_GetAcfMsgType((Avtp_AcfCommon_t *)abb), AVTP_ACF_TYPE_BYTE_BUS_BRIEF);
+    assert_int_equal(Avtp_AcfCommon_GetAcfMsgType((Avtp_AcfCommon_t *)abb),
+                     AVTP_ACF_TYPE_BYTE_BUS_BRIEF);
     assert_int_equal(Avtp_Abb_GetByteBusId(abb), 0x5FF);
     assert_int_equal(Avtp_Abb_IsOp(abb), true);
     assert_int_equal(Avtp_Abb_GetTransactionNum(abb), 0xBF);
@@ -385,7 +386,8 @@ static void Test_Abb_CreateFromGarbage(void **state)
     memset(msg, 0xAA, msg_len);
     Avtp_Abb_CreateAcfMessage(abb, 0x5FF, true, 0xBF, payload, sizeof(payload));
 
-    assert_int_equal(Avtp_AcfCommon_GetAcfMsgType((Avtp_AcfCommon_t *)abb), AVTP_ACF_TYPE_BYTE_BUS_BRIEF);
+    assert_int_equal(Avtp_AcfCommon_GetAcfMsgType((Avtp_AcfCommon_t *)abb),
+                     AVTP_ACF_TYPE_BYTE_BUS_BRIEF);
     assert_int_equal(Avtp_Abb_IsMtv(abb), false);
     assert_int_equal(Avtp_Abb_IsHs(abb), false);
     assert_int_equal(Avtp_Abb_IsCs(abb), false);

--- a/unit/test-abb.c
+++ b/unit/test-abb.c
@@ -55,14 +55,6 @@ static void Test_Abb_Init(void **state)
     assert_memory_equal(msg, expected_msg, msg_len);
 }
 
-static void Test_Abb_GetAcfMsgLength(void **state)
-{
-    const size_t msg_len = AVTP_ABB_HEADER_LEN + 4;
-    uint8_t msg[msg_len] = {0x1C, 0x02, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0};
-    Avtp_Abb_t *abb = (Avtp_Abb_t *)msg;
-    assert_int_equal(Avtp_Abb_GetAcfMsgLength(abb), 2);
-}
-
 static void Test_Abb_GetPad(void **state)
 {
     const size_t msg_len = AVTP_ABB_HEADER_LEN + 4;
@@ -181,25 +173,6 @@ static void Test_Abb_GetPayloadLength_NoPadding(void **state)
     uint8_t msg[msg_len] = {0x1C, 0x03, 0x0, 0x0, 0x0, 0x0, 0x0B, 0xFF, 0x0, 0x0, 0x0, 0x0};
     Avtp_Abb_t *abb = (Avtp_Abb_t *)msg;
     assert_int_equal(Avtp_Abb_GetPayloadLength(abb), 4);
-}
-
-static void Test_Abb_GetAcfMsgLengthInBytes(void **state)
-{
-    const size_t msg_len = AVTP_ABB_HEADER_LEN + 4;
-    uint8_t msg[msg_len] = {0x1C, 0x03, 0x0, 0x0, 0x0, 0x0, 0x0B, 0xFF, 0x0, 0x0, 0x0, 0x0};
-    Avtp_Abb_t *abb = (Avtp_Abb_t *)msg;
-    assert_int_equal(Avtp_Abb_GetAcfMsgLengthInBytes(abb), 3 * 4);
-}
-
-static void Test_Abb_SetAcfMsgLength(void **state)
-{
-    const size_t msg_len = AVTP_ABB_HEADER_LEN + 4;
-    uint8_t msg[msg_len] = {0};
-    Avtp_Abb_t *abb = (Avtp_Abb_t *)msg;
-    Avtp_Abb_Init(abb);
-    Avtp_Abb_SetAcfMsgLength(abb, 5);
-    assert_int_equal(Avtp_Abb_GetAcfMsgLength(abb), 5);
-    assert_int_equal(Avtp_Abb_GetAcfMsgLengthInBytes(abb), 20);
 }
 
 static void Test_Abb_SetMtv(void **state)
@@ -450,7 +423,6 @@ static void Test_Abb_IsValid(void **state)
 int main(void)
 {
     const struct CMUnitTest tests[] = {cmocka_unit_test(Test_Abb_Init),
-                                       cmocka_unit_test(Test_Abb_GetAcfMsgLength),
                                        cmocka_unit_test(Test_Abb_GetPad),
                                        cmocka_unit_test(Test_Abb_IsMtv),
                                        cmocka_unit_test(Test_Abb_GetByteBusId),
@@ -466,8 +438,6 @@ int main(void)
                                        cmocka_unit_test(Test_Abb_GetSegmentNum),
                                        cmocka_unit_test(Test_Abb_GetPayloadLength),
                                        cmocka_unit_test(Test_Abb_GetPayloadLength_NoPadding),
-                                       cmocka_unit_test(Test_Abb_GetAcfMsgLengthInBytes),
-                                       cmocka_unit_test(Test_Abb_SetAcfMsgLength),
                                        cmocka_unit_test(Test_Abb_SetMtv),
                                        cmocka_unit_test(Test_Abb_SetByteBusId),
                                        cmocka_unit_test(Test_Abb_SetEvt),

--- a/unit/test-abb.c
+++ b/unit/test-abb.c
@@ -55,14 +55,6 @@ static void Test_Abb_Init(void **state)
     assert_memory_equal(msg, expected_msg, msg_len);
 }
 
-static void Test_Abb_GetAcfMsgType(void **state)
-{
-    const size_t msg_len = AVTP_ABB_HEADER_LEN + 4;
-    uint8_t msg[msg_len] = {0x1C, 0x02, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0};
-    Avtp_Abb_t *abb = (Avtp_Abb_t *)msg;
-    assert_int_equal(Avtp_Abb_GetAcfMsgType(abb), AVTP_ACF_TYPE_BYTE_BUS_BRIEF);
-}
-
 static void Test_Abb_GetAcfMsgLength(void **state)
 {
     const size_t msg_len = AVTP_ABB_HEADER_LEN + 4;
@@ -197,16 +189,6 @@ static void Test_Abb_GetAcfMsgLengthInBytes(void **state)
     uint8_t msg[msg_len] = {0x1C, 0x03, 0x0, 0x0, 0x0, 0x0, 0x0B, 0xFF, 0x0, 0x0, 0x0, 0x0};
     Avtp_Abb_t *abb = (Avtp_Abb_t *)msg;
     assert_int_equal(Avtp_Abb_GetAcfMsgLengthInBytes(abb), 3 * 4);
-}
-
-static void Test_Abb_SetAcfMsgType(void **state)
-{
-    const size_t msg_len = AVTP_ABB_HEADER_LEN + 4;
-    uint8_t msg[msg_len] = {0};
-    Avtp_Abb_t *abb = (Avtp_Abb_t *)msg;
-    Avtp_Abb_Init(abb);
-    Avtp_Abb_SetAcfMsgType(abb, AVTP_ACF_TYPE_BYTE_BUS_BRIEF);
-    assert_int_equal(Avtp_Abb_GetAcfMsgType(abb), AVTP_ACF_TYPE_BYTE_BUS_BRIEF);
 }
 
 static void Test_Abb_SetAcfMsgLength(void **state)
@@ -411,7 +393,7 @@ static void Test_Abb_CreateAcfMessage(void **state)
 
     Avtp_Abb_CreateAcfMessage(abb, 0x5FF, true, 0xBF, payload, sizeof(payload));
 
-    assert_int_equal(Avtp_Abb_GetAcfMsgType(abb), AVTP_ACF_TYPE_BYTE_BUS_BRIEF);
+    assert_int_equal(Avtp_AcfCommon_GetAcfMsgType((Avtp_AcfCommon_t *)abb), AVTP_ACF_TYPE_BYTE_BUS_BRIEF);
     assert_int_equal(Avtp_Abb_GetByteBusId(abb), 0x5FF);
     assert_int_equal(Avtp_Abb_IsOp(abb), true);
     assert_int_equal(Avtp_Abb_GetTransactionNum(abb), 0xBF);
@@ -430,7 +412,7 @@ static void Test_Abb_CreateFromGarbage(void **state)
     memset(msg, 0xAA, msg_len);
     Avtp_Abb_CreateAcfMessage(abb, 0x5FF, true, 0xBF, payload, sizeof(payload));
 
-    assert_int_equal(Avtp_Abb_GetAcfMsgType(abb), AVTP_ACF_TYPE_BYTE_BUS_BRIEF);
+    assert_int_equal(Avtp_AcfCommon_GetAcfMsgType((Avtp_AcfCommon_t *)abb), AVTP_ACF_TYPE_BYTE_BUS_BRIEF);
     assert_int_equal(Avtp_Abb_IsMtv(abb), false);
     assert_int_equal(Avtp_Abb_IsHs(abb), false);
     assert_int_equal(Avtp_Abb_IsCs(abb), false);
@@ -468,7 +450,6 @@ static void Test_Abb_IsValid(void **state)
 int main(void)
 {
     const struct CMUnitTest tests[] = {cmocka_unit_test(Test_Abb_Init),
-                                       cmocka_unit_test(Test_Abb_GetAcfMsgType),
                                        cmocka_unit_test(Test_Abb_GetAcfMsgLength),
                                        cmocka_unit_test(Test_Abb_GetPad),
                                        cmocka_unit_test(Test_Abb_IsMtv),
@@ -486,7 +467,6 @@ int main(void)
                                        cmocka_unit_test(Test_Abb_GetPayloadLength),
                                        cmocka_unit_test(Test_Abb_GetPayloadLength_NoPadding),
                                        cmocka_unit_test(Test_Abb_GetAcfMsgLengthInBytes),
-                                       cmocka_unit_test(Test_Abb_SetAcfMsgType),
                                        cmocka_unit_test(Test_Abb_SetAcfMsgLength),
                                        cmocka_unit_test(Test_Abb_SetMtv),
                                        cmocka_unit_test(Test_Abb_SetByteBusId),

--- a/unit/test-can-brief-v2.c
+++ b/unit/test-can-brief-v2.c
@@ -55,14 +55,6 @@ static void Test_CanBriefV2_Init(void **state)
     assert_memory_equal(msg, expected_msg, msg_len);
 }
 
-static void Test_CanBriefV2_GetAcfMsgType(void **state)
-{
-    const size_t msg_len = AVTP_CAN_BRIEF_V2_HEADER_LEN + 4;
-    uint8_t msg[msg_len] = {0x44, 0x02, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0};
-    Avtp_CanBriefV2_t *canV2 = (Avtp_CanBriefV2_t *)msg;
-    assert_int_equal(Avtp_CanBriefV2_GetAcfMsgType(canV2), AVTP_ACF_TYPE_CAN_BRIEF_V2);
-}
-
 static void Test_CanBriefV2_GetAcfMsgLength(void **state)
 {
     const size_t msg_len = AVTP_CAN_BRIEF_V2_HEADER_LEN + 4;
@@ -165,16 +157,6 @@ static void Test_CanBriefV2_GetAcfMsgLengthInBytes(void **state)
     uint8_t msg[msg_len] = {0x44, 0x03, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0};
     Avtp_CanBriefV2_t *canV2 = (Avtp_CanBriefV2_t *)msg;
     assert_int_equal(Avtp_CanBriefV2_GetAcfMsgLengthInBytes(canV2), 3 * 4);
-}
-
-static void Test_CanBriefV2_SetAcfMsgType(void **state)
-{
-    const size_t msg_len = AVTP_CAN_BRIEF_V2_HEADER_LEN + 4;
-    uint8_t msg[msg_len] = {0};
-    Avtp_CanBriefV2_t *canV2 = (Avtp_CanBriefV2_t *)msg;
-    Avtp_CanBriefV2_Init(canV2);
-    Avtp_CanBriefV2_SetAcfMsgType(canV2, AVTP_ACF_TYPE_CAN_BRIEF_V2);
-    assert_int_equal(Avtp_CanBriefV2_GetAcfMsgType(canV2), AVTP_ACF_TYPE_CAN_BRIEF_V2);
 }
 
 static void Test_CanBriefV2_SetAcfMsgLength(void **state)
@@ -408,7 +390,7 @@ static void Test_CanBriefV2_CreateFromGarbage(void **state)
     memset(msg, 0xAA, msg_len);
     Avtp_CanBriefV2_CreateAcfMessage(canV2, 0x123, 0x0, payload, sizeof(payload), AVTP_CAN_CLASSIC);
 
-    assert_int_equal(Avtp_CanBriefV2_GetAcfMsgType(canV2), AVTP_ACF_TYPE_CAN_BRIEF_V2);
+    assert_int_equal(Avtp_AcfCommon_GetAcfMsgType((Avtp_AcfCommon_t *)canV2), AVTP_ACF_TYPE_CAN_BRIEF_V2);
     assert_int_equal(Avtp_CanBriefV2_IsMtv(canV2), false);
     assert_int_equal(Avtp_CanBriefV2_IsRtr(canV2), false);
     assert_int_equal(Avtp_CanBriefV2_IsBrs(canV2), false);
@@ -422,7 +404,6 @@ static void Test_CanBriefV2_CreateFromGarbage(void **state)
 int main(void)
 {
     const struct CMUnitTest tests[] = {cmocka_unit_test(Test_CanBriefV2_Init),
-                                       cmocka_unit_test(Test_CanBriefV2_GetAcfMsgType),
                                        cmocka_unit_test(Test_CanBriefV2_GetAcfMsgLength),
                                        cmocka_unit_test(Test_CanBriefV2_GetPad),
                                        cmocka_unit_test(Test_CanBriefV2_IsMtv),
@@ -436,7 +417,6 @@ int main(void)
                                        cmocka_unit_test(Test_CanBriefV2_GetPayloadLength),
                                        cmocka_unit_test(Test_CanBriefV2_GetPayloadLength_NoPadding),
                                        cmocka_unit_test(Test_CanBriefV2_GetAcfMsgLengthInBytes),
-                                       cmocka_unit_test(Test_CanBriefV2_SetAcfMsgType),
                                        cmocka_unit_test(Test_CanBriefV2_SetAcfMsgLength),
                                        cmocka_unit_test(Test_CanBriefV2_SetMtv),
                                        cmocka_unit_test(Test_CanBriefV2_SetRtr),

--- a/unit/test-can-brief-v2.c
+++ b/unit/test-can-brief-v2.c
@@ -363,7 +363,8 @@ static void Test_CanBriefV2_CreateFromGarbage(void **state)
     memset(msg, 0xAA, msg_len);
     Avtp_CanBriefV2_CreateAcfMessage(canV2, 0x123, 0x0, payload, sizeof(payload), AVTP_CAN_CLASSIC);
 
-    assert_int_equal(Avtp_AcfCommon_GetAcfMsgType((Avtp_AcfCommon_t *)canV2), AVTP_ACF_TYPE_CAN_BRIEF_V2);
+    assert_int_equal(Avtp_AcfCommon_GetAcfMsgType((Avtp_AcfCommon_t *)canV2),
+                     AVTP_ACF_TYPE_CAN_BRIEF_V2);
     assert_int_equal(Avtp_CanBriefV2_IsMtv(canV2), false);
     assert_int_equal(Avtp_CanBriefV2_IsRtr(canV2), false);
     assert_int_equal(Avtp_CanBriefV2_IsBrs(canV2), false);

--- a/unit/test-can-brief-v2.c
+++ b/unit/test-can-brief-v2.c
@@ -55,14 +55,6 @@ static void Test_CanBriefV2_Init(void **state)
     assert_memory_equal(msg, expected_msg, msg_len);
 }
 
-static void Test_CanBriefV2_GetAcfMsgLength(void **state)
-{
-    const size_t msg_len = AVTP_CAN_BRIEF_V2_HEADER_LEN + 4;
-    uint8_t msg[msg_len] = {0x44, 0x02, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0};
-    Avtp_CanBriefV2_t *canV2 = (Avtp_CanBriefV2_t *)msg;
-    assert_int_equal(Avtp_CanBriefV2_GetAcfMsgLength(canV2), 2);
-}
-
 static void Test_CanBriefV2_GetPad(void **state)
 {
     const size_t msg_len = AVTP_CAN_BRIEF_V2_HEADER_LEN + 4;
@@ -149,25 +141,6 @@ static void Test_CanBriefV2_GetPayloadLength_NoPadding(void **state)
     uint8_t msg[msg_len] = {0x44, 0x03, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0};
     Avtp_CanBriefV2_t *canV2 = (Avtp_CanBriefV2_t *)msg;
     assert_int_equal(Avtp_CanBriefV2_GetPayloadLength(canV2), 4);
-}
-
-static void Test_CanBriefV2_GetAcfMsgLengthInBytes(void **state)
-{
-    const size_t msg_len = AVTP_CAN_BRIEF_V2_HEADER_LEN + 4;
-    uint8_t msg[msg_len] = {0x44, 0x03, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0};
-    Avtp_CanBriefV2_t *canV2 = (Avtp_CanBriefV2_t *)msg;
-    assert_int_equal(Avtp_CanBriefV2_GetAcfMsgLengthInBytes(canV2), 3 * 4);
-}
-
-static void Test_CanBriefV2_SetAcfMsgLength(void **state)
-{
-    const size_t msg_len = AVTP_CAN_BRIEF_V2_HEADER_LEN + 4;
-    uint8_t msg[msg_len] = {0};
-    Avtp_CanBriefV2_t *canV2 = (Avtp_CanBriefV2_t *)msg;
-    Avtp_CanBriefV2_Init(canV2);
-    Avtp_CanBriefV2_SetAcfMsgLength(canV2, 5);
-    assert_int_equal(Avtp_CanBriefV2_GetAcfMsgLength(canV2), 5);
-    assert_int_equal(Avtp_CanBriefV2_GetAcfMsgLengthInBytes(canV2), 20);
 }
 
 static void Test_CanBriefV2_SetMtv(void **state)
@@ -404,7 +377,6 @@ static void Test_CanBriefV2_CreateFromGarbage(void **state)
 int main(void)
 {
     const struct CMUnitTest tests[] = {cmocka_unit_test(Test_CanBriefV2_Init),
-                                       cmocka_unit_test(Test_CanBriefV2_GetAcfMsgLength),
                                        cmocka_unit_test(Test_CanBriefV2_GetPad),
                                        cmocka_unit_test(Test_CanBriefV2_IsMtv),
                                        cmocka_unit_test(Test_CanBriefV2_IsRtr),
@@ -416,8 +388,6 @@ int main(void)
                                        cmocka_unit_test(Test_CanBriefV2_GetCanIdentifier),
                                        cmocka_unit_test(Test_CanBriefV2_GetPayloadLength),
                                        cmocka_unit_test(Test_CanBriefV2_GetPayloadLength_NoPadding),
-                                       cmocka_unit_test(Test_CanBriefV2_GetAcfMsgLengthInBytes),
-                                       cmocka_unit_test(Test_CanBriefV2_SetAcfMsgLength),
                                        cmocka_unit_test(Test_CanBriefV2_SetMtv),
                                        cmocka_unit_test(Test_CanBriefV2_SetRtr),
                                        cmocka_unit_test(Test_CanBriefV2_SetEff),

--- a/unit/test-can-v2.c
+++ b/unit/test-can-v2.c
@@ -56,15 +56,6 @@ static void Test_CanV2_Init(void **state)
     assert_memory_equal(msg, expected_msg, msg_len);
 }
 
-static void Test_CanV2_GetAcfMsgLength(void **state)
-{
-    const size_t msg_len = AVTP_CAN_V2_HEADER_LEN + 4;
-    uint8_t msg[msg_len] = {0x42, 0x04, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0,
-                            0x0,  0x0,  0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0};
-    Avtp_CanV2_t *canV2 = (Avtp_CanV2_t *)msg;
-    assert_int_equal(Avtp_CanV2_GetAcfMsgLength(canV2), 4);
-}
-
 static void Test_CanV2_GetPad(void **state)
 {
     const size_t msg_len = AVTP_CAN_V2_HEADER_LEN + 4;
@@ -171,26 +162,6 @@ static void Test_CanV2_GetPayloadLength_NoPadding(void **state)
                             0x0,  0x0,  0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0};
     Avtp_CanV2_t *canV2 = (Avtp_CanV2_t *)msg;
     assert_int_equal(Avtp_CanV2_GetPayloadLength(canV2), 4);
-}
-
-static void Test_CanV2_GetAcfMsgLengthInBytes(void **state)
-{
-    const size_t msg_len = AVTP_CAN_V2_HEADER_LEN + 4;
-    uint8_t msg[msg_len] = {0x42, 0x05, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0,
-                            0x0,  0x0,  0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0};
-    Avtp_CanV2_t *canV2 = (Avtp_CanV2_t *)msg;
-    assert_int_equal(Avtp_CanV2_GetAcfMsgLengthInBytes(canV2), 5 * 4);
-}
-
-static void Test_CanV2_SetAcfMsgLength(void **state)
-{
-    const size_t msg_len = AVTP_CAN_V2_HEADER_LEN + 4;
-    uint8_t msg[msg_len] = {0};
-    Avtp_CanV2_t *canV2 = (Avtp_CanV2_t *)msg;
-    Avtp_CanV2_Init(canV2);
-    Avtp_CanV2_SetAcfMsgLength(canV2, 5);
-    assert_int_equal(Avtp_CanV2_GetAcfMsgLength(canV2), 5);
-    assert_int_equal(Avtp_CanV2_GetAcfMsgLengthInBytes(canV2), 20);
 }
 
 static void Test_CanV2_SetMtv(void **state)
@@ -451,7 +422,6 @@ static void Test_CanV2_IsValid(void **state)
 int main(void)
 {
     const struct CMUnitTest tests[] = {cmocka_unit_test(Test_CanV2_Init),
-                                       cmocka_unit_test(Test_CanV2_GetAcfMsgLength),
                                        cmocka_unit_test(Test_CanV2_GetPad),
                                        cmocka_unit_test(Test_CanV2_IsMtv),
                                        cmocka_unit_test(Test_CanV2_IsRtr),
@@ -464,8 +434,6 @@ int main(void)
                                        cmocka_unit_test(Test_CanV2_GetCanIdentifier),
                                        cmocka_unit_test(Test_CanV2_GetPayloadLength),
                                        cmocka_unit_test(Test_CanV2_GetPayloadLength_NoPadding),
-                                       cmocka_unit_test(Test_CanV2_GetAcfMsgLengthInBytes),
-                                       cmocka_unit_test(Test_CanV2_SetAcfMsgLength),
                                        cmocka_unit_test(Test_CanV2_SetMtv),
                                        cmocka_unit_test(Test_CanV2_SetRtr),
                                        cmocka_unit_test(Test_CanV2_SetEff),

--- a/unit/test-can-v2.c
+++ b/unit/test-can-v2.c
@@ -56,15 +56,6 @@ static void Test_CanV2_Init(void **state)
     assert_memory_equal(msg, expected_msg, msg_len);
 }
 
-static void Test_CanV2_GetAcfMsgType(void **state)
-{
-    const size_t msg_len = AVTP_CAN_V2_HEADER_LEN + 4;
-    uint8_t msg[msg_len] = {0x42, 0x04, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0,
-                            0x0,  0x0,  0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0};
-    Avtp_CanV2_t *canV2 = (Avtp_CanV2_t *)msg;
-    assert_int_equal(Avtp_CanV2_GetAcfMsgType(canV2), AVTP_ACF_TYPE_CAN_V2);
-}
-
 static void Test_CanV2_GetAcfMsgLength(void **state)
 {
     const size_t msg_len = AVTP_CAN_V2_HEADER_LEN + 4;
@@ -189,16 +180,6 @@ static void Test_CanV2_GetAcfMsgLengthInBytes(void **state)
                             0x0,  0x0,  0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0};
     Avtp_CanV2_t *canV2 = (Avtp_CanV2_t *)msg;
     assert_int_equal(Avtp_CanV2_GetAcfMsgLengthInBytes(canV2), 5 * 4);
-}
-
-static void Test_CanV2_SetAcfMsgType(void **state)
-{
-    const size_t msg_len = AVTP_CAN_V2_HEADER_LEN + 4;
-    uint8_t msg[msg_len] = {0};
-    Avtp_CanV2_t *canV2 = (Avtp_CanV2_t *)msg;
-    Avtp_CanV2_Init(canV2);
-    Avtp_CanV2_SetAcfMsgType(canV2, AVTP_ACF_TYPE_CAN_V2);
-    assert_int_equal(Avtp_CanV2_GetAcfMsgType(canV2), AVTP_ACF_TYPE_CAN_V2);
 }
 
 static void Test_CanV2_SetAcfMsgLength(void **state)
@@ -378,7 +359,7 @@ static void Test_CanV2_CreateAcfMessage(void **state)
 
     Avtp_CanV2_CreateAcfMessage(canV2, 0x7ff, payload, sizeof(payload), AVTP_CAN_CLASSIC);
 
-    assert_int_equal(Avtp_CanV2_GetAcfMsgType(canV2), AVTP_ACF_TYPE_CAN_V2);
+    assert_int_equal(Avtp_AcfCommon_GetAcfMsgType((Avtp_AcfCommon_t *)canV2), AVTP_ACF_TYPE_CAN_V2);
     assert_int_equal(Avtp_CanV2_GetCanIdentifier(canV2), 0x7ff);
     assert_int_equal(Avtp_CanV2_IsEff(canV2), false);
     assert_memory_equal(payload, msg + AVTP_CAN_V2_HEADER_LEN, sizeof(payload));
@@ -409,7 +390,7 @@ static void Test_CanV2_CreateFromGarbage(void **state)
     memset(msg, 0xAA, msg_len);
     Avtp_CanV2_CreateAcfMessage(canV2, 0x123, payload, sizeof(payload), AVTP_CAN_CLASSIC);
 
-    assert_int_equal(Avtp_CanV2_GetAcfMsgType(canV2), AVTP_ACF_TYPE_CAN_V2);
+    assert_int_equal(Avtp_AcfCommon_GetAcfMsgType((Avtp_AcfCommon_t *)canV2), AVTP_ACF_TYPE_CAN_V2);
     assert_int_equal(Avtp_CanV2_IsMtv(canV2), false);
     assert_int_equal(Avtp_CanV2_IsRtr(canV2), false);
     assert_int_equal(Avtp_CanV2_IsBrs(canV2), false);
@@ -470,7 +451,6 @@ static void Test_CanV2_IsValid(void **state)
 int main(void)
 {
     const struct CMUnitTest tests[] = {cmocka_unit_test(Test_CanV2_Init),
-                                       cmocka_unit_test(Test_CanV2_GetAcfMsgType),
                                        cmocka_unit_test(Test_CanV2_GetAcfMsgLength),
                                        cmocka_unit_test(Test_CanV2_GetPad),
                                        cmocka_unit_test(Test_CanV2_IsMtv),
@@ -485,7 +465,6 @@ int main(void)
                                        cmocka_unit_test(Test_CanV2_GetPayloadLength),
                                        cmocka_unit_test(Test_CanV2_GetPayloadLength_NoPadding),
                                        cmocka_unit_test(Test_CanV2_GetAcfMsgLengthInBytes),
-                                       cmocka_unit_test(Test_CanV2_SetAcfMsgType),
                                        cmocka_unit_test(Test_CanV2_SetAcfMsgLength),
                                        cmocka_unit_test(Test_CanV2_SetMtv),
                                        cmocka_unit_test(Test_CanV2_SetRtr),

--- a/unit/test-can.c
+++ b/unit/test-can.c
@@ -334,7 +334,8 @@ static void can_brief_create_from_garbage(void **state)
     Avtp_CanBrief_CreateAcfMessage((Avtp_CanBrief_t *)pdu, frame_id, payload, sizeof(payload),
                                    AVTP_CAN_CLASSIC);
 
-    assert_int_equal(Avtp_AcfCommon_GetAcfMsgType((Avtp_AcfCommon_t *)pdu), AVTP_ACF_TYPE_CAN_BRIEF);
+    assert_int_equal(Avtp_AcfCommon_GetAcfMsgType((Avtp_AcfCommon_t *)pdu),
+                     AVTP_ACF_TYPE_CAN_BRIEF);
     assert_int_equal(Avtp_CanBrief_IsMtv((Avtp_CanBrief_t *)pdu), 0);
     assert_int_equal(Avtp_CanBrief_IsRtr((Avtp_CanBrief_t *)pdu), 0);
     assert_int_equal(Avtp_CanBrief_IsBrs((Avtp_CanBrief_t *)pdu), 0);

--- a/unit/test-can.c
+++ b/unit/test-can.c
@@ -311,7 +311,7 @@ static void can_create_from_garbage(void **state)
     Avtp_Can_CreateAcfMessage((Avtp_Can_t *)pdu, frame_id, payload, sizeof(payload),
                               AVTP_CAN_CLASSIC);
 
-    assert_int_equal(Avtp_Can_GetAcfMsgType((Avtp_Can_t *)pdu), AVTP_ACF_TYPE_CAN);
+    assert_int_equal(Avtp_AcfCommon_GetAcfMsgType((Avtp_AcfCommon_t *)pdu), AVTP_ACF_TYPE_CAN);
     assert_int_equal(Avtp_Can_IsMtv((Avtp_Can_t *)pdu), 0);
     assert_int_equal(Avtp_Can_IsRtr((Avtp_Can_t *)pdu), 0);
     assert_int_equal(Avtp_Can_IsBrs((Avtp_Can_t *)pdu), 0);
@@ -334,7 +334,7 @@ static void can_brief_create_from_garbage(void **state)
     Avtp_CanBrief_CreateAcfMessage((Avtp_CanBrief_t *)pdu, frame_id, payload, sizeof(payload),
                                    AVTP_CAN_CLASSIC);
 
-    assert_int_equal(Avtp_CanBrief_GetAcfMsgType((Avtp_CanBrief_t *)pdu), AVTP_ACF_TYPE_CAN_BRIEF);
+    assert_int_equal(Avtp_AcfCommon_GetAcfMsgType((Avtp_AcfCommon_t *)pdu), AVTP_ACF_TYPE_CAN_BRIEF);
     assert_int_equal(Avtp_CanBrief_IsMtv((Avtp_CanBrief_t *)pdu), 0);
     assert_int_equal(Avtp_CanBrief_IsRtr((Avtp_CanBrief_t *)pdu), 0);
     assert_int_equal(Avtp_CanBrief_IsBrs((Avtp_CanBrief_t *)pdu), 0);

--- a/unit/test-can.c
+++ b/unit/test-can.c
@@ -154,12 +154,12 @@ static void can_is_valid(void **state)
     // Valid IEEE 1722 CAN Frame (Length 24, Buffer 25). AcfMsgLength=6
     // quadlets = 24 bytes; payload = 24 - 16 header = 8 bytes (classic max).
     Avtp_Can_Init((Avtp_Can_t *)pdu);
-    Avtp_Can_SetAcfMsgLength((Avtp_Can_t *)pdu, 6);
+    Avtp_AcfCommon_SetAcfMsgLength((Avtp_AcfCommon_t *)pdu, 6);
     assert_int_equal(Avtp_Can_IsValid((Avtp_Can_t *)pdu, 25), 1);
 
     // Invalid IEEE 1722 CAN Frame (Length 24 but buffer only 9!).
     Avtp_Can_Init((Avtp_Can_t *)pdu);
-    Avtp_Can_SetAcfMsgLength((Avtp_Can_t *)pdu, 6);
+    Avtp_AcfCommon_SetAcfMsgLength((Avtp_AcfCommon_t *)pdu, 6);
     assert_int_equal(Avtp_Can_IsValid((Avtp_Can_t *)pdu, 9), 0);
 
     // Classic CAN payload bound: a frame declaring a 12-byte payload as
@@ -229,7 +229,7 @@ static void can_brief_set_payload(void **state)
         uint16_t msgLenBytes = AVTP_CAN_BRIEF_HEADER_LEN + i;
         uint8_t pad = (uint8_t)(4 - (msgLenBytes % 4)) % 4;
         assert_int_equal(Avtp_CanBrief_GetPad((Avtp_CanBrief_t *)pdu), pad);
-        assert_int_equal(Avtp_CanBrief_GetAcfMsgLength((Avtp_CanBrief_t *)pdu),
+        assert_int_equal(Avtp_AcfCommon_GetAcfMsgLength((Avtp_AcfCommon_t *)pdu),
                          (msgLenBytes + pad) / 4);
     }
 }
@@ -263,12 +263,12 @@ static void can_brief_is_valid(void **state)
     // Valid IEEE 1722 CAN Brief Frame (Length 16, Buffer 17). AcfMsgLength=4
     // quadlets = 16 bytes; payload = 16 - 8 header = 8 bytes (classic max).
     Avtp_CanBrief_Init((Avtp_CanBrief_t *)pdu);
-    Avtp_CanBrief_SetAcfMsgLength((Avtp_CanBrief_t *)pdu, 4);
+    Avtp_AcfCommon_SetAcfMsgLength((Avtp_AcfCommon_t *)pdu, 4);
     assert_int_equal(Avtp_CanBrief_IsValid((Avtp_CanBrief_t *)pdu, 17), 1);
 
     // Invalid IEEE 1722 CAN Brief Frame (Length 16 but buffer only 9!).
     Avtp_CanBrief_Init((Avtp_CanBrief_t *)pdu);
-    Avtp_CanBrief_SetAcfMsgLength((Avtp_CanBrief_t *)pdu, 4);
+    Avtp_AcfCommon_SetAcfMsgLength((Avtp_AcfCommon_t *)pdu, 4);
     assert_int_equal(Avtp_CanBrief_IsValid((Avtp_CanBrief_t *)pdu, 9), 0);
 
     // Classic CAN payload bound: a frame declaring a 12-byte payload as

--- a/unit/test-canxl-brief.c
+++ b/unit/test-canxl-brief.c
@@ -374,7 +374,8 @@ static void Test_CanXlBrief_CreateAcfMessage(void **state)
 
     Avtp_CanXlBrief_CreateAcfMessage(canxl, 0x5FF, 0xBFFFFFFFul, 0xBF, payload, sizeof(payload));
 
-    assert_int_equal(Avtp_AcfCommon_GetAcfMsgType((Avtp_AcfCommon_t *)canxl), AVTP_ACF_TYPE_CAN_XL_BRIEF);
+    assert_int_equal(Avtp_AcfCommon_GetAcfMsgType((Avtp_AcfCommon_t *)canxl),
+                     AVTP_ACF_TYPE_CAN_XL_BRIEF);
     assert_int_equal(Avtp_CanXlBrief_GetPriorityId(canxl), 0x5FF);
     assert_int_equal(Avtp_CanXlBrief_GetAcceptanceField(canxl), 0xBFFFFFFFul);
     assert_int_equal(Avtp_CanXlBrief_GetSdt(canxl), 0xBF);
@@ -399,7 +400,8 @@ static void Test_CanXlBrief_CreateFromGarbage(void **state)
     memset(msg, 0xAA, msg_len);
     Avtp_CanXlBrief_CreateAcfMessage(canxl, 0x5FF, 0x0, 0x0, payload, sizeof(payload));
 
-    assert_int_equal(Avtp_AcfCommon_GetAcfMsgType((Avtp_AcfCommon_t *)canxl), AVTP_ACF_TYPE_CAN_XL_BRIEF);
+    assert_int_equal(Avtp_AcfCommon_GetAcfMsgType((Avtp_AcfCommon_t *)canxl),
+                     AVTP_ACF_TYPE_CAN_XL_BRIEF);
     assert_int_equal(Avtp_CanXlBrief_IsMtv(canxl), false);
     assert_int_equal(Avtp_CanXlBrief_IsRrs(canxl), false);
     assert_int_equal(Avtp_CanXlBrief_IsSec(canxl), false);

--- a/unit/test-canxl-brief.c
+++ b/unit/test-canxl-brief.c
@@ -56,15 +56,6 @@ static void Test_CanXlBrief_Init(void **state)
     assert_memory_equal(msg, expected_msg, msg_len);
 }
 
-static void Test_CanXlBrief_GetAcfMsgType(void **state)
-{
-    const size_t msg_len = AVTP_CANXL_BRIEF_HEADER_LEN + 4;
-    uint8_t msg[msg_len] = {0x24, 0x04, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0,
-                            0x0,  0x0,  0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0};
-    Avtp_CanXlBrief_t *canxl = (Avtp_CanXlBrief_t *)msg;
-    assert_int_equal(Avtp_CanXlBrief_GetAcfMsgType(canxl), AVTP_ACF_TYPE_CAN_XL_BRIEF);
-}
-
 static void Test_CanXlBrief_GetAcfMsgLength(void **state)
 {
     const size_t msg_len = AVTP_CANXL_BRIEF_HEADER_LEN + 4;
@@ -207,16 +198,6 @@ static void Test_CanXlBrief_GetAcfMsgLengthInBytes(void **state)
                             0x0,  0x0,  0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0};
     Avtp_CanXlBrief_t *canxl = (Avtp_CanXlBrief_t *)msg;
     assert_int_equal(Avtp_CanXlBrief_GetAcfMsgLengthInBytes(canxl), 5 * 4);
-}
-
-static void Test_CanXlBrief_SetAcfMsgType(void **state)
-{
-    const size_t msg_len = AVTP_CANXL_BRIEF_HEADER_LEN + 4;
-    uint8_t msg[msg_len] = {0};
-    Avtp_CanXlBrief_t *canxl = (Avtp_CanXlBrief_t *)msg;
-    Avtp_CanXlBrief_Init(canxl);
-    Avtp_CanXlBrief_SetAcfMsgType(canxl, AVTP_ACF_TYPE_CAN_XL_BRIEF);
-    assert_int_equal(Avtp_CanXlBrief_GetAcfMsgType(canxl), AVTP_ACF_TYPE_CAN_XL_BRIEF);
 }
 
 static void Test_CanXlBrief_SetAcfMsgLength(void **state)
@@ -422,7 +403,7 @@ static void Test_CanXlBrief_CreateAcfMessage(void **state)
 
     Avtp_CanXlBrief_CreateAcfMessage(canxl, 0x5FF, 0xBFFFFFFFul, 0xBF, payload, sizeof(payload));
 
-    assert_int_equal(Avtp_CanXlBrief_GetAcfMsgType(canxl), AVTP_ACF_TYPE_CAN_XL_BRIEF);
+    assert_int_equal(Avtp_AcfCommon_GetAcfMsgType((Avtp_AcfCommon_t *)canxl), AVTP_ACF_TYPE_CAN_XL_BRIEF);
     assert_int_equal(Avtp_CanXlBrief_GetPriorityId(canxl), 0x5FF);
     assert_int_equal(Avtp_CanXlBrief_GetAcceptanceField(canxl), 0xBFFFFFFFul);
     assert_int_equal(Avtp_CanXlBrief_GetSdt(canxl), 0xBF);
@@ -447,7 +428,7 @@ static void Test_CanXlBrief_CreateFromGarbage(void **state)
     memset(msg, 0xAA, msg_len);
     Avtp_CanXlBrief_CreateAcfMessage(canxl, 0x5FF, 0x0, 0x0, payload, sizeof(payload));
 
-    assert_int_equal(Avtp_CanXlBrief_GetAcfMsgType(canxl), AVTP_ACF_TYPE_CAN_XL_BRIEF);
+    assert_int_equal(Avtp_AcfCommon_GetAcfMsgType((Avtp_AcfCommon_t *)canxl), AVTP_ACF_TYPE_CAN_XL_BRIEF);
     assert_int_equal(Avtp_CanXlBrief_IsMtv(canxl), false);
     assert_int_equal(Avtp_CanXlBrief_IsRrs(canxl), false);
     assert_int_equal(Avtp_CanXlBrief_IsSec(canxl), false);
@@ -484,7 +465,6 @@ static void Test_CanXlBrief_IsValid(void **state)
 int main(void)
 {
     const struct CMUnitTest tests[] = {cmocka_unit_test(Test_CanXlBrief_Init),
-                                       cmocka_unit_test(Test_CanXlBrief_GetAcfMsgType),
                                        cmocka_unit_test(Test_CanXlBrief_GetAcfMsgLength),
                                        cmocka_unit_test(Test_CanXlBrief_GetPad),
                                        cmocka_unit_test(Test_CanXlBrief_IsMtv),
@@ -501,7 +481,6 @@ int main(void)
                                        cmocka_unit_test(Test_CanXlBrief_GetPayloadLength),
                                        cmocka_unit_test(Test_CanXlBrief_GetPayloadLength_NoPadding),
                                        cmocka_unit_test(Test_CanXlBrief_GetAcfMsgLengthInBytes),
-                                       cmocka_unit_test(Test_CanXlBrief_SetAcfMsgType),
                                        cmocka_unit_test(Test_CanXlBrief_SetAcfMsgLength),
                                        cmocka_unit_test(Test_CanXlBrief_SetMtv),
                                        cmocka_unit_test(Test_CanXlBrief_SetCanBusId),

--- a/unit/test-canxl-brief.c
+++ b/unit/test-canxl-brief.c
@@ -56,15 +56,6 @@ static void Test_CanXlBrief_Init(void **state)
     assert_memory_equal(msg, expected_msg, msg_len);
 }
 
-static void Test_CanXlBrief_GetAcfMsgLength(void **state)
-{
-    const size_t msg_len = AVTP_CANXL_BRIEF_HEADER_LEN + 4;
-    uint8_t msg[msg_len] = {0x24, 0x04, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0,
-                            0x0,  0x0,  0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0};
-    Avtp_CanXlBrief_t *canxl = (Avtp_CanXlBrief_t *)msg;
-    assert_int_equal(Avtp_CanXlBrief_GetAcfMsgLength(canxl), 4);
-}
-
 static void Test_CanXlBrief_GetPad(void **state)
 {
     const size_t msg_len = AVTP_CANXL_BRIEF_HEADER_LEN + 4;
@@ -189,26 +180,6 @@ static void Test_CanXlBrief_GetPayloadLength_NoPadding(void **state)
                             0x0,  0x0,  0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0};
     Avtp_CanXlBrief_t *canxl = (Avtp_CanXlBrief_t *)msg;
     assert_int_equal(Avtp_CanXlBrief_GetPayloadLength(canxl), 4);
-}
-
-static void Test_CanXlBrief_GetAcfMsgLengthInBytes(void **state)
-{
-    const size_t msg_len = AVTP_CANXL_BRIEF_HEADER_LEN + 4;
-    uint8_t msg[msg_len] = {0x24, 0x05, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0,
-                            0x0,  0x0,  0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0};
-    Avtp_CanXlBrief_t *canxl = (Avtp_CanXlBrief_t *)msg;
-    assert_int_equal(Avtp_CanXlBrief_GetAcfMsgLengthInBytes(canxl), 5 * 4);
-}
-
-static void Test_CanXlBrief_SetAcfMsgLength(void **state)
-{
-    const size_t msg_len = AVTP_CANXL_BRIEF_HEADER_LEN + 4;
-    uint8_t msg[msg_len] = {0};
-    Avtp_CanXlBrief_t *canxl = (Avtp_CanXlBrief_t *)msg;
-    Avtp_CanXlBrief_Init(canxl);
-    Avtp_CanXlBrief_SetAcfMsgLength(canxl, 5);
-    assert_int_equal(Avtp_CanXlBrief_GetAcfMsgLength(canxl), 5);
-    assert_int_equal(Avtp_CanXlBrief_GetAcfMsgLengthInBytes(canxl), 20);
 }
 
 static void Test_CanXlBrief_SetMtv(void **state)
@@ -465,7 +436,6 @@ static void Test_CanXlBrief_IsValid(void **state)
 int main(void)
 {
     const struct CMUnitTest tests[] = {cmocka_unit_test(Test_CanXlBrief_Init),
-                                       cmocka_unit_test(Test_CanXlBrief_GetAcfMsgLength),
                                        cmocka_unit_test(Test_CanXlBrief_GetPad),
                                        cmocka_unit_test(Test_CanXlBrief_IsMtv),
                                        cmocka_unit_test(Test_CanXlBrief_GetCanBusId),
@@ -480,8 +450,6 @@ int main(void)
                                        cmocka_unit_test(Test_CanXlBrief_GetSegmentNum),
                                        cmocka_unit_test(Test_CanXlBrief_GetPayloadLength),
                                        cmocka_unit_test(Test_CanXlBrief_GetPayloadLength_NoPadding),
-                                       cmocka_unit_test(Test_CanXlBrief_GetAcfMsgLengthInBytes),
-                                       cmocka_unit_test(Test_CanXlBrief_SetAcfMsgLength),
                                        cmocka_unit_test(Test_CanXlBrief_SetMtv),
                                        cmocka_unit_test(Test_CanXlBrief_SetCanBusId),
                                        cmocka_unit_test(Test_CanXlBrief_SetVcid),

--- a/unit/test-canxl.c
+++ b/unit/test-canxl.c
@@ -57,15 +57,6 @@ static void Test_CanXl_Init(void **state)
     assert_memory_equal(msg, expected_msg, msg_len);
 }
 
-static void Test_CanXl_GetAcfMsgLength(void **state)
-{
-    const size_t msg_len = AVTP_CANXL_HEADER_LEN + 4;
-    uint8_t msg[msg_len] = {0x22, 0x06, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0,
-                            0x0,  0x0,  0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0};
-    Avtp_CanXl_t *canxl = (Avtp_CanXl_t *)msg;
-    assert_int_equal(Avtp_CanXl_GetAcfMsgLength(canxl), 6);
-}
-
 static void Test_CanXl_GetPad(void **state)
 {
     const size_t msg_len = AVTP_CANXL_HEADER_LEN + 4;
@@ -209,26 +200,6 @@ static void Test_CanXl_GetPayloadLength_NoPadding(void **state)
                             0x0,  0x0,  0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0};
     Avtp_CanXl_t *canxl = (Avtp_CanXl_t *)msg;
     assert_int_equal(Avtp_CanXl_GetPayloadLength(canxl), 4);
-}
-
-static void Test_CanXl_GetAcfMsgLengthInBytes(void **state)
-{
-    const size_t msg_len = AVTP_CANXL_HEADER_LEN + 4;
-    uint8_t msg[msg_len] = {0x22, 0x07, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0,
-                            0x0,  0x0,  0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0};
-    Avtp_CanXl_t *canxl = (Avtp_CanXl_t *)msg;
-    assert_int_equal(Avtp_CanXl_GetAcfMsgLengthInBytes(canxl), 7 * 4);
-}
-
-static void Test_CanXl_SetAcfMsgLength(void **state)
-{
-    const size_t msg_len = AVTP_CANXL_HEADER_LEN + 4;
-    uint8_t msg[msg_len] = {0};
-    Avtp_CanXl_t *canxl = (Avtp_CanXl_t *)msg;
-    Avtp_CanXl_Init(canxl);
-    Avtp_CanXl_SetAcfMsgLength(canxl, 5);
-    assert_int_equal(Avtp_CanXl_GetAcfMsgLength(canxl), 5);
-    assert_int_equal(Avtp_CanXl_GetAcfMsgLengthInBytes(canxl), 20);
 }
 
 static void Test_CanXl_SetMtv(void **state)
@@ -515,7 +486,6 @@ static void Test_CanXl_IsValid(void **state)
 int main(void)
 {
     const struct CMUnitTest tests[] = {cmocka_unit_test(Test_CanXl_Init),
-                                       cmocka_unit_test(Test_CanXl_GetAcfMsgLength),
                                        cmocka_unit_test(Test_CanXl_GetPad),
                                        cmocka_unit_test(Test_CanXl_IsMtv),
                                        cmocka_unit_test(Test_CanXl_GetCanBusId),
@@ -531,8 +501,6 @@ int main(void)
                                        cmocka_unit_test(Test_CanXl_GetSegmentNum),
                                        cmocka_unit_test(Test_CanXl_GetPayloadLength),
                                        cmocka_unit_test(Test_CanXl_GetPayloadLength_NoPadding),
-                                       cmocka_unit_test(Test_CanXl_GetAcfMsgLengthInBytes),
-                                       cmocka_unit_test(Test_CanXl_SetAcfMsgLength),
                                        cmocka_unit_test(Test_CanXl_SetMtv),
                                        cmocka_unit_test(Test_CanXl_SetCanBusId),
                                        cmocka_unit_test(Test_CanXl_SetMessageTimestamp),

--- a/unit/test-canxl.c
+++ b/unit/test-canxl.c
@@ -57,15 +57,6 @@ static void Test_CanXl_Init(void **state)
     assert_memory_equal(msg, expected_msg, msg_len);
 }
 
-static void Test_CanXl_GetAcfMsgType(void **state)
-{
-    const size_t msg_len = AVTP_CANXL_HEADER_LEN + 4;
-    uint8_t msg[msg_len] = {0x22, 0x06, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0,
-                            0x0,  0x0,  0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0};
-    Avtp_CanXl_t *canxl = (Avtp_CanXl_t *)msg;
-    assert_int_equal(Avtp_CanXl_GetAcfMsgType(canxl), AVTP_ACF_TYPE_CAN_XL);
-}
-
 static void Test_CanXl_GetAcfMsgLength(void **state)
 {
     const size_t msg_len = AVTP_CANXL_HEADER_LEN + 4;
@@ -227,16 +218,6 @@ static void Test_CanXl_GetAcfMsgLengthInBytes(void **state)
                             0x0,  0x0,  0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0};
     Avtp_CanXl_t *canxl = (Avtp_CanXl_t *)msg;
     assert_int_equal(Avtp_CanXl_GetAcfMsgLengthInBytes(canxl), 7 * 4);
-}
-
-static void Test_CanXl_SetAcfMsgType(void **state)
-{
-    const size_t msg_len = AVTP_CANXL_HEADER_LEN + 4;
-    uint8_t msg[msg_len] = {0};
-    Avtp_CanXl_t *canxl = (Avtp_CanXl_t *)msg;
-    Avtp_CanXl_Init(canxl);
-    Avtp_CanXl_SetAcfMsgType(canxl, AVTP_ACF_TYPE_CAN_XL);
-    assert_int_equal(Avtp_CanXl_GetAcfMsgType(canxl), AVTP_ACF_TYPE_CAN_XL);
 }
 
 static void Test_CanXl_SetAcfMsgLength(void **state)
@@ -469,7 +450,7 @@ static void Test_CanXl_CreateAcfMessage(void **state)
 
     Avtp_CanXl_CreateAcfMessage(canxl, 0x5FF, 0xBFFFFFFFul, 0xBF, payload, sizeof(payload));
 
-    assert_int_equal(Avtp_CanXl_GetAcfMsgType(canxl), AVTP_ACF_TYPE_CAN_XL);
+    assert_int_equal(Avtp_AcfCommon_GetAcfMsgType((Avtp_AcfCommon_t *)canxl), AVTP_ACF_TYPE_CAN_XL);
     assert_int_equal(Avtp_CanXl_GetPriorityId(canxl), 0x5FF);
     assert_int_equal(Avtp_CanXl_GetAcceptanceField(canxl), 0xBFFFFFFFul);
     assert_int_equal(Avtp_CanXl_GetSdt(canxl), 0xBF);
@@ -496,7 +477,7 @@ static void Test_CanXl_CreateFromGarbage(void **state)
     memset(msg, 0xAA, msg_len);
     Avtp_CanXl_CreateAcfMessage(canxl, 0x5FF, 0x0, 0x0, payload, sizeof(payload));
 
-    assert_int_equal(Avtp_CanXl_GetAcfMsgType(canxl), AVTP_ACF_TYPE_CAN_XL);
+    assert_int_equal(Avtp_AcfCommon_GetAcfMsgType((Avtp_AcfCommon_t *)canxl), AVTP_ACF_TYPE_CAN_XL);
     assert_int_equal(Avtp_CanXl_IsMtv(canxl), false);
     assert_int_equal(Avtp_CanXl_IsRrs(canxl), false);
     assert_int_equal(Avtp_CanXl_IsSec(canxl), false);
@@ -534,7 +515,6 @@ static void Test_CanXl_IsValid(void **state)
 int main(void)
 {
     const struct CMUnitTest tests[] = {cmocka_unit_test(Test_CanXl_Init),
-                                       cmocka_unit_test(Test_CanXl_GetAcfMsgType),
                                        cmocka_unit_test(Test_CanXl_GetAcfMsgLength),
                                        cmocka_unit_test(Test_CanXl_GetPad),
                                        cmocka_unit_test(Test_CanXl_IsMtv),
@@ -552,7 +532,6 @@ int main(void)
                                        cmocka_unit_test(Test_CanXl_GetPayloadLength),
                                        cmocka_unit_test(Test_CanXl_GetPayloadLength_NoPadding),
                                        cmocka_unit_test(Test_CanXl_GetAcfMsgLengthInBytes),
-                                       cmocka_unit_test(Test_CanXl_SetAcfMsgType),
                                        cmocka_unit_test(Test_CanXl_SetAcfMsgLength),
                                        cmocka_unit_test(Test_CanXl_SetMtv),
                                        cmocka_unit_test(Test_CanXl_SetCanBusId),

--- a/unit/test-flexray.c
+++ b/unit/test-flexray.c
@@ -65,8 +65,8 @@ static void flexray_get_set_fields(void **state)
 
     assert_int_equal(Avtp_AcfCommon_GetAcfMsgType((Avtp_AcfCommon_t *)pdu), AVTP_ACF_TYPE_FLEXRAY);
 
-    Avtp_FlexRay_SetAcfMsgLength((Avtp_FlexRay_t *)pdu, 100);
-    assert_int_equal(Avtp_FlexRay_GetAcfMsgLength((Avtp_FlexRay_t *)pdu), 100);
+    Avtp_AcfCommon_SetAcfMsgLength((Avtp_AcfCommon_t *)pdu, 100);
+    assert_int_equal(Avtp_AcfCommon_GetAcfMsgLength((Avtp_AcfCommon_t *)pdu), 100);
 
     Avtp_FlexRay_SetPad((Avtp_FlexRay_t *)pdu, 2);
     assert_int_equal(Avtp_FlexRay_GetPad((Avtp_FlexRay_t *)pdu), 2);
@@ -126,23 +126,23 @@ static void flexray_is_valid(void **state)
     assert_int_equal(Avtp_FlexRay_IsValid((Avtp_FlexRay_t *)pdu, MAX_PDU_SIZE), 0);
 
     Avtp_FlexRay_Init((Avtp_FlexRay_t *)pdu);
-    Avtp_FlexRay_SetAcfMsgLength((Avtp_FlexRay_t *)pdu, 4);
+    Avtp_AcfCommon_SetAcfMsgLength((Avtp_AcfCommon_t *)pdu, 4);
     assert_int_equal(Avtp_FlexRay_IsValid((Avtp_FlexRay_t *)pdu, MAX_PDU_SIZE), 1);
 
     memset(pdu, 0xFF, MAX_PDU_SIZE);
     assert_int_equal(Avtp_FlexRay_IsValid((Avtp_FlexRay_t *)pdu, MAX_PDU_SIZE), 0);
 
     Avtp_FlexRay_Init((Avtp_FlexRay_t *)pdu);
-    Avtp_FlexRay_SetAcfMsgLength((Avtp_FlexRay_t *)pdu, 6);
+    Avtp_AcfCommon_SetAcfMsgLength((Avtp_AcfCommon_t *)pdu, 6);
     assert_int_equal(Avtp_FlexRay_IsValid((Avtp_FlexRay_t *)pdu, 25), 1);
 
     Avtp_FlexRay_Init((Avtp_FlexRay_t *)pdu);
-    Avtp_FlexRay_SetAcfMsgLength((Avtp_FlexRay_t *)pdu, 6);
+    Avtp_AcfCommon_SetAcfMsgLength((Avtp_AcfCommon_t *)pdu, 6);
     assert_int_equal(Avtp_FlexRay_IsValid((Avtp_FlexRay_t *)pdu, 9), 0);
 
     // FlexRay payload bound: > 254 bytes is invalid.
     Avtp_FlexRay_Init((Avtp_FlexRay_t *)pdu);
-    Avtp_FlexRay_SetAcfMsgLength((Avtp_FlexRay_t *)pdu, 68);
+    Avtp_AcfCommon_SetAcfMsgLength((Avtp_AcfCommon_t *)pdu, 68);
     assert_int_equal(Avtp_FlexRay_IsValid((Avtp_FlexRay_t *)pdu, MAX_PDU_SIZE), 0);
 }
 

--- a/unit/test-flexray.c
+++ b/unit/test-flexray.c
@@ -63,8 +63,7 @@ static void flexray_get_set_fields(void **state)
 
     Avtp_FlexRay_Init((Avtp_FlexRay_t *)pdu);
 
-    Avtp_FlexRay_SetAcfMsgType((Avtp_FlexRay_t *)pdu, AVTP_ACF_TYPE_FLEXRAY);
-    assert_int_equal(Avtp_FlexRay_GetAcfMsgType((Avtp_FlexRay_t *)pdu), AVTP_ACF_TYPE_FLEXRAY);
+    assert_int_equal(Avtp_AcfCommon_GetAcfMsgType((Avtp_AcfCommon_t *)pdu), AVTP_ACF_TYPE_FLEXRAY);
 
     Avtp_FlexRay_SetAcfMsgLength((Avtp_FlexRay_t *)pdu, 100);
     assert_int_equal(Avtp_FlexRay_GetAcfMsgLength((Avtp_FlexRay_t *)pdu), 100);
@@ -154,7 +153,7 @@ static void flexray_create_message(void **state)
 
     Avtp_FlexRay_CreateAcfMessage((Avtp_FlexRay_t *)pdu, 0x7FF, 63, payload, sizeof(payload));
 
-    assert_int_equal(Avtp_FlexRay_GetAcfMsgType((Avtp_FlexRay_t *)pdu), AVTP_ACF_TYPE_FLEXRAY);
+    assert_int_equal(Avtp_AcfCommon_GetAcfMsgType((Avtp_AcfCommon_t *)pdu), AVTP_ACF_TYPE_FLEXRAY);
     assert_int_equal(Avtp_FlexRay_GetFrFrameId((Avtp_FlexRay_t *)pdu), 0x7FF);
     assert_int_equal(Avtp_FlexRay_GetCycle((Avtp_FlexRay_t *)pdu), 63);
     assert_memory_equal(payload, pdu + AVTP_FLEXRAY_HEADER_LEN, sizeof(payload));
@@ -171,7 +170,7 @@ static void flexray_create_from_garbage(void **state)
     memset(pdu, 0xAA, MAX_PDU_SIZE);
     Avtp_FlexRay_CreateAcfMessage((Avtp_FlexRay_t *)pdu, 0x123, 0x3F, payload, sizeof(payload));
 
-    assert_int_equal(Avtp_FlexRay_GetAcfMsgType((Avtp_FlexRay_t *)pdu), AVTP_ACF_TYPE_FLEXRAY);
+    assert_int_equal(Avtp_AcfCommon_GetAcfMsgType((Avtp_AcfCommon_t *)pdu), AVTP_ACF_TYPE_FLEXRAY);
     assert_int_equal(Avtp_FlexRay_IsMtv((Avtp_FlexRay_t *)pdu), 0);
     assert_int_equal(Avtp_FlexRay_IsStr((Avtp_FlexRay_t *)pdu), 0);
     assert_int_equal(Avtp_FlexRay_IsSyn((Avtp_FlexRay_t *)pdu), 0);

--- a/unit/test-gbb.c
+++ b/unit/test-gbb.c
@@ -56,15 +56,6 @@ static void Test_Gbb_Init(void **state)
     assert_memory_equal(msg, expected_msg, msg_len);
 }
 
-static void Test_Gbb_GetAcfMsgType(void **state)
-{
-    const size_t msg_len = AVTP_GBB_HEADER_LEN + 4;
-    uint8_t msg[msg_len] = {0x1A, 0x04, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0,
-                            0x0,  0x0,  0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0};
-    Avtp_Gbb_t *gbb = (Avtp_Gbb_t *)msg;
-    assert_int_equal(Avtp_Gbb_GetAcfMsgType(gbb), AVTP_ACF_TYPE_BYTE_BUS);
-}
-
 static void Test_Gbb_GetAcfMsgLength(void **state)
 {
     const size_t msg_len = AVTP_GBB_HEADER_LEN + 4;
@@ -225,16 +216,6 @@ static void Test_Gbb_GetAcfMsgLengthInBytes(void **state)
                             0x0,  0x0,  0x0, 0x0, 0x0B, 0xFF, 0x0, 0x0, 0x0, 0x0};
     Avtp_Gbb_t *gbb = (Avtp_Gbb_t *)msg;
     assert_int_equal(Avtp_Gbb_GetAcfMsgLengthInBytes(gbb), 5 * 4);
-}
-
-static void Test_Gbb_SetAcfMsgType(void **state)
-{
-    const size_t msg_len = AVTP_GBB_HEADER_LEN + 4;
-    uint8_t msg[msg_len] = {0};
-    Avtp_Gbb_t *gbb = (Avtp_Gbb_t *)msg;
-    Avtp_Gbb_Init(gbb);
-    Avtp_Gbb_SetAcfMsgType(gbb, AVTP_ACF_TYPE_BYTE_BUS);
-    assert_int_equal(Avtp_Gbb_GetAcfMsgType(gbb), AVTP_ACF_TYPE_BYTE_BUS);
 }
 
 static void Test_Gbb_SetAcfMsgLength(void **state)
@@ -466,7 +447,7 @@ static void Test_Gbb_CreateAcfMessage(void **state)
 
     Avtp_Gbb_CreateAcfMessage(gbb, 0x5FF, true, 0xBF, payload, sizeof(payload));
 
-    assert_int_equal(Avtp_Gbb_GetAcfMsgType(gbb), AVTP_ACF_TYPE_BYTE_BUS);
+    assert_int_equal(Avtp_AcfCommon_GetAcfMsgType((Avtp_AcfCommon_t *)gbb), AVTP_ACF_TYPE_BYTE_BUS);
     assert_int_equal(Avtp_Gbb_GetByteBusId(gbb), 0x5FF);
     assert_int_equal(Avtp_Gbb_IsOp(gbb), true);
     assert_int_equal(Avtp_Gbb_GetTransactionNum(gbb), 0xBF);
@@ -489,7 +470,7 @@ static void Test_Gbb_CreateFromGarbage(void **state)
     memset(msg, 0xAA, msg_len);
     Avtp_Gbb_CreateAcfMessage(gbb, 0x5FF, true, 0xBF, payload, sizeof(payload));
 
-    assert_int_equal(Avtp_Gbb_GetAcfMsgType(gbb), AVTP_ACF_TYPE_BYTE_BUS);
+    assert_int_equal(Avtp_AcfCommon_GetAcfMsgType((Avtp_AcfCommon_t *)gbb), AVTP_ACF_TYPE_BYTE_BUS);
     assert_int_equal(Avtp_Gbb_IsMtv(gbb), false);
     assert_int_equal(Avtp_Gbb_IsHs(gbb), false);
     assert_int_equal(Avtp_Gbb_IsCs(gbb), false);
@@ -528,7 +509,6 @@ static void Test_Gbb_IsValid(void **state)
 int main(void)
 {
     const struct CMUnitTest tests[] = {cmocka_unit_test(Test_Gbb_Init),
-                                       cmocka_unit_test(Test_Gbb_GetAcfMsgType),
                                        cmocka_unit_test(Test_Gbb_GetAcfMsgLength),
                                        cmocka_unit_test(Test_Gbb_GetPad),
                                        cmocka_unit_test(Test_Gbb_IsMtv),
@@ -547,7 +527,6 @@ int main(void)
                                        cmocka_unit_test(Test_Gbb_GetPayloadLength),
                                        cmocka_unit_test(Test_Gbb_GetPayloadLength_NoPadding),
                                        cmocka_unit_test(Test_Gbb_GetAcfMsgLengthInBytes),
-                                       cmocka_unit_test(Test_Gbb_SetAcfMsgType),
                                        cmocka_unit_test(Test_Gbb_SetAcfMsgLength),
                                        cmocka_unit_test(Test_Gbb_SetMtv),
                                        cmocka_unit_test(Test_Gbb_SetByteBusId),

--- a/unit/test-gbb.c
+++ b/unit/test-gbb.c
@@ -56,15 +56,6 @@ static void Test_Gbb_Init(void **state)
     assert_memory_equal(msg, expected_msg, msg_len);
 }
 
-static void Test_Gbb_GetAcfMsgLength(void **state)
-{
-    const size_t msg_len = AVTP_GBB_HEADER_LEN + 4;
-    uint8_t msg[msg_len] = {0x1A, 0x04, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0,
-                            0x0,  0x0,  0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0};
-    Avtp_Gbb_t *gbb = (Avtp_Gbb_t *)msg;
-    assert_int_equal(Avtp_Gbb_GetAcfMsgLength(gbb), 4);
-}
-
 static void Test_Gbb_GetPad(void **state)
 {
     const size_t msg_len = AVTP_GBB_HEADER_LEN + 4;
@@ -207,26 +198,6 @@ static void Test_Gbb_GetPayloadLength_NoPadding(void **state)
                             0x0,  0x0,  0x0, 0x0, 0x0B, 0xFF, 0x0, 0x0, 0x0, 0x0};
     Avtp_Gbb_t *gbb = (Avtp_Gbb_t *)msg;
     assert_int_equal(Avtp_Gbb_GetPayloadLength(gbb), 4);
-}
-
-static void Test_Gbb_GetAcfMsgLengthInBytes(void **state)
-{
-    const size_t msg_len = AVTP_GBB_HEADER_LEN + 4;
-    uint8_t msg[msg_len] = {0x1A, 0x05, 0x0, 0x0, 0x0,  0x0,  0x0, 0x0, 0x0, 0x0,
-                            0x0,  0x0,  0x0, 0x0, 0x0B, 0xFF, 0x0, 0x0, 0x0, 0x0};
-    Avtp_Gbb_t *gbb = (Avtp_Gbb_t *)msg;
-    assert_int_equal(Avtp_Gbb_GetAcfMsgLengthInBytes(gbb), 5 * 4);
-}
-
-static void Test_Gbb_SetAcfMsgLength(void **state)
-{
-    const size_t msg_len = AVTP_GBB_HEADER_LEN + 4;
-    uint8_t msg[msg_len] = {0};
-    Avtp_Gbb_t *gbb = (Avtp_Gbb_t *)msg;
-    Avtp_Gbb_Init(gbb);
-    Avtp_Gbb_SetAcfMsgLength(gbb, 5);
-    assert_int_equal(Avtp_Gbb_GetAcfMsgLength(gbb), 5);
-    assert_int_equal(Avtp_Gbb_GetAcfMsgLengthInBytes(gbb), 20);
 }
 
 static void Test_Gbb_SetMtv(void **state)
@@ -509,7 +480,6 @@ static void Test_Gbb_IsValid(void **state)
 int main(void)
 {
     const struct CMUnitTest tests[] = {cmocka_unit_test(Test_Gbb_Init),
-                                       cmocka_unit_test(Test_Gbb_GetAcfMsgLength),
                                        cmocka_unit_test(Test_Gbb_GetPad),
                                        cmocka_unit_test(Test_Gbb_IsMtv),
                                        cmocka_unit_test(Test_Gbb_GetByteBusId),
@@ -526,8 +496,6 @@ int main(void)
                                        cmocka_unit_test(Test_Gbb_GetSegmentNum),
                                        cmocka_unit_test(Test_Gbb_GetPayloadLength),
                                        cmocka_unit_test(Test_Gbb_GetPayloadLength_NoPadding),
-                                       cmocka_unit_test(Test_Gbb_GetAcfMsgLengthInBytes),
-                                       cmocka_unit_test(Test_Gbb_SetAcfMsgLength),
                                        cmocka_unit_test(Test_Gbb_SetMtv),
                                        cmocka_unit_test(Test_Gbb_SetByteBusId),
                                        cmocka_unit_test(Test_Gbb_SetMessageTimestamp),

--- a/unit/test-gisf.c
+++ b/unit/test-gisf.c
@@ -55,17 +55,6 @@ static void Test_Gisf_Init(void **state)
     assert_memory_equal(msg, expected_msg, msg_len);
 }
 
-static void Test_Gisf_GetAcfMsgLength(void **state)
-{
-    const size_t msg_len = AVTP_GISF_HEADER_LEN + 4;
-    uint8_t msg[msg_len] = {
-        0x18, 0x05, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0,
-        0x0,  0x0,  0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0,
-    };
-    Avtp_Gisf_t *gisf = (Avtp_Gisf_t *)msg;
-    assert_int_equal(Avtp_Gisf_GetAcfMsgLength(gisf), 5);
-}
-
 static void Test_Gisf_GetPad(void **state)
 {
     const size_t msg_len = AVTP_GISF_HEADER_LEN + 4;
@@ -229,28 +218,6 @@ static void Test_Gisf_GetPayloadLength_NoPadding(void **state)
     };
     Avtp_Gisf_t *gisf = (Avtp_Gisf_t *)msg;
     assert_int_equal(Avtp_Gisf_GetPayloadLength(gisf), 4);
-}
-
-static void Test_Gisf_GetAcfMsgLengthInBytes(void **state)
-{
-    const size_t msg_len = AVTP_GISF_HEADER_LEN + 4;
-    uint8_t msg[msg_len] = {
-        0x18, 0x06, 0xC0, 0x0, 0x0, 0x0, 0x0,  0x0,  0x0, 0x0, 0x0, 0x0,
-        0x0,  0x0,  0x0,  0x0, 0x0, 0x0, 0xBF, 0xFF, 0x0, 0x0, 0x0, 0x0,
-    };
-    Avtp_Gisf_t *gisf = (Avtp_Gisf_t *)msg;
-    assert_int_equal(Avtp_Gisf_GetAcfMsgLengthInBytes(gisf), 6 * 4);
-}
-
-static void Test_Gisf_SetAcfMsgLength(void **state)
-{
-    const size_t msg_len = AVTP_GISF_HEADER_LEN + 4;
-    uint8_t msg[msg_len] = {0};
-    Avtp_Gisf_t *gisf = (Avtp_Gisf_t *)msg;
-    Avtp_Gisf_Init(gisf);
-    Avtp_Gisf_SetAcfMsgLength(gisf, 5);
-    assert_int_equal(Avtp_Gisf_GetAcfMsgLength(gisf), 5);
-    assert_int_equal(Avtp_Gisf_GetAcfMsgLengthInBytes(gisf), 20);
 }
 
 static void Test_Gisf_SetMtv(void **state)
@@ -521,7 +488,6 @@ static void Test_Gisf_IsValid(void **state)
 int main(void)
 {
     const struct CMUnitTest tests[] = {cmocka_unit_test(Test_Gisf_Init),
-                                       cmocka_unit_test(Test_Gisf_GetAcfMsgLength),
                                        cmocka_unit_test(Test_Gisf_GetPad),
                                        cmocka_unit_test(Test_Gisf_IsMtv),
                                        cmocka_unit_test(Test_Gisf_GetImageSensorId),
@@ -537,8 +503,6 @@ int main(void)
                                        cmocka_unit_test(Test_Gisf_GetLineNumber),
                                        cmocka_unit_test(Test_Gisf_GetPayloadLength),
                                        cmocka_unit_test(Test_Gisf_GetPayloadLength_NoPadding),
-                                       cmocka_unit_test(Test_Gisf_GetAcfMsgLengthInBytes),
-                                       cmocka_unit_test(Test_Gisf_SetAcfMsgLength),
                                        cmocka_unit_test(Test_Gisf_SetMtv),
                                        cmocka_unit_test(Test_Gisf_SetImageSensorId),
                                        cmocka_unit_test(Test_Gisf_SetMessageTimestamp),

--- a/unit/test-gisf.c
+++ b/unit/test-gisf.c
@@ -55,17 +55,6 @@ static void Test_Gisf_Init(void **state)
     assert_memory_equal(msg, expected_msg, msg_len);
 }
 
-static void Test_Gisf_GetAcfMsgType(void **state)
-{
-    const size_t msg_len = AVTP_GISF_HEADER_LEN + 4;
-    uint8_t msg[msg_len] = {
-        0x18, 0x05, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0,
-        0x0,  0x0,  0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0,
-    };
-    Avtp_Gisf_t *gisf = (Avtp_Gisf_t *)msg;
-    assert_int_equal(Avtp_Gisf_GetAcfMsgType(gisf), AVTP_ACF_TYPE_GISF);
-}
-
 static void Test_Gisf_GetAcfMsgLength(void **state)
 {
     const size_t msg_len = AVTP_GISF_HEADER_LEN + 4;
@@ -251,16 +240,6 @@ static void Test_Gisf_GetAcfMsgLengthInBytes(void **state)
     };
     Avtp_Gisf_t *gisf = (Avtp_Gisf_t *)msg;
     assert_int_equal(Avtp_Gisf_GetAcfMsgLengthInBytes(gisf), 6 * 4);
-}
-
-static void Test_Gisf_SetAcfMsgType(void **state)
-{
-    const size_t msg_len = AVTP_GISF_HEADER_LEN + 4;
-    uint8_t msg[msg_len] = {0};
-    Avtp_Gisf_t *gisf = (Avtp_Gisf_t *)msg;
-    Avtp_Gisf_Init(gisf);
-    Avtp_Gisf_SetAcfMsgType(gisf, AVTP_ACF_TYPE_GISF);
-    assert_int_equal(Avtp_Gisf_GetAcfMsgType(gisf), AVTP_ACF_TYPE_GISF);
 }
 
 static void Test_Gisf_SetAcfMsgLength(void **state)
@@ -486,7 +465,7 @@ static void Test_Gisf_CreateAcfMessage(void **state)
 
     Avtp_Gisf_CreateAcfMessage(gisf, 0x5FF, payload, sizeof(payload));
 
-    assert_int_equal(Avtp_Gisf_GetAcfMsgType(gisf), AVTP_ACF_TYPE_GISF);
+    assert_int_equal(Avtp_AcfCommon_GetAcfMsgType((Avtp_AcfCommon_t *)gisf), AVTP_ACF_TYPE_GISF);
     assert_int_equal(Avtp_Gisf_GetImageSensorId(gisf), 0x5FF);
     assert_memory_equal(payload, msg + AVTP_GISF_HEADER_LEN, sizeof(payload));
     assert_int_equal(Avtp_Gisf_GetPayloadLength(gisf), 8);
@@ -504,7 +483,7 @@ static void Test_Gisf_CreateFromGarbage(void **state)
     memset(msg, 0xAA, msg_len);
     Avtp_Gisf_CreateAcfMessage(gisf, 0x5FF, payload, sizeof(payload));
 
-    assert_int_equal(Avtp_Gisf_GetAcfMsgType(gisf), AVTP_ACF_TYPE_GISF);
+    assert_int_equal(Avtp_AcfCommon_GetAcfMsgType((Avtp_AcfCommon_t *)gisf), AVTP_ACF_TYPE_GISF);
     assert_int_equal(Avtp_Gisf_IsMtv(gisf), false);
     assert_int_equal(Avtp_Gisf_IsEl(gisf), false);
     assert_int_equal(Avtp_Gisf_IsTl(gisf), false);
@@ -542,7 +521,6 @@ static void Test_Gisf_IsValid(void **state)
 int main(void)
 {
     const struct CMUnitTest tests[] = {cmocka_unit_test(Test_Gisf_Init),
-                                       cmocka_unit_test(Test_Gisf_GetAcfMsgType),
                                        cmocka_unit_test(Test_Gisf_GetAcfMsgLength),
                                        cmocka_unit_test(Test_Gisf_GetPad),
                                        cmocka_unit_test(Test_Gisf_IsMtv),
@@ -560,7 +538,6 @@ int main(void)
                                        cmocka_unit_test(Test_Gisf_GetPayloadLength),
                                        cmocka_unit_test(Test_Gisf_GetPayloadLength_NoPadding),
                                        cmocka_unit_test(Test_Gisf_GetAcfMsgLengthInBytes),
-                                       cmocka_unit_test(Test_Gisf_SetAcfMsgType),
                                        cmocka_unit_test(Test_Gisf_SetAcfMsgLength),
                                        cmocka_unit_test(Test_Gisf_SetMtv),
                                        cmocka_unit_test(Test_Gisf_SetImageSensorId),

--- a/unit/test-gpc.c
+++ b/unit/test-gpc.c
@@ -63,8 +63,7 @@ static void gpc_get_set_fields(void **state)
 
     Avtp_Gpc_Init((Avtp_Gpc_t *)pdu);
 
-    Avtp_Gpc_SetAcfMsgType((Avtp_Gpc_t *)pdu, AVTP_ACF_TYPE_GPC);
-    assert_int_equal(Avtp_Gpc_GetAcfMsgType((Avtp_Gpc_t *)pdu), AVTP_ACF_TYPE_GPC);
+    assert_int_equal(Avtp_AcfCommon_GetAcfMsgType((Avtp_AcfCommon_t *)pdu), AVTP_ACF_TYPE_GPC);
 
     Avtp_Gpc_SetAcfMsgLength((Avtp_Gpc_t *)pdu, 200);
     assert_int_equal(Avtp_Gpc_GetAcfMsgLength((Avtp_Gpc_t *)pdu), 200);
@@ -100,7 +99,7 @@ static void gpc_create_message(void **state)
 
     Avtp_Gpc_CreateAcfMessage((Avtp_Gpc_t *)pdu, 0x456789ABCDEFULL, payload, sizeof(payload));
 
-    assert_int_equal(Avtp_Gpc_GetAcfMsgType((Avtp_Gpc_t *)pdu), AVTP_ACF_TYPE_GPC);
+    assert_int_equal(Avtp_AcfCommon_GetAcfMsgType((Avtp_AcfCommon_t *)pdu), AVTP_ACF_TYPE_GPC);
     assert_int_equal(Avtp_Gpc_GetGpcMsgId((Avtp_Gpc_t *)pdu), 0x456789ABCDEFULL);
     assert_memory_equal(payload, pdu + AVTP_GPC_HEADER_LEN, sizeof(payload));
     assert_int_equal(Avtp_Gpc_GetAcfMsgLengthInBytes((Avtp_Gpc_t *)pdu), 16);
@@ -116,7 +115,7 @@ static void gpc_create_from_garbage(void **state)
     memset(pdu, 0xAA, MAX_PDU_SIZE);
     Avtp_Gpc_CreateAcfMessage((Avtp_Gpc_t *)pdu, 0x456789ABCDEFULL, payload, sizeof(payload));
 
-    assert_int_equal(Avtp_Gpc_GetAcfMsgType((Avtp_Gpc_t *)pdu), AVTP_ACF_TYPE_GPC);
+    assert_int_equal(Avtp_AcfCommon_GetAcfMsgType((Avtp_AcfCommon_t *)pdu), AVTP_ACF_TYPE_GPC);
     assert_int_equal(Avtp_Gpc_GetGpcMsgId((Avtp_Gpc_t *)pdu), 0x456789ABCDEFULL);
     assert_memory_equal(payload, pdu + AVTP_GPC_HEADER_LEN, sizeof(payload));
     assert_int_equal(Avtp_Gpc_IsValid((Avtp_Gpc_t *)pdu, MAX_PDU_SIZE), 1);

--- a/unit/test-gpc.c
+++ b/unit/test-gpc.c
@@ -65,8 +65,8 @@ static void gpc_get_set_fields(void **state)
 
     assert_int_equal(Avtp_AcfCommon_GetAcfMsgType((Avtp_AcfCommon_t *)pdu), AVTP_ACF_TYPE_GPC);
 
-    Avtp_Gpc_SetAcfMsgLength((Avtp_Gpc_t *)pdu, 200);
-    assert_int_equal(Avtp_Gpc_GetAcfMsgLength((Avtp_Gpc_t *)pdu), 200);
+    Avtp_AcfCommon_SetAcfMsgLength((Avtp_AcfCommon_t *)pdu, 200);
+    assert_int_equal(Avtp_AcfCommon_GetAcfMsgLength((Avtp_AcfCommon_t *)pdu), 200);
 
     Avtp_Gpc_SetGpcMsgId((Avtp_Gpc_t *)pdu, 0x456789ABCDEFULL);
     assert_int_equal(Avtp_Gpc_GetGpcMsgId((Avtp_Gpc_t *)pdu), 0x456789ABCDEFULL);
@@ -84,11 +84,11 @@ static void gpc_is_valid(void **state)
     assert_int_equal(Avtp_Gpc_IsValid((Avtp_Gpc_t *)pdu, MAX_PDU_SIZE), 0);
 
     Avtp_Gpc_Init((Avtp_Gpc_t *)pdu);
-    Avtp_Gpc_SetAcfMsgLength((Avtp_Gpc_t *)pdu, 4);
+    Avtp_AcfCommon_SetAcfMsgLength((Avtp_AcfCommon_t *)pdu, 4);
     assert_int_equal(Avtp_Gpc_IsValid((Avtp_Gpc_t *)pdu, 20), 1);
 
     Avtp_Gpc_Init((Avtp_Gpc_t *)pdu);
-    Avtp_Gpc_SetAcfMsgLength((Avtp_Gpc_t *)pdu, 4);
+    Avtp_AcfCommon_SetAcfMsgLength((Avtp_AcfCommon_t *)pdu, 4);
     assert_int_equal(Avtp_Gpc_IsValid((Avtp_Gpc_t *)pdu, 5), 0);
 }
 
@@ -102,7 +102,7 @@ static void gpc_create_message(void **state)
     assert_int_equal(Avtp_AcfCommon_GetAcfMsgType((Avtp_AcfCommon_t *)pdu), AVTP_ACF_TYPE_GPC);
     assert_int_equal(Avtp_Gpc_GetGpcMsgId((Avtp_Gpc_t *)pdu), 0x456789ABCDEFULL);
     assert_memory_equal(payload, pdu + AVTP_GPC_HEADER_LEN, sizeof(payload));
-    assert_int_equal(Avtp_Gpc_GetAcfMsgLengthInBytes((Avtp_Gpc_t *)pdu), 16);
+    assert_int_equal(Avtp_AcfCommon_GetAcfMsgLengthInBytes((Avtp_AcfCommon_t *)pdu), 16);
     assert_int_equal(Avtp_Gpc_IsValid((Avtp_Gpc_t *)pdu, MAX_PDU_SIZE), 1);
 }
 

--- a/unit/test-lin.c
+++ b/unit/test-lin.c
@@ -65,8 +65,8 @@ static void lin_get_set_fields(void **state)
 
     assert_int_equal(Avtp_AcfCommon_GetAcfMsgType((Avtp_AcfCommon_t *)pdu), AVTP_ACF_TYPE_LIN);
 
-    Avtp_Lin_SetAcfMsgLength((Avtp_Lin_t *)pdu, 50);
-    assert_int_equal(Avtp_Lin_GetAcfMsgLength((Avtp_Lin_t *)pdu), 50);
+    Avtp_AcfCommon_SetAcfMsgLength((Avtp_AcfCommon_t *)pdu, 50);
+    assert_int_equal(Avtp_AcfCommon_GetAcfMsgLength((Avtp_AcfCommon_t *)pdu), 50);
 
     Avtp_Lin_SetPad((Avtp_Lin_t *)pdu, 3);
     assert_int_equal(Avtp_Lin_GetPad((Avtp_Lin_t *)pdu), 3);
@@ -103,19 +103,19 @@ static void lin_is_valid(void **state)
     // Valid IEEE 1722 LIN Frame (Length 20, Buffer 25). AcfMsgLength=5
     // quadlets = 20 bytes; payload = 20 - 12 header = 8 bytes (LIN max).
     Avtp_Lin_Init((Avtp_Lin_t *)pdu);
-    Avtp_Lin_SetAcfMsgLength((Avtp_Lin_t *)pdu, 5);
+    Avtp_AcfCommon_SetAcfMsgLength((Avtp_AcfCommon_t *)pdu, 5);
     assert_int_equal(Avtp_Lin_IsValid((Avtp_Lin_t *)pdu, 25), 1);
 
     // Invalid IEEE 1722 LIN Frame (Length 20 but buffer only 9!).
     Avtp_Lin_Init((Avtp_Lin_t *)pdu);
-    Avtp_Lin_SetAcfMsgLength((Avtp_Lin_t *)pdu, 5);
+    Avtp_AcfCommon_SetAcfMsgLength((Avtp_AcfCommon_t *)pdu, 5);
     assert_int_equal(Avtp_Lin_IsValid((Avtp_Lin_t *)pdu, 9), 0);
 
     // LIN payload bound: a frame declaring a 12-byte payload is invalid
     // (LIN tops out at 8 bytes). AcfMsgLength=6 quadlets = 24 bytes;
     // payload = 24 - 12 header = 12 bytes.
     Avtp_Lin_Init((Avtp_Lin_t *)pdu);
-    Avtp_Lin_SetAcfMsgLength((Avtp_Lin_t *)pdu, 6);
+    Avtp_AcfCommon_SetAcfMsgLength((Avtp_AcfCommon_t *)pdu, 6);
     assert_int_equal(Avtp_Lin_IsValid((Avtp_Lin_t *)pdu, MAX_PDU_SIZE), 0);
 }
 
@@ -133,7 +133,7 @@ static void lin_create_message(void **state)
     assert_int_equal(Avtp_Lin_GetMessageTimestamp((Avtp_Lin_t *)pdu), 0x123456789ABCULL);
     assert_memory_equal(payload, pdu + AVTP_LIN_HEADER_LEN, sizeof(payload));
     assert_int_equal(Avtp_Lin_GetPayloadLength((Avtp_Lin_t *)pdu), 8);
-    assert_int_equal(Avtp_Lin_GetAcfMsgLength((Avtp_Lin_t *)pdu), 5);
+    assert_int_equal(Avtp_AcfCommon_GetAcfMsgLength((Avtp_AcfCommon_t *)pdu), 5);
     assert_int_equal(Avtp_Lin_IsValid((Avtp_Lin_t *)pdu, MAX_PDU_SIZE), 1);
 }
 

--- a/unit/test-lin.c
+++ b/unit/test-lin.c
@@ -63,8 +63,7 @@ static void lin_get_set_fields(void **state)
 
     Avtp_Lin_Init((Avtp_Lin_t *)pdu);
 
-    Avtp_Lin_SetAcfMsgType((Avtp_Lin_t *)pdu, AVTP_ACF_TYPE_LIN);
-    assert_int_equal(Avtp_Lin_GetAcfMsgType((Avtp_Lin_t *)pdu), AVTP_ACF_TYPE_LIN);
+    assert_int_equal(Avtp_AcfCommon_GetAcfMsgType((Avtp_AcfCommon_t *)pdu), AVTP_ACF_TYPE_LIN);
 
     Avtp_Lin_SetAcfMsgLength((Avtp_Lin_t *)pdu, 50);
     assert_int_equal(Avtp_Lin_GetAcfMsgLength((Avtp_Lin_t *)pdu), 50);
@@ -148,7 +147,7 @@ static void lin_create_from_garbage(void **state)
     Avtp_Lin_CreateAcfMessage((Avtp_Lin_t *)pdu, 7, 0x3F, 0x123456789ABCULL, payload,
                               sizeof(payload));
 
-    assert_int_equal(Avtp_Lin_GetAcfMsgType((Avtp_Lin_t *)pdu), AVTP_ACF_TYPE_LIN);
+    assert_int_equal(Avtp_AcfCommon_GetAcfMsgType((Avtp_AcfCommon_t *)pdu), AVTP_ACF_TYPE_LIN);
     assert_int_equal(Avtp_Lin_IsMtv((Avtp_Lin_t *)pdu), 0);
     assert_int_equal(Avtp_Lin_GetLinBusId((Avtp_Lin_t *)pdu), 7);
     assert_int_equal(Avtp_Lin_GetLinIdentifier((Avtp_Lin_t *)pdu), 0x3F);

--- a/unit/test-most.c
+++ b/unit/test-most.c
@@ -63,8 +63,7 @@ static void most_get_set_fields(void **state)
 
     Avtp_Most_Init((Avtp_Most_t *)pdu);
 
-    Avtp_Most_SetAcfMsgType((Avtp_Most_t *)pdu, AVTP_ACF_TYPE_MOST);
-    assert_int_equal(Avtp_Most_GetAcfMsgType((Avtp_Most_t *)pdu), AVTP_ACF_TYPE_MOST);
+    assert_int_equal(Avtp_AcfCommon_GetAcfMsgType((Avtp_AcfCommon_t *)pdu), AVTP_ACF_TYPE_MOST);
 
     Avtp_Most_SetAcfMsgLength((Avtp_Most_t *)pdu, 120);
     assert_int_equal(Avtp_Most_GetAcfMsgLength((Avtp_Most_t *)pdu), 120);
@@ -128,7 +127,7 @@ static void most_create_message(void **state)
     Avtp_Most_CreateAcfMessage((Avtp_Most_t *)pdu, 0x1234, 0xAB, 0x12, 0x456, 0x0F, payload,
                                sizeof(payload));
 
-    assert_int_equal(Avtp_Most_GetAcfMsgType((Avtp_Most_t *)pdu), AVTP_ACF_TYPE_MOST);
+    assert_int_equal(Avtp_AcfCommon_GetAcfMsgType((Avtp_AcfCommon_t *)pdu), AVTP_ACF_TYPE_MOST);
     assert_int_equal(Avtp_Most_GetDeviceId((Avtp_Most_t *)pdu), 0x1234);
     assert_int_equal(Avtp_Most_GetFblockId((Avtp_Most_t *)pdu), 0xAB);
     assert_int_equal(Avtp_Most_GetInstId((Avtp_Most_t *)pdu), 0x12);
@@ -149,7 +148,7 @@ static void most_create_from_garbage(void **state)
     Avtp_Most_CreateAcfMessage((Avtp_Most_t *)pdu, 0x1234, 0xAB, 0x12, 0x456, 0x0F, payload,
                                sizeof(payload));
 
-    assert_int_equal(Avtp_Most_GetAcfMsgType((Avtp_Most_t *)pdu), AVTP_ACF_TYPE_MOST);
+    assert_int_equal(Avtp_AcfCommon_GetAcfMsgType((Avtp_AcfCommon_t *)pdu), AVTP_ACF_TYPE_MOST);
     assert_int_equal(Avtp_Most_IsMtv((Avtp_Most_t *)pdu), 0);
     assert_int_equal(Avtp_Most_GetMostNetId((Avtp_Most_t *)pdu), 0);
     assert_int_equal(Avtp_Most_GetMessageTimestamp((Avtp_Most_t *)pdu), 0);

--- a/unit/test-most.c
+++ b/unit/test-most.c
@@ -65,8 +65,8 @@ static void most_get_set_fields(void **state)
 
     assert_int_equal(Avtp_AcfCommon_GetAcfMsgType((Avtp_AcfCommon_t *)pdu), AVTP_ACF_TYPE_MOST);
 
-    Avtp_Most_SetAcfMsgLength((Avtp_Most_t *)pdu, 120);
-    assert_int_equal(Avtp_Most_GetAcfMsgLength((Avtp_Most_t *)pdu), 120);
+    Avtp_AcfCommon_SetAcfMsgLength((Avtp_AcfCommon_t *)pdu, 120);
+    assert_int_equal(Avtp_AcfCommon_GetAcfMsgLength((Avtp_AcfCommon_t *)pdu), 120);
 
     Avtp_Most_SetPad((Avtp_Most_t *)pdu, 1);
     assert_int_equal(Avtp_Most_GetPad((Avtp_Most_t *)pdu), 1);
@@ -111,11 +111,11 @@ static void most_is_valid(void **state)
     assert_int_equal(Avtp_Most_IsValid((Avtp_Most_t *)pdu, MAX_PDU_SIZE), 0);
 
     Avtp_Most_Init((Avtp_Most_t *)pdu);
-    Avtp_Most_SetAcfMsgLength((Avtp_Most_t *)pdu, 8);
+    Avtp_AcfCommon_SetAcfMsgLength((Avtp_AcfCommon_t *)pdu, 8);
     assert_int_equal(Avtp_Most_IsValid((Avtp_Most_t *)pdu, 35), 1);
 
     Avtp_Most_Init((Avtp_Most_t *)pdu);
-    Avtp_Most_SetAcfMsgLength((Avtp_Most_t *)pdu, 8);
+    Avtp_AcfCommon_SetAcfMsgLength((Avtp_AcfCommon_t *)pdu, 8);
     assert_int_equal(Avtp_Most_IsValid((Avtp_Most_t *)pdu, 9), 0);
 }
 

--- a/unit/test-sensor.c
+++ b/unit/test-sensor.c
@@ -64,8 +64,7 @@ static void sensor_get_set_fields(void **state)
 
     Avtp_Sensor_Init((Avtp_Sensor_t *)pdu);
 
-    Avtp_Sensor_SetAcfMsgType((Avtp_Sensor_t *)pdu, AVTP_ACF_TYPE_SENSOR);
-    assert_int_equal(Avtp_Sensor_GetAcfMsgType((Avtp_Sensor_t *)pdu), AVTP_ACF_TYPE_SENSOR);
+    assert_int_equal(Avtp_AcfCommon_GetAcfMsgType((Avtp_AcfCommon_t *)pdu), AVTP_ACF_TYPE_SENSOR);
 
     Avtp_Sensor_SetAcfMsgLength((Avtp_Sensor_t *)pdu, 80);
     assert_int_equal(Avtp_Sensor_GetAcfMsgLength((Avtp_Sensor_t *)pdu), 80);
@@ -131,7 +130,7 @@ static void sensor_create_message(void **state)
     // 3 sensors * 2 octets each = 6 bytes of payload.
     Avtp_Sensor_CreateAcfMessage((Avtp_Sensor_t *)pdu, 3, 2, payload, sizeof(payload));
 
-    assert_int_equal(Avtp_Sensor_GetAcfMsgType((Avtp_Sensor_t *)pdu), AVTP_ACF_TYPE_SENSOR);
+    assert_int_equal(Avtp_AcfCommon_GetAcfMsgType((Avtp_AcfCommon_t *)pdu), AVTP_ACF_TYPE_SENSOR);
     assert_int_equal(Avtp_Sensor_GetNumSensor((Avtp_Sensor_t *)pdu), 3);
     assert_int_equal(Avtp_Sensor_GetSz((Avtp_Sensor_t *)pdu), 2);
     assert_int_equal(Avtp_Sensor_GetPayloadLength((Avtp_Sensor_t *)pdu), 6);
@@ -177,7 +176,7 @@ static void sensor_create_from_garbage(void **state)
     memset(pdu, 0xAA, MAX_PDU_SIZE);
     Avtp_Sensor_CreateAcfMessage((Avtp_Sensor_t *)pdu, 3, 2, payload, sizeof(payload));
 
-    assert_int_equal(Avtp_Sensor_GetAcfMsgType((Avtp_Sensor_t *)pdu), AVTP_ACF_TYPE_SENSOR);
+    assert_int_equal(Avtp_AcfCommon_GetAcfMsgType((Avtp_AcfCommon_t *)pdu), AVTP_ACF_TYPE_SENSOR);
     assert_int_equal(Avtp_Sensor_IsMtv((Avtp_Sensor_t *)pdu), 0);
     assert_int_equal(Avtp_Sensor_GetSensorGroup((Avtp_Sensor_t *)pdu), 0);
     assert_int_equal(Avtp_Sensor_GetMessageTimestamp((Avtp_Sensor_t *)pdu), 0);
@@ -204,8 +203,7 @@ static void sensor_brief_get_set_fields(void **state)
 
     Avtp_SensorBrief_Init((Avtp_SensorBrief_t *)pdu);
 
-    Avtp_SensorBrief_SetAcfMsgType((Avtp_SensorBrief_t *)pdu, AVTP_ACF_TYPE_SENSOR_BRIEF);
-    assert_int_equal(Avtp_SensorBrief_GetAcfMsgType((Avtp_SensorBrief_t *)pdu),
+    assert_int_equal(Avtp_AcfCommon_GetAcfMsgType((Avtp_AcfCommon_t *)pdu),
                      AVTP_ACF_TYPE_SENSOR_BRIEF);
 
     Avtp_SensorBrief_SetAcfMsgLength((Avtp_SensorBrief_t *)pdu, 5);
@@ -259,7 +257,7 @@ static void sensor_brief_create_message(void **state)
     // 3 sensors * 2 octets each = 6 bytes of payload.
     Avtp_SensorBrief_CreateAcfMessage((Avtp_SensorBrief_t *)pdu, 3, 2, payload, sizeof(payload));
 
-    assert_int_equal(Avtp_SensorBrief_GetAcfMsgType((Avtp_SensorBrief_t *)pdu),
+    assert_int_equal(Avtp_AcfCommon_GetAcfMsgType((Avtp_AcfCommon_t *)pdu),
                      AVTP_ACF_TYPE_SENSOR_BRIEF);
     assert_int_equal(Avtp_SensorBrief_GetNumSensor((Avtp_SensorBrief_t *)pdu), 3);
     assert_int_equal(Avtp_SensorBrief_GetSz((Avtp_SensorBrief_t *)pdu), 2);

--- a/unit/test-sensor.c
+++ b/unit/test-sensor.c
@@ -66,8 +66,8 @@ static void sensor_get_set_fields(void **state)
 
     assert_int_equal(Avtp_AcfCommon_GetAcfMsgType((Avtp_AcfCommon_t *)pdu), AVTP_ACF_TYPE_SENSOR);
 
-    Avtp_Sensor_SetAcfMsgLength((Avtp_Sensor_t *)pdu, 80);
-    assert_int_equal(Avtp_Sensor_GetAcfMsgLength((Avtp_Sensor_t *)pdu), 80);
+    Avtp_AcfCommon_SetAcfMsgLength((Avtp_AcfCommon_t *)pdu, 80);
+    assert_int_equal(Avtp_AcfCommon_GetAcfMsgLength((Avtp_AcfCommon_t *)pdu), 80);
 
     Avtp_Sensor_SetMtv((Avtp_Sensor_t *)pdu, true);
     assert_int_equal(Avtp_Sensor_IsMtv((Avtp_Sensor_t *)pdu), 1);
@@ -112,13 +112,13 @@ static void sensor_is_valid(void **state)
     Avtp_Sensor_Init((Avtp_Sensor_t *)pdu);
     Avtp_Sensor_SetNumSensor((Avtp_Sensor_t *)pdu, 3);
     Avtp_Sensor_SetSz((Avtp_Sensor_t *)pdu, 2);
-    Avtp_Sensor_SetAcfMsgLength((Avtp_Sensor_t *)pdu, 4);
+    Avtp_AcfCommon_SetAcfMsgLength((Avtp_AcfCommon_t *)pdu, 4);
     assert_int_equal(Avtp_Sensor_IsValid((Avtp_Sensor_t *)pdu, MAX_PDU_SIZE), 0);
 
     Avtp_Sensor_Init((Avtp_Sensor_t *)pdu);
     Avtp_Sensor_SetNumSensor((Avtp_Sensor_t *)pdu, 3);
     Avtp_Sensor_SetSz((Avtp_Sensor_t *)pdu, 2);
-    Avtp_Sensor_SetAcfMsgLength((Avtp_Sensor_t *)pdu, 6);
+    Avtp_AcfCommon_SetAcfMsgLength((Avtp_AcfCommon_t *)pdu, 6);
     assert_int_equal(Avtp_Sensor_IsValid((Avtp_Sensor_t *)pdu, MAX_PDU_SIZE), 0);
 }
 
@@ -206,8 +206,8 @@ static void sensor_brief_get_set_fields(void **state)
     assert_int_equal(Avtp_AcfCommon_GetAcfMsgType((Avtp_AcfCommon_t *)pdu),
                      AVTP_ACF_TYPE_SENSOR_BRIEF);
 
-    Avtp_SensorBrief_SetAcfMsgLength((Avtp_SensorBrief_t *)pdu, 5);
-    assert_int_equal(Avtp_SensorBrief_GetAcfMsgLength((Avtp_SensorBrief_t *)pdu), 5);
+    Avtp_AcfCommon_SetAcfMsgLength((Avtp_AcfCommon_t *)pdu, 5);
+    assert_int_equal(Avtp_AcfCommon_GetAcfMsgLength((Avtp_AcfCommon_t *)pdu), 5);
 
     Avtp_SensorBrief_SetMtv((Avtp_SensorBrief_t *)pdu, true);
     assert_int_equal(Avtp_SensorBrief_IsMtv((Avtp_SensorBrief_t *)pdu), 1);
@@ -245,7 +245,7 @@ static void sensor_brief_is_valid(void **state)
     Avtp_SensorBrief_Init((Avtp_SensorBrief_t *)pdu);
     Avtp_SensorBrief_SetNumSensor((Avtp_SensorBrief_t *)pdu, 3);
     Avtp_SensorBrief_SetSz((Avtp_SensorBrief_t *)pdu, 2);
-    Avtp_SensorBrief_SetAcfMsgLength((Avtp_SensorBrief_t *)pdu, 2);
+    Avtp_AcfCommon_SetAcfMsgLength((Avtp_AcfCommon_t *)pdu, 2);
     assert_int_equal(Avtp_SensorBrief_IsValid((Avtp_SensorBrief_t *)pdu, MAX_PDU_SIZE), 0);
 }
 

--- a/unit/test-vss.c
+++ b/unit/test-vss.c
@@ -70,7 +70,7 @@ static void vss_pad(void **state)
     uint8_t pdu[MAX_PDU_SIZE];
     Avtp_Vss_t *vss_pdu = (Avtp_Vss_t *)pdu;
     Avtp_Vss_Init(vss_pdu);
-    Avtp_Vss_SetAcfMsgLength(vss_pdu, 20);
+    Avtp_AcfCommon_SetAcfMsgLength((Avtp_AcfCommon_t *)vss_pdu, 20);
 
     // Check if the function is initializing properly
     Avtp_Vss_Init(vss_pdu);
@@ -78,7 +78,7 @@ static void vss_pad(void **state)
     for (int i = 1; i < 4; i++) {
         Avtp_Vss_SetPayloadLength(vss_pdu, i);
 
-        uint8_t vss_quadlets = Avtp_Vss_GetAcfMsgLength(vss_pdu);
+        uint8_t vss_quadlets = Avtp_AcfCommon_GetAcfMsgLength((Avtp_AcfCommon_t *)vss_pdu);
         assert_int_equal(vss_quadlets, AVTP_VSS_FIXED_HEADER_LEN / 4 + 1);
 
         uint8_t vss_pad = Avtp_Vss_GetPad(vss_pdu);
@@ -92,7 +92,7 @@ static void vss_static_path(void **state)
     uint8_t pdu[MAX_PDU_SIZE];
     Avtp_Vss_t *vss_pdu = (Avtp_Vss_t *)pdu;
     Avtp_Vss_Init(vss_pdu);
-    Avtp_Vss_SetAcfMsgLength(vss_pdu, 20);
+    Avtp_AcfCommon_SetAcfMsgLength((Avtp_AcfCommon_t *)vss_pdu, 20);
 
     VssPath_t path_id = {.vss_static_id_path = 0x01020304};
     Avtp_Vss_SetAddrMode(vss_pdu, VSS_STATIC_ID_MODE);
@@ -114,7 +114,7 @@ static void vss_interop_path(void **state)
     uint8_t pdu[MAX_PDU_SIZE];
     Avtp_Vss_t *vss_pdu = (Avtp_Vss_t *)pdu;
     Avtp_Vss_Init(vss_pdu);
-    Avtp_Vss_SetAcfMsgLength(vss_pdu, 20);
+    Avtp_AcfCommon_SetAcfMsgLength((Avtp_AcfCommon_t *)vss_pdu, 20);
 
     char path[] = "Vehicle.Speed";
     uint32_t path_length = strlen(path);
@@ -144,7 +144,7 @@ static void vss_data_uint8(void **state)
     uint8_t pdu[MAX_PDU_SIZE];
     Avtp_Vss_t *vss_pdu = (Avtp_Vss_t *)pdu;
     Avtp_Vss_Init(vss_pdu);
-    Avtp_Vss_SetAcfMsgLength(vss_pdu, 20);
+    Avtp_AcfCommon_SetAcfMsgLength((Avtp_AcfCommon_t *)vss_pdu, 20);
     char path[] = "Vehicle.Speed";
     uint32_t path_length = strlen(path);
 
@@ -172,7 +172,7 @@ static void vss_data_int8(void **state)
     uint8_t pdu[MAX_PDU_SIZE];
     Avtp_Vss_t *vss_pdu = (Avtp_Vss_t *)pdu;
     Avtp_Vss_Init(vss_pdu);
-    Avtp_Vss_SetAcfMsgLength(vss_pdu, 20);
+    Avtp_AcfCommon_SetAcfMsgLength((Avtp_AcfCommon_t *)vss_pdu, 20);
     char path[] = "Vehicle.Speed";
     uint32_t path_length = strlen(path);
 
@@ -200,7 +200,7 @@ static void vss_data_uint16(void **state)
     uint8_t pdu[MAX_PDU_SIZE];
     Avtp_Vss_t *vss_pdu = (Avtp_Vss_t *)pdu;
     Avtp_Vss_Init(vss_pdu);
-    Avtp_Vss_SetAcfMsgLength(vss_pdu, 20);
+    Avtp_AcfCommon_SetAcfMsgLength((Avtp_AcfCommon_t *)vss_pdu, 20);
     char path[] = "Vehicle.Speed";
     uint32_t path_length = strlen(path);
 
@@ -228,7 +228,7 @@ static void vss_data_int16(void **state)
     uint8_t pdu[MAX_PDU_SIZE];
     Avtp_Vss_t *vss_pdu = (Avtp_Vss_t *)pdu;
     Avtp_Vss_Init(vss_pdu);
-    Avtp_Vss_SetAcfMsgLength(vss_pdu, 20);
+    Avtp_AcfCommon_SetAcfMsgLength((Avtp_AcfCommon_t *)vss_pdu, 20);
     char path[] = "Vehicle.Speed";
     uint32_t path_length = strlen(path);
 
@@ -256,7 +256,7 @@ static void vss_data_uint32(void **state)
     uint8_t pdu[MAX_PDU_SIZE];
     Avtp_Vss_t *vss_pdu = (Avtp_Vss_t *)pdu;
     Avtp_Vss_Init(vss_pdu);
-    Avtp_Vss_SetAcfMsgLength(vss_pdu, 20);
+    Avtp_AcfCommon_SetAcfMsgLength((Avtp_AcfCommon_t *)vss_pdu, 20);
     char path[] = "Vehicle.Speed";
     uint32_t path_length = strlen(path);
 
@@ -284,7 +284,7 @@ static void vss_data_int32(void **state)
     uint8_t pdu[MAX_PDU_SIZE];
     Avtp_Vss_t *vss_pdu = (Avtp_Vss_t *)pdu;
     Avtp_Vss_Init(vss_pdu);
-    Avtp_Vss_SetAcfMsgLength(vss_pdu, 20);
+    Avtp_AcfCommon_SetAcfMsgLength((Avtp_AcfCommon_t *)vss_pdu, 20);
     char path[] = "Vehicle.Speed";
     uint32_t path_length = strlen(path);
 
@@ -312,7 +312,7 @@ static void vss_data_uint64(void **state)
     uint8_t pdu[MAX_PDU_SIZE];
     Avtp_Vss_t *vss_pdu = (Avtp_Vss_t *)pdu;
     Avtp_Vss_Init(vss_pdu);
-    Avtp_Vss_SetAcfMsgLength(vss_pdu, 20);
+    Avtp_AcfCommon_SetAcfMsgLength((Avtp_AcfCommon_t *)vss_pdu, 20);
     char path[] = "Vehicle.Speed";
     uint32_t path_length = strlen(path);
 
@@ -341,7 +341,7 @@ static void vss_data_int64(void **state)
     uint8_t pdu[MAX_PDU_SIZE];
     Avtp_Vss_t *vss_pdu = (Avtp_Vss_t *)pdu;
     Avtp_Vss_Init(vss_pdu);
-    Avtp_Vss_SetAcfMsgLength(vss_pdu, 20);
+    Avtp_AcfCommon_SetAcfMsgLength((Avtp_AcfCommon_t *)vss_pdu, 20);
     char path[] = "Vehicle.Speed";
     uint32_t path_length = strlen(path);
 
@@ -370,7 +370,7 @@ static void vss_data_bool(void **state)
     uint8_t pdu[MAX_PDU_SIZE];
     Avtp_Vss_t *vss_pdu = (Avtp_Vss_t *)pdu;
     Avtp_Vss_Init(vss_pdu);
-    Avtp_Vss_SetAcfMsgLength(vss_pdu, 20);
+    Avtp_AcfCommon_SetAcfMsgLength((Avtp_AcfCommon_t *)vss_pdu, 20);
     char path[] = "Vehicle.Speed";
     uint32_t path_length = strlen(path);
 
@@ -398,7 +398,7 @@ static void vss_data_float(void **state)
     uint8_t pdu[MAX_PDU_SIZE];
     Avtp_Vss_t *vss_pdu = (Avtp_Vss_t *)pdu;
     Avtp_Vss_Init(vss_pdu);
-    Avtp_Vss_SetAcfMsgLength(vss_pdu, 20);
+    Avtp_AcfCommon_SetAcfMsgLength((Avtp_AcfCommon_t *)vss_pdu, 20);
     char path[] = "Vehicle.Speed";
     uint32_t path_length = strlen(path);
 
@@ -426,7 +426,7 @@ static void vss_data_double(void **state)
     uint8_t pdu[MAX_PDU_SIZE];
     Avtp_Vss_t *vss_pdu = (Avtp_Vss_t *)pdu;
     Avtp_Vss_Init(vss_pdu);
-    Avtp_Vss_SetAcfMsgLength(vss_pdu, 20);
+    Avtp_AcfCommon_SetAcfMsgLength((Avtp_AcfCommon_t *)vss_pdu, 20);
     char path[] = "Vehicle.Speed";
     uint32_t path_length = strlen(path);
 
@@ -454,7 +454,7 @@ static void vss_data_string(void **state)
     uint8_t pdu[MAX_PDU_SIZE];
     Avtp_Vss_t *vss_pdu = (Avtp_Vss_t *)pdu;
     Avtp_Vss_Init(vss_pdu);
-    Avtp_Vss_SetAcfMsgLength(vss_pdu, 20);
+    Avtp_AcfCommon_SetAcfMsgLength((Avtp_AcfCommon_t *)vss_pdu, 20);
     char path[] = "Vehicle.Speed";
     uint32_t path_length = strlen(path);
 
@@ -495,7 +495,7 @@ static void vss_data_uint8_array(void **state)
     uint8_t pdu[MAX_PDU_SIZE];
     Avtp_Vss_t *vss_pdu = (Avtp_Vss_t *)pdu;
     Avtp_Vss_Init(vss_pdu);
-    Avtp_Vss_SetAcfMsgLength(vss_pdu, 20);
+    Avtp_AcfCommon_SetAcfMsgLength((Avtp_AcfCommon_t *)vss_pdu, 20);
     char path[] = "Vehicle.Speed";
     uint32_t path_length = strlen(path);
 
@@ -536,7 +536,7 @@ static void vss_data_int8_array(void **state)
     uint8_t pdu[MAX_PDU_SIZE];
     Avtp_Vss_t *vss_pdu = (Avtp_Vss_t *)pdu;
     Avtp_Vss_Init(vss_pdu);
-    Avtp_Vss_SetAcfMsgLength(vss_pdu, 20);
+    Avtp_AcfCommon_SetAcfMsgLength((Avtp_AcfCommon_t *)vss_pdu, 20);
     char path[] = "Vehicle.Speed";
     uint32_t path_length = strlen(path);
 
@@ -578,7 +578,7 @@ static void vss_data_uint16_array(void **state)
     uint8_t pdu[MAX_PDU_SIZE];
     Avtp_Vss_t *vss_pdu = (Avtp_Vss_t *)pdu;
     Avtp_Vss_Init(vss_pdu);
-    Avtp_Vss_SetAcfMsgLength(vss_pdu, 20);
+    Avtp_AcfCommon_SetAcfMsgLength((Avtp_AcfCommon_t *)vss_pdu, 20);
     char path[] = "Vehicle.Speed";
     uint32_t path_length = strlen(path);
 
@@ -621,7 +621,7 @@ static void vss_data_int16_array(void **state)
     uint8_t pdu[MAX_PDU_SIZE];
     Avtp_Vss_t *vss_pdu = (Avtp_Vss_t *)pdu;
     Avtp_Vss_Init(vss_pdu);
-    Avtp_Vss_SetAcfMsgLength(vss_pdu, 20);
+    Avtp_AcfCommon_SetAcfMsgLength((Avtp_AcfCommon_t *)vss_pdu, 20);
     char path[] = "Vehicle.Speed";
     uint32_t path_length = strlen(path);
 
@@ -664,7 +664,7 @@ static void vss_data_uint32_array(void **state)
     uint8_t pdu[MAX_PDU_SIZE];
     Avtp_Vss_t *vss_pdu = (Avtp_Vss_t *)pdu;
     Avtp_Vss_Init(vss_pdu);
-    Avtp_Vss_SetAcfMsgLength(vss_pdu, 20);
+    Avtp_AcfCommon_SetAcfMsgLength((Avtp_AcfCommon_t *)vss_pdu, 20);
     char path[] = "Vehicle.Speed";
     uint32_t path_length = strlen(path);
 
@@ -707,7 +707,7 @@ static void vss_data_int32_array(void **state)
     uint8_t pdu[MAX_PDU_SIZE];
     Avtp_Vss_t *vss_pdu = (Avtp_Vss_t *)pdu;
     Avtp_Vss_Init(vss_pdu);
-    Avtp_Vss_SetAcfMsgLength(vss_pdu, 20);
+    Avtp_AcfCommon_SetAcfMsgLength((Avtp_AcfCommon_t *)vss_pdu, 20);
     char path[] = "Vehicle.Speed";
     uint32_t path_length = strlen(path);
 
@@ -751,7 +751,7 @@ static void vss_data_uint64_array(void **state)
     uint8_t pdu[MAX_PDU_SIZE];
     Avtp_Vss_t *vss_pdu = (Avtp_Vss_t *)pdu;
     Avtp_Vss_Init(vss_pdu);
-    Avtp_Vss_SetAcfMsgLength(vss_pdu, 20);
+    Avtp_AcfCommon_SetAcfMsgLength((Avtp_AcfCommon_t *)vss_pdu, 20);
     char path[] = "Vehicle.Speed";
     uint32_t path_length = strlen(path);
 
@@ -794,7 +794,7 @@ static void vss_data_int64_array(void **state)
     uint8_t pdu[MAX_PDU_SIZE];
     Avtp_Vss_t *vss_pdu = (Avtp_Vss_t *)pdu;
     Avtp_Vss_Init(vss_pdu);
-    Avtp_Vss_SetAcfMsgLength(vss_pdu, 20);
+    Avtp_AcfCommon_SetAcfMsgLength((Avtp_AcfCommon_t *)vss_pdu, 20);
     char path[] = "Vehicle.Speed";
     uint32_t path_length = strlen(path);
 
@@ -842,7 +842,7 @@ static void vss_data_bool_array(void **state)
     uint8_t pdu[MAX_PDU_SIZE];
     Avtp_Vss_t *vss_pdu = (Avtp_Vss_t *)pdu;
     Avtp_Vss_Init(vss_pdu);
-    Avtp_Vss_SetAcfMsgLength(vss_pdu, 20);
+    Avtp_AcfCommon_SetAcfMsgLength((Avtp_AcfCommon_t *)vss_pdu, 20);
     char path[] = "Vehicle.Speed";
     uint32_t path_length = strlen(path);
 
@@ -885,7 +885,7 @@ static void vss_data_float_array(void **state)
     uint8_t pdu[MAX_PDU_SIZE];
     Avtp_Vss_t *vss_pdu = (Avtp_Vss_t *)pdu;
     Avtp_Vss_Init(vss_pdu);
-    Avtp_Vss_SetAcfMsgLength(vss_pdu, 20);
+    Avtp_AcfCommon_SetAcfMsgLength((Avtp_AcfCommon_t *)vss_pdu, 20);
     char path[] = "Vehicle.Speed";
     uint32_t path_length = strlen(path);
 
@@ -930,7 +930,7 @@ static void vss_data_double_array(void **state)
     uint8_t pdu[MAX_PDU_SIZE];
     Avtp_Vss_t *vss_pdu = (Avtp_Vss_t *)pdu;
     Avtp_Vss_Init(vss_pdu);
-    Avtp_Vss_SetAcfMsgLength(vss_pdu, 20);
+    Avtp_AcfCommon_SetAcfMsgLength((Avtp_AcfCommon_t *)vss_pdu, 20);
     char path[] = "Vehicle.Speed";
     uint32_t path_length = strlen(path);
 
@@ -975,7 +975,7 @@ static void vss_data_string_array(void **state)
     uint8_t pdu[MAX_PDU_SIZE];
     Avtp_Vss_t *vss_pdu = (Avtp_Vss_t *)pdu;
     Avtp_Vss_Init(vss_pdu);
-    Avtp_Vss_SetAcfMsgLength(vss_pdu, 20);
+    Avtp_AcfCommon_SetAcfMsgLength((Avtp_AcfCommon_t *)vss_pdu, 20);
     char path[] = "Vehicle.Speed";
     uint32_t path_length = strlen(path);
 
@@ -1123,7 +1123,7 @@ static Avtp_Vss_t *vss_build_data_oob_pdu(uint8_t *buf, size_t buf_size, uint8_t
     Avtp_Vss_t *pdu = (Avtp_Vss_t *)buf;
     Avtp_Vss_Init(pdu);
     Avtp_Vss_SetAddrMode(pdu, VSS_STATIC_ID_MODE);
-    Avtp_Vss_SetAcfMsgLength(pdu, msg_quadlets);
+    Avtp_AcfCommon_SetAcfMsgLength((Avtp_AcfCommon_t *)pdu, msg_quadlets);
     Avtp_Vss_SetDatatype(pdu, datatype);
 
     /* Inflated wire data_length at offset 16 (payload start) */
@@ -1150,7 +1150,7 @@ static void vss_path_interop_oob(void **state)
      * 6 bytes available for path data after the length prefix. */
     Avtp_Vss_Init(pdu);
     Avtp_Vss_SetAddrMode(pdu, VSS_INTEROP_MODE);
-    Avtp_Vss_SetAcfMsgLength(pdu, 5);
+    Avtp_AcfCommon_SetAcfMsgLength((Avtp_AcfCommon_t *)pdu, 5);
 
     buf[12] = 0xFF;
     buf[13] = 0xFF; /* wire path_length = 0xFFFF */
@@ -1504,7 +1504,7 @@ static Avtp_Vss_t *vss_build_inflated_path_pdu(uint8_t *buf, size_t buf_size, ui
     Avtp_Vss_t *pdu = (Avtp_Vss_t *)buf;
     Avtp_Vss_Init(pdu);
     Avtp_Vss_SetAddrMode(pdu, VSS_INTEROP_MODE);
-    Avtp_Vss_SetAcfMsgLength(pdu, msg_quadlets);
+    Avtp_AcfCommon_SetAcfMsgLength((Avtp_AcfCommon_t *)pdu, msg_quadlets);
     Avtp_Vss_SetDatatype(pdu, datatype);
 
     /* Inflated path_length at offset 12 (INTEROP length prefix).
@@ -1587,7 +1587,7 @@ static void vss_data_static_id_truncated_oob(void **state)
     memset(buf, 0, sizeof(buf));
     Avtp_Vss_Init(pdu);
     Avtp_Vss_SetAddrMode(pdu, VSS_STATIC_ID_MODE);
-    Avtp_Vss_SetAcfMsgLength(pdu, 3); /* 12 bytes — header only */
+    Avtp_AcfCommon_SetAcfMsgLength((Avtp_AcfCommon_t *)pdu, 3); /* 12 bytes — header only */
     Avtp_Vss_SetDatatype(pdu, VSS_UINT8);
 
     VssData_t vd;


### PR DESCRIPTION
This is... saving more than 1000 LOC :)

Mainly it moves Generic ACF Functions out of each individual  ACF

The Avtp_FORMAT_SetAcfType did not make sense (you could use them to set ACF Type LIN in a CAN ACF....) So those have been removed. The Type is set in each formats init() and checked in each isValid using the common methods in ACFCommon (which a user can still use to set "weird" ACF Types)

 Avtp_FORMAT_Get/SetAcfMsgLength have also been removed from the individual ACFs and the common methods are used instead. The ACF specific PayloadLength functions remain