### PR TITLE
Fix const casts and add compiler check

### DIFF
--- a/include/avtp/Udp.h
+++ b/include/avtp/Udp.h
@@ -9,7 +9,7 @@
  *    * Redistributions in binary form must reproduce the above copyright
  *      notice, this list of conditions and the following disclaimer in the
  *      documentation and/or other materials provided with the distribution.
- *    * Neither the name of COVESA nor the names of its contributors may be 
+ *    * Neither the name of COVESA nor the names of its contributors may be
  *      used to endorse or promote products derived from this software without
  *      specific prior written permission.
  *
@@ -46,13 +46,12 @@
 extern "C" {
 #endif
 
-#define AVTP_UDP_HEADER_LEN               (1 * AVTP_QUADLET_SIZE)
+#define AVTP_UDP_HEADER_LEN (1 * AVTP_QUADLET_SIZE)
 
-#define GET_UDP_FIELD(field) \
-        (Avtp_GetField(Avtp_UdpFieldDesc, AVTP_UDP_FIELD_MAX, (const uint8_t*)pdu, field))
-#define SET_UDP_FIELD(field, value) \
-        (Avtp_SetField(Avtp_UdpFieldDesc, AVTP_UDP_FIELD_MAX, (uint8_t*)pdu, field, value))
-
+#define GET_UDP_FIELD(field)                                                                       \
+    (Avtp_GetField(Avtp_UdpFieldDesc, AVTP_UDP_FIELD_MAX, (const uint8_t *)pdu, field))
+#define SET_UDP_FIELD(field, value)                                                                \
+    (Avtp_SetField(Avtp_UdpFieldDesc, AVTP_UDP_FIELD_MAX, (uint8_t *)pdu, field, value))
 
 typedef struct {
     uint8_t header[AVTP_UDP_HEADER_LEN];
@@ -60,7 +59,7 @@ typedef struct {
 } Avtp_Udp_t;
 
 typedef enum {
-    
+
     /* Common AVTP UDP header */
     AVTP_UDP_FIELD_ENCAPSULATION_SEQ_NO,
 
@@ -73,7 +72,7 @@ typedef enum {
  */
 static const Avtp_FieldDescriptor_t Avtp_UdpFieldDesc[AVTP_UDP_FIELD_MAX] = {
 
-    [AVTP_UDP_FIELD_ENCAPSULATION_SEQ_NO]       = { .quadlet = 0, .offset = 0, .bits = 32 },
+    [AVTP_UDP_FIELD_ENCAPSULATION_SEQ_NO] = {.quadlet = 0, .offset = 0, .bits = 32},
 };
 
 /**
@@ -82,8 +81,9 @@ static const Avtp_FieldDescriptor_t Avtp_UdpFieldDesc[AVTP_UDP_FIELD_MAX] = {
  * @param pdu Pointer to the first bit of an 1722 AVTP UDP PDU.
  * @param value Pointer to location to store the value.
  */
-OPEN1722_INLINE uint32_t Avtp_Udp_GetEncapsulationSeqNo(const Avtp_Udp_t* const pdu) {
-    return (uint32_t) GET_UDP_FIELD(AVTP_UDP_FIELD_ENCAPSULATION_SEQ_NO);
+OPEN1722_INLINE uint32_t Avtp_Udp_GetEncapsulationSeqNo(const Avtp_Udp_t *const pdu)
+{
+    return (uint32_t)GET_UDP_FIELD(AVTP_UDP_FIELD_ENCAPSULATION_SEQ_NO);
 }
 
 /**
@@ -92,16 +92,18 @@ OPEN1722_INLINE uint32_t Avtp_Udp_GetEncapsulationSeqNo(const Avtp_Udp_t* const 
  * @param pdu Pointer to the first bit of an 1722 AVTP UDP PDU.
  * @param value Pointer to location to store the value.
  */
-OPEN1722_INLINE void Avtp_Udp_SetEncapsulationSeqNo(Avtp_Udp_t* pdu, uint32_t value) {
+OPEN1722_INLINE void Avtp_Udp_SetEncapsulationSeqNo(Avtp_Udp_t *pdu, uint32_t value)
+{
     SET_UDP_FIELD(AVTP_UDP_FIELD_ENCAPSULATION_SEQ_NO, value);
 }
 
 /**
  * Initializes a UDP PDU as specified in the IEEE 1722-2016 Specification.
  *
- * @param pdu Pointer to the first bit of an IEEE 1722 UDP PDU. 
+ * @param pdu Pointer to the first bit of an IEEE 1722 UDP PDU.
  */
-OPEN1722_INLINE void Avtp_Udp_Init(Avtp_Udp_t* pdu) {
+OPEN1722_INLINE void Avtp_Udp_Init(Avtp_Udp_t *pdu)
+{
     if (pdu != NULL) {
         memset(pdu, 0, sizeof(Avtp_Udp_t));
         Avtp_Udp_SetEncapsulationSeqNo(pdu, 0);
@@ -116,7 +118,8 @@ OPEN1722_INLINE void Avtp_Udp_Init(Avtp_Udp_t* pdu) {
  * @param value Pointer to location to store the value.
  * @returns This function returns the value of the field.
  */
-OPEN1722_INLINE uint64_t Avtp_Udp_GetField(const Avtp_Udp_t* const pdu, Avtp_UdpFields_t field) {
+OPEN1722_INLINE uint64_t Avtp_Udp_GetField(const Avtp_Udp_t *const pdu, Avtp_UdpFields_t field)
+{
     return GET_UDP_FIELD(field);
 }
 
@@ -127,7 +130,8 @@ OPEN1722_INLINE uint64_t Avtp_Udp_GetField(const Avtp_Udp_t* const pdu, Avtp_Udp
  * @param field Specifies the position of the data field to be read
  * @param value Pointer to location to store the value.
  */
-OPEN1722_INLINE void Avtp_Udp_SetField(Avtp_Udp_t* pdu, Avtp_UdpFields_t field, uint64_t value) {
+OPEN1722_INLINE void Avtp_Udp_SetField(Avtp_Udp_t *pdu, Avtp_UdpFields_t field, uint64_t value)
+{
     SET_UDP_FIELD(field, value);
 }
 

--- a/include/avtp/Udp.h
+++ b/include/avtp/Udp.h
@@ -49,7 +49,7 @@ extern "C" {
 #define AVTP_UDP_HEADER_LEN               (1 * AVTP_QUADLET_SIZE)
 
 #define GET_UDP_FIELD(field) \
-        (Avtp_GetField(Avtp_UdpFieldDesc, AVTP_UDP_FIELD_MAX, (uint8_t*)pdu, field))
+        (Avtp_GetField(Avtp_UdpFieldDesc, AVTP_UDP_FIELD_MAX, (const uint8_t*)pdu, field))
 #define SET_UDP_FIELD(field, value) \
         (Avtp_SetField(Avtp_UdpFieldDesc, AVTP_UDP_FIELD_MAX, (uint8_t*)pdu, field, value))
 

--- a/include/avtp/acf/Abb.h
+++ b/include/avtp/acf/Abb.h
@@ -49,7 +49,7 @@ extern "C" {
 #include "avtp/acf/AcfCommon.h"
 
 #define GET_ABB_FIELD(field)                                                                       \
-    (Avtp_GetField(Avtp_AbbFieldDesc, AVTP_ABB_FIELD_MAX, (uint8_t *)pdu, field))
+    (Avtp_GetField(Avtp_AbbFieldDesc, AVTP_ABB_FIELD_MAX, (const uint8_t *)pdu, field))
 #define SET_ABB_FIELD(field, value)                                                                \
     (Avtp_SetField(Avtp_AbbFieldDesc, AVTP_ABB_FIELD_MAX, (uint8_t *)pdu, field, value))
 

--- a/include/avtp/acf/AcfCommon.h
+++ b/include/avtp/acf/AcfCommon.h
@@ -45,7 +45,7 @@ extern "C" {
 #define AVTP_ACF_COMMON_HEADER_LEN (1 * AVTP_QUADLET_SIZE)
 
 #define GET_ACF_COMMON_FIELD(field)                                                                \
-    (Avtp_GetField(Avtp_AcfCommonFieldDesc, AVTP_ACF_COMMON_FIELD_MAX, (uint8_t *)pdu, field))
+    (Avtp_GetField(Avtp_AcfCommonFieldDesc, AVTP_ACF_COMMON_FIELD_MAX, (const uint8_t *)pdu, field))
 #define SET_ACF_COMMON_FIELD(field, value)                                                         \
     (Avtp_SetField(Avtp_AcfCommonFieldDesc, AVTP_ACF_COMMON_FIELD_MAX, (uint8_t *)pdu, field,      \
                    value))

--- a/include/avtp/acf/Can.h
+++ b/include/avtp/acf/Can.h
@@ -52,7 +52,7 @@ extern "C" {
 #endif
 
 #define GET_CAN_FIELD(field)                                                                       \
-    (Avtp_GetField(Avtp_CanFieldDesc, AVTP_CAN_FIELD_MAX, (uint8_t *)pdu, field))
+    (Avtp_GetField(Avtp_CanFieldDesc, AVTP_CAN_FIELD_MAX, (const uint8_t *)pdu, field))
 #define SET_CAN_FIELD(field, value)                                                                \
     (Avtp_SetField(Avtp_CanFieldDesc, AVTP_CAN_FIELD_MAX, (uint8_t *)pdu, field, value))
 

--- a/include/avtp/acf/CanBrief.h
+++ b/include/avtp/acf/CanBrief.h
@@ -52,7 +52,7 @@ extern "C" {
 #endif
 
 #define GET_CAN_BRIEF_FIELD(field)                                                                 \
-    (Avtp_GetField(Avtp_CanBriefFieldDesc, AVTP_CAN_BRIEF_FIELD_MAX, (uint8_t *)pdu, field))
+    (Avtp_GetField(Avtp_CanBriefFieldDesc, AVTP_CAN_BRIEF_FIELD_MAX, (const uint8_t *)pdu, field))
 #define SET_CAN_BRIEF_FIELD(field, value)                                                          \
     (Avtp_SetField(Avtp_CanBriefFieldDesc, AVTP_CAN_BRIEF_FIELD_MAX, (uint8_t *)pdu, field, value))
 

--- a/include/avtp/acf/CanBriefV2.h
+++ b/include/avtp/acf/CanBriefV2.h
@@ -48,7 +48,8 @@ extern "C" {
 #include "avtp/acf/AcfCommon.h"
 
 #define GET_CAN_BRIEF_V2_FIELD(field)                                                              \
-    (Avtp_GetField(Avtp_CanBriefV2FieldDesc, AVTP_CAN_BRIEF_V2_FIELD_MAX, (uint8_t *)pdu, field))
+    (Avtp_GetField(Avtp_CanBriefV2FieldDesc, AVTP_CAN_BRIEF_V2_FIELD_MAX, (const uint8_t *)pdu,    \
+                   field))
 #define SET_CAN_BRIEF_V2_FIELD(field, value)                                                       \
     (Avtp_SetField(Avtp_CanBriefV2FieldDesc, AVTP_CAN_BRIEF_V2_FIELD_MAX, (uint8_t *)pdu, field,   \
                    value))

--- a/include/avtp/acf/CanV2.h
+++ b/include/avtp/acf/CanV2.h
@@ -49,7 +49,7 @@ extern "C" {
 #include "avtp/acf/AcfCommon.h"
 
 #define GET_CAN_V2_FIELD(field)                                                                    \
-    (Avtp_GetField(Avtp_CanV2FieldDesc, AVTP_CAN_V2_FIELD_MAX, (uint8_t *)pdu, field))
+    (Avtp_GetField(Avtp_CanV2FieldDesc, AVTP_CAN_V2_FIELD_MAX, (const uint8_t *)pdu, field))
 #define SET_CAN_V2_FIELD(field, value)                                                             \
     (Avtp_SetField(Avtp_CanV2FieldDesc, AVTP_CAN_V2_FIELD_MAX, (uint8_t *)pdu, field, value))
 

--- a/include/avtp/acf/CanXl.h
+++ b/include/avtp/acf/CanXl.h
@@ -49,7 +49,7 @@ extern "C" {
 #include "avtp/acf/AcfCommon.h"
 
 #define GET_CANXL_FIELD(field)                                                                     \
-    (Avtp_GetField(Avtp_CanXlFieldDesc, AVTP_CANXL_FIELD_MAX, (uint8_t *)pdu, field))
+    (Avtp_GetField(Avtp_CanXlFieldDesc, AVTP_CANXL_FIELD_MAX, (const uint8_t *)pdu, field))
 #define SET_CANXL_FIELD(field, value)                                                              \
     (Avtp_SetField(Avtp_CanXlFieldDesc, AVTP_CANXL_FIELD_MAX, (uint8_t *)pdu, field, value))
 

--- a/include/avtp/acf/CanXlBrief.h
+++ b/include/avtp/acf/CanXlBrief.h
@@ -49,7 +49,8 @@ extern "C" {
 #include "avtp/acf/AcfCommon.h"
 
 #define GET_CANXL_BRIEF_FIELD(field)                                                               \
-    (Avtp_GetField(Avtp_CanXlBriefFieldDesc, AVTP_CANXL_BRIEF_FIELD_MAX, (uint8_t *)pdu, field))
+    (Avtp_GetField(Avtp_CanXlBriefFieldDesc, AVTP_CANXL_BRIEF_FIELD_MAX, (const uint8_t *)pdu,     \
+                   field))
 #define SET_CANXL_BRIEF_FIELD(field, value)                                                        \
     (Avtp_SetField(Avtp_CanXlBriefFieldDesc, AVTP_CANXL_BRIEF_FIELD_MAX, (uint8_t *)pdu, field,    \
                    value))

--- a/include/avtp/acf/FlexRay.h
+++ b/include/avtp/acf/FlexRay.h
@@ -51,7 +51,7 @@ extern "C" {
 #endif
 
 #define GET_FLEXRAY_FIELD(field)                                                                   \
-    (Avtp_GetField(Avtp_FlexRayFieldDesc, AVTP_FLEXRAY_FIELD_MAX, (uint8_t *)pdu, field))
+    (Avtp_GetField(Avtp_FlexRayFieldDesc, AVTP_FLEXRAY_FIELD_MAX, (const uint8_t *)pdu, field))
 #define SET_FLEXRAY_FIELD(field, value)                                                            \
     (Avtp_SetField(Avtp_FlexRayFieldDesc, AVTP_FLEXRAY_FIELD_MAX, (uint8_t *)pdu, field, value))
 

--- a/include/avtp/acf/Gbb.h
+++ b/include/avtp/acf/Gbb.h
@@ -49,7 +49,7 @@ extern "C" {
 #include "avtp/acf/AcfCommon.h"
 
 #define GET_GBB_FIELD(field)                                                                       \
-    (Avtp_GetField(Avtp_GbbFieldDesc, AVTP_GBB_FIELD_MAX, (uint8_t *)pdu, field))
+    (Avtp_GetField(Avtp_GbbFieldDesc, AVTP_GBB_FIELD_MAX, (const uint8_t *)pdu, field))
 #define SET_GBB_FIELD(field, value)                                                                \
     (Avtp_SetField(Avtp_GbbFieldDesc, AVTP_GBB_FIELD_MAX, (uint8_t *)pdu, field, value))
 

--- a/include/avtp/acf/Gisf.h
+++ b/include/avtp/acf/Gisf.h
@@ -49,7 +49,7 @@ extern "C" {
 #include "avtp/acf/AcfCommon.h"
 
 #define GET_GISF_FIELD(field)                                                                      \
-    (Avtp_GetField(Avtp_GisfFieldDesc, AVTP_GISF_FIELD_MAX, (uint8_t *)pdu, field))
+    (Avtp_GetField(Avtp_GisfFieldDesc, AVTP_GISF_FIELD_MAX, (const uint8_t *)pdu, field))
 #define SET_GISF_FIELD(field, value)                                                               \
     (Avtp_SetField(Avtp_GisfFieldDesc, AVTP_GISF_FIELD_MAX, (uint8_t *)pdu, field, value))
 

--- a/include/avtp/acf/Gpc.h
+++ b/include/avtp/acf/Gpc.h
@@ -53,7 +53,7 @@ extern "C" {
 #define AVTP_GPC_HEADER_LEN (2 * AVTP_QUADLET_SIZE)
 
 #define GET_GPC_FIELD(field)                                                                       \
-    (Avtp_GetField(Avtp_GpcFieldDesc, AVTP_GPC_FIELD_MAX, (uint8_t *)pdu, field))
+    (Avtp_GetField(Avtp_GpcFieldDesc, AVTP_GPC_FIELD_MAX, (const uint8_t *)pdu, field))
 #define SET_GPC_FIELD(field, value)                                                                \
     (Avtp_SetField(Avtp_GpcFieldDesc, AVTP_GPC_FIELD_MAX, (uint8_t *)pdu, field, value))
 

--- a/include/avtp/acf/Lin.h
+++ b/include/avtp/acf/Lin.h
@@ -51,7 +51,7 @@ extern "C" {
 #endif
 
 #define GET_LIN_FIELD(field)                                                                       \
-    (Avtp_GetField(Avtp_LinFieldDesc, AVTP_LIN_FIELD_MAX, (uint8_t *)pdu, field))
+    (Avtp_GetField(Avtp_LinFieldDesc, AVTP_LIN_FIELD_MAX, (const uint8_t *)pdu, field))
 #define SET_LIN_FIELD(field, value)                                                                \
     (Avtp_SetField(Avtp_LinFieldDesc, AVTP_LIN_FIELD_MAX, (uint8_t *)pdu, field, value))
 

--- a/include/avtp/acf/Most.h
+++ b/include/avtp/acf/Most.h
@@ -54,7 +54,7 @@ extern "C" {
 #define AVTP_MOST_HEADER_LEN (5 * AVTP_QUADLET_SIZE)
 
 #define GET_MOST_FIELD(field)                                                                      \
-    (Avtp_GetField(Avtp_MostFieldDesc, AVTP_MOST_FIELD_MAX, (uint8_t *)pdu, field))
+    (Avtp_GetField(Avtp_MostFieldDesc, AVTP_MOST_FIELD_MAX, (const uint8_t *)pdu, field))
 #define SET_MOST_FIELD(field, value)                                                               \
     (Avtp_SetField(Avtp_MostFieldDesc, AVTP_MOST_FIELD_MAX, (uint8_t *)pdu, field, value))
 

--- a/include/avtp/acf/Ntscf.h
+++ b/include/avtp/acf/Ntscf.h
@@ -54,7 +54,7 @@ extern "C" {
 #define AVTP_NTSCF_HEADER_LEN (3 * AVTP_QUADLET_SIZE)
 
 #define GET_NTSCF_FIELD(field)                                                                     \
-    (Avtp_GetField(Avtp_NtscfFieldDesc, AVTP_NTSCF_FIELD_MAX, (uint8_t *)pdu, field))
+    (Avtp_GetField(Avtp_NtscfFieldDesc, AVTP_NTSCF_FIELD_MAX, (const uint8_t *)pdu, field))
 #define SET_NTSCF_FIELD(field, value)                                                              \
     (Avtp_SetField(Avtp_NtscfFieldDesc, AVTP_NTSCF_FIELD_MAX, (uint8_t *)pdu, field, value))
 

--- a/include/avtp/acf/Sensor.h
+++ b/include/avtp/acf/Sensor.h
@@ -54,7 +54,7 @@ extern "C" {
 #define AVTP_SENSOR_HEADER_LEN (3 * AVTP_QUADLET_SIZE)
 
 #define GET_SENSOR_FIELD(field)                                                                    \
-    (Avtp_GetField(Avtp_SensorFieldDesc, AVTP_SENSOR_FIELD_MAX, (uint8_t *)pdu, field))
+    (Avtp_GetField(Avtp_SensorFieldDesc, AVTP_SENSOR_FIELD_MAX, (const uint8_t *)pdu, field))
 #define SET_SENSOR_FIELD(field, value)                                                             \
     (Avtp_SetField(Avtp_SensorFieldDesc, AVTP_SENSOR_FIELD_MAX, (uint8_t *)pdu, field, value))
 

--- a/include/avtp/acf/SensorBrief.h
+++ b/include/avtp/acf/SensorBrief.h
@@ -54,7 +54,8 @@ extern "C" {
 #define AVTP_SENSOR_BRIEF_HEADER_LEN (1 * AVTP_QUADLET_SIZE)
 
 #define GET_SENSOR_BRIEF_FIELD(field)                                                              \
-    (Avtp_GetField(Avtp_SensorBriefFieldDesc, AVTP_SENSOR_BRIEF_FIELD_MAX, (uint8_t *)pdu, field))
+    (Avtp_GetField(Avtp_SensorBriefFieldDesc, AVTP_SENSOR_BRIEF_FIELD_MAX, (const uint8_t *)pdu,   \
+                   field))
 #define SET_SENSOR_BRIEF_FIELD(field, value)                                                       \
     (Avtp_SetField(Avtp_SensorBriefFieldDesc, AVTP_SENSOR_BRIEF_FIELD_MAX, (uint8_t *)pdu, field,  \
                    value))

--- a/include/avtp/acf/Tscf.h
+++ b/include/avtp/acf/Tscf.h
@@ -54,7 +54,7 @@ extern "C" {
 #define AVTP_TSCF_HEADER_LEN (6 * AVTP_QUADLET_SIZE)
 
 #define GET_TSCF_FIELD(field)                                                                      \
-    (Avtp_GetField(Avtp_TscfFieldDesc, AVTP_TSCF_FIELD_MAX, (uint8_t *)pdu, field))
+    (Avtp_GetField(Avtp_TscfFieldDesc, AVTP_TSCF_FIELD_MAX, (const uint8_t *)pdu, field))
 #define SET_TSCF_FIELD(field, value)                                                               \
     (Avtp_SetField(Avtp_TscfFieldDesc, AVTP_TSCF_FIELD_MAX, (uint8_t *)pdu, field, value))
 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -38,7 +38,7 @@ elseif(DEFINED ENV{ZEPHYR_BASE})
     target_link_libraries(${LIB_NAME} PRIVATE zephyr_interface)
 endif()
 target_compile_options(${LIB_NAME} PRIVATE
-    $<$<C_COMPILER_ID:GNU,Clang>:-Wall -Wextra -Wconversion -Wsign-conversion>
+    $<$<C_COMPILER_ID:GNU,Clang>:-Wall -Wextra -Wconversion -Wsign-conversion -Wcast-qual>
 )
 target_include_directories(${LIB_NAME} PRIVATE
     $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/include>
@@ -52,7 +52,7 @@ elseif(DEFINED ENV{ZEPHYR_BASE})
     target_link_libraries(${LIB_NAME}custom PRIVATE zephyr_interface)
 endif()
 target_compile_options(${LIB_NAME}custom PRIVATE
-    $<$<C_COMPILER_ID:GNU,Clang>:-Wall -Wextra -Wconversion -Wsign-conversion>
+    $<$<C_COMPILER_ID:GNU,Clang>:-Wall -Wextra -Wconversion -Wsign-conversion -Wcast-qual>
 )
 target_compile_options(${LIB_NAME}custom PRIVATE -Wall -Wextra -Wconversion -Wsign-conversion)
 target_include_directories(${LIB_NAME}custom PRIVATE

--- a/src/avtp/CommonHeader.c
+++ b/src/avtp/CommonHeader.c
@@ -9,7 +9,7 @@
  *    * Redistributions in binary form must reproduce the above copyright
  *      notice, this list of conditions and the following disclaimer in the
  *      documentation and/or other materials provided with the distribution.
- *    * Neither the name of COVESA nor the names of its contributors may be 
+ *    * Neither the name of COVESA nor the names of its contributors may be
  *      used to endorse or promote products derived from this software without
  *      specific prior written permission.
  *
@@ -28,70 +28,72 @@
  */
 
 #ifdef LINUX_KERNEL1722
-    #include <linux/errno.h>
-    #include <linux/string.h>
+#include <linux/errno.h>
+#include <linux/string.h>
 #else
-    #include <errno.h>
-    #include <string.h>
+#include <errno.h>
+#include <string.h>
 #endif
 
 #include "avtp/CommonHeader.h"
-#include "avtp/Utils.h" 
+#include "avtp/Utils.h"
 #include "avtp/Defines.h"
 
-#define GET_FIELD(field) \
-        (Avtp_GetField(Avtp_CommonHeaderFieldDesc, AVTP_COMMON_HEADER_FIELD_MAX, (const uint8_t*)pdu, field))
-#define SET_FIELD(field, value) \
-        (Avtp_SetField(Avtp_CommonHeaderFieldDesc, AVTP_COMMON_HEADER_FIELD_MAX, (uint8_t*)pdu, field, value))
+#define GET_FIELD(field)                                                                           \
+    (Avtp_GetField(Avtp_CommonHeaderFieldDesc, AVTP_COMMON_HEADER_FIELD_MAX, (const uint8_t *)pdu, \
+                   field))
+#define SET_FIELD(field, value)                                                                    \
+    (Avtp_SetField(Avtp_CommonHeaderFieldDesc, AVTP_COMMON_HEADER_FIELD_MAX, (uint8_t *)pdu,       \
+                   field, value))
 
 /**
  * This table maps all IEEE 1722 common header fields to a descriptor.
  */
 static const Avtp_FieldDescriptor_t Avtp_CommonHeaderFieldDesc[AVTP_COMMON_HEADER_FIELD_MAX] = {
     /* Common AVTP header */
-    [AVTP_COMMON_HEADER_FIELD_SUBTYPE]            = { .quadlet = 0, .offset = 0, .bits = 8 },
-    [AVTP_COMMON_HEADER_FIELD_H]                  = { .quadlet = 0, .offset = 8, .bits = 1 },
-    [AVTP_COMMON_HEADER_FIELD_VERSION]            = { .quadlet = 0, .offset = 9, .bits = 3 },
+    [AVTP_COMMON_HEADER_FIELD_SUBTYPE] = {.quadlet = 0, .offset = 0, .bits = 8},
+    [AVTP_COMMON_HEADER_FIELD_H] = {.quadlet = 0, .offset = 8, .bits = 1},
+    [AVTP_COMMON_HEADER_FIELD_VERSION] = {.quadlet = 0, .offset = 9, .bits = 3},
 };
 
-uint64_t Avtp_CommonHeader_GetField(const Avtp_CommonHeader_t* const pdu,
-        Avtp_CommonHeaderField_t field)
+uint64_t Avtp_CommonHeader_GetField(const Avtp_CommonHeader_t *const pdu,
+                                    Avtp_CommonHeaderField_t field)
 {
     return GET_FIELD(field);
 }
 
-uint8_t Avtp_CommonHeader_GetSubtype(const Avtp_CommonHeader_t* const pdu)
+uint8_t Avtp_CommonHeader_GetSubtype(const Avtp_CommonHeader_t *const pdu)
 {
     return (uint8_t)GET_FIELD(AVTP_COMMON_HEADER_FIELD_SUBTYPE);
 }
 
-uint8_t Avtp_CommonHeader_GetH(const Avtp_CommonHeader_t* const pdu)
+uint8_t Avtp_CommonHeader_GetH(const Avtp_CommonHeader_t *const pdu)
 {
     return (uint8_t)GET_FIELD(AVTP_COMMON_HEADER_FIELD_H);
 }
 
-uint8_t Avtp_CommonHeader_GetVersion(const Avtp_CommonHeader_t* const pdu)
+uint8_t Avtp_CommonHeader_GetVersion(const Avtp_CommonHeader_t *const pdu)
 {
     return (uint8_t)GET_FIELD(AVTP_COMMON_HEADER_FIELD_VERSION);
 }
 
-void Avtp_CommonHeader_SetField(Avtp_CommonHeader_t* pdu,
-        Avtp_CommonHeaderField_t field, uint64_t value)
+void Avtp_CommonHeader_SetField(Avtp_CommonHeader_t *pdu, Avtp_CommonHeaderField_t field,
+                                uint64_t value)
 {
     SET_FIELD(field, value);
 }
 
-void Avtp_CommonHeader_SetSubtype(Avtp_CommonHeader_t* pdu, uint8_t value)
+void Avtp_CommonHeader_SetSubtype(Avtp_CommonHeader_t *pdu, uint8_t value)
 {
     SET_FIELD(AVTP_COMMON_HEADER_FIELD_SUBTYPE, value);
 }
 
-void Avtp_CommonHeader_SetH(Avtp_CommonHeader_t* pdu, uint8_t value)
+void Avtp_CommonHeader_SetH(Avtp_CommonHeader_t *pdu, uint8_t value)
 {
     SET_FIELD(AVTP_COMMON_HEADER_FIELD_H, value);
 }
 
-void Avtp_CommonHeader_SetVersion(Avtp_CommonHeader_t* pdu, uint8_t value)
+void Avtp_CommonHeader_SetVersion(Avtp_CommonHeader_t *pdu, uint8_t value)
 {
     SET_FIELD(AVTP_COMMON_HEADER_FIELD_VERSION, value);
 }
@@ -99,25 +101,24 @@ void Avtp_CommonHeader_SetVersion(Avtp_CommonHeader_t* pdu, uint8_t value)
 /******************************************************************************
  * Legacy API
  *****************************************************************************/
-int avtp_pdu_get(const struct avtp_common_pdu * const pdu, Avtp_CommonHeaderField_t field,
-                                uint32_t *val)
+int avtp_pdu_get(const struct avtp_common_pdu *const pdu, Avtp_CommonHeaderField_t field,
+                 uint32_t *val)
 {
     if (pdu == NULL || val == NULL || field >= AVTP_COMMON_HEADER_FIELD_MAX) {
         return -EINVAL;
     } else {
-        uint64_t temp = Avtp_CommonHeader_GetField((const Avtp_CommonHeader_t* const) pdu, field);
+        uint64_t temp = Avtp_CommonHeader_GetField((const Avtp_CommonHeader_t *const)pdu, field);
         *val = (uint32_t)temp;
         return 0;
     }
 }
 
-int avtp_pdu_set(struct avtp_common_pdu *pdu, Avtp_CommonHeaderField_t field,
-                                uint32_t value)
+int avtp_pdu_set(struct avtp_common_pdu *pdu, Avtp_CommonHeaderField_t field, uint32_t value)
 {
     if (pdu == NULL || field >= AVTP_COMMON_HEADER_FIELD_MAX) {
         return -EINVAL;
     } else {
-        Avtp_CommonHeader_SetField((Avtp_CommonHeader_t*)pdu, field, value);
+        Avtp_CommonHeader_SetField((Avtp_CommonHeader_t *)pdu, field, value);
         return 0;
     }
 }

--- a/src/avtp/CommonHeader.c
+++ b/src/avtp/CommonHeader.c
@@ -40,7 +40,7 @@
 #include "avtp/Defines.h"
 
 #define GET_FIELD(field) \
-        (Avtp_GetField(Avtp_CommonHeaderFieldDesc, AVTP_COMMON_HEADER_FIELD_MAX, (uint8_t*)pdu, field))
+        (Avtp_GetField(Avtp_CommonHeaderFieldDesc, AVTP_COMMON_HEADER_FIELD_MAX, (const uint8_t*)pdu, field))
 #define SET_FIELD(field, value) \
         (Avtp_SetField(Avtp_CommonHeaderFieldDesc, AVTP_COMMON_HEADER_FIELD_MAX, (uint8_t*)pdu, field, value))
 

--- a/src/avtp/Crf.c
+++ b/src/avtp/Crf.c
@@ -35,34 +35,33 @@
 #include "avtp/Utils.h"
 #include "avtp/CommonHeader.h"
 
-#define GET_FIELD(field) \
-        (Avtp_GetField(Avtp_CrfFieldDescriptors, AVTP_CRF_FIELD_MAX, (const uint8_t*)pdu, field))
-#define SET_FIELD(field, value) \
-        (Avtp_SetField(Avtp_CrfFieldDescriptors, AVTP_CRF_FIELD_MAX, (uint8_t*)pdu, field, value))
+#define GET_FIELD(field)                                                                           \
+    (Avtp_GetField(Avtp_CrfFieldDescriptors, AVTP_CRF_FIELD_MAX, (const uint8_t *)pdu, field))
+#define SET_FIELD(field, value)                                                                    \
+    (Avtp_SetField(Avtp_CrfFieldDescriptors, AVTP_CRF_FIELD_MAX, (uint8_t *)pdu, field, value))
 
 /**
  * This table maps all IEEE 1722 Clock Reference Format (CRF) specific header fields
  * to a descriptor.
  */
-static const Avtp_FieldDescriptor_t Avtp_CrfFieldDescriptors[AVTP_CRF_FIELD_MAX] =
-{
-    [AVTP_CRF_FIELD_SUBTYPE]                = { .quadlet = 0, .offset = 0, .bits = 8 },
-    [AVTP_CRF_FIELD_SV]                     = { .quadlet = 0, .offset = 8, .bits = 1 },
-    [AVTP_CRF_FIELD_VERSION]                = { .quadlet = 0, .offset = 9, .bits = 3 },
-    [AVTP_CRF_FIELD_MR]                     = { .quadlet = 0, .offset = 12, .bits = 1 },
-    [AVTP_CRF_FIELD_RESERVED]               = { .quadlet = 0, .offset = 13, .bits = 1 },
-    [AVTP_CRF_FIELD_FS]                     = { .quadlet = 0, .offset = 14, .bits = 1 },
-    [AVTP_CRF_FIELD_TU]                     = { .quadlet = 0, .offset = 15, .bits = 1 },
-    [AVTP_CRF_FIELD_SEQUENCE_NUM]           = { .quadlet = 0, .offset = 16, .bits = 8 },
-    [AVTP_CRF_FIELD_TYPE]                   = { .quadlet = 0, .offset = 24, .bits = 8 },
-    [AVTP_CRF_FIELD_STREAM_ID]              = { .quadlet = 1, .offset = 0, .bits = 64 },
-    [AVTP_CRF_FIELD_PULL]                   = { .quadlet = 3, .offset = 0, .bits = 3 },
-    [AVTP_CRF_FIELD_BASE_FREQUENCY]         = { .quadlet = 3, .offset = 3, .bits = 29 },
-    [AVTP_CRF_FIELD_CRF_DATA_LENGTH]        = { .quadlet = 4, .offset = 0, .bits = 16 },
-    [AVTP_CRF_FIELD_TIMESTAMP_INTERVAL]     = { .quadlet = 4, .offset = 16, .bits = 16 },
+static const Avtp_FieldDescriptor_t Avtp_CrfFieldDescriptors[AVTP_CRF_FIELD_MAX] = {
+    [AVTP_CRF_FIELD_SUBTYPE] = {.quadlet = 0, .offset = 0, .bits = 8},
+    [AVTP_CRF_FIELD_SV] = {.quadlet = 0, .offset = 8, .bits = 1},
+    [AVTP_CRF_FIELD_VERSION] = {.quadlet = 0, .offset = 9, .bits = 3},
+    [AVTP_CRF_FIELD_MR] = {.quadlet = 0, .offset = 12, .bits = 1},
+    [AVTP_CRF_FIELD_RESERVED] = {.quadlet = 0, .offset = 13, .bits = 1},
+    [AVTP_CRF_FIELD_FS] = {.quadlet = 0, .offset = 14, .bits = 1},
+    [AVTP_CRF_FIELD_TU] = {.quadlet = 0, .offset = 15, .bits = 1},
+    [AVTP_CRF_FIELD_SEQUENCE_NUM] = {.quadlet = 0, .offset = 16, .bits = 8},
+    [AVTP_CRF_FIELD_TYPE] = {.quadlet = 0, .offset = 24, .bits = 8},
+    [AVTP_CRF_FIELD_STREAM_ID] = {.quadlet = 1, .offset = 0, .bits = 64},
+    [AVTP_CRF_FIELD_PULL] = {.quadlet = 3, .offset = 0, .bits = 3},
+    [AVTP_CRF_FIELD_BASE_FREQUENCY] = {.quadlet = 3, .offset = 3, .bits = 29},
+    [AVTP_CRF_FIELD_CRF_DATA_LENGTH] = {.quadlet = 4, .offset = 0, .bits = 16},
+    [AVTP_CRF_FIELD_TIMESTAMP_INTERVAL] = {.quadlet = 4, .offset = 16, .bits = 16},
 };
 
-void Avtp_Crf_Init(Avtp_Crf_t* pdu)
+void Avtp_Crf_Init(Avtp_Crf_t *pdu)
 {
     if (pdu != NULL) {
         memset(pdu, 0, sizeof(Avtp_Crf_t));
@@ -71,162 +70,162 @@ void Avtp_Crf_Init(Avtp_Crf_t* pdu)
     }
 }
 
-uint64_t Avtp_Crf_GetField(const Avtp_Crf_t* const pdu, Avtp_CrfField_t field)
+uint64_t Avtp_Crf_GetField(const Avtp_Crf_t *const pdu, Avtp_CrfField_t field)
 {
     return GET_FIELD(field);
 }
 
-uint8_t Avtp_Crf_GetSubtype(const Avtp_Crf_t* const pdu)
+uint8_t Avtp_Crf_GetSubtype(const Avtp_Crf_t *const pdu)
 {
     return (uint8_t)GET_FIELD(AVTP_CRF_FIELD_SUBTYPE);
 }
 
-uint8_t Avtp_Crf_GetSv(const Avtp_Crf_t* const pdu)
+uint8_t Avtp_Crf_GetSv(const Avtp_Crf_t *const pdu)
 {
     return (uint8_t)GET_FIELD(AVTP_CRF_FIELD_SV);
 }
 
-uint8_t Avtp_Crf_GetVersion(const Avtp_Crf_t* const pdu)
+uint8_t Avtp_Crf_GetVersion(const Avtp_Crf_t *const pdu)
 {
     return (uint8_t)GET_FIELD(AVTP_CRF_FIELD_VERSION);
 }
 
-uint8_t Avtp_Crf_GetMr(const Avtp_Crf_t* const pdu)
+uint8_t Avtp_Crf_GetMr(const Avtp_Crf_t *const pdu)
 {
     return (uint8_t)GET_FIELD(AVTP_CRF_FIELD_MR);
 }
 
-uint8_t Avtp_Crf_GetFs(const Avtp_Crf_t* const pdu)
+uint8_t Avtp_Crf_GetFs(const Avtp_Crf_t *const pdu)
 {
     return (uint8_t)GET_FIELD(AVTP_CRF_FIELD_FS);
 }
 
-uint8_t Avtp_Crf_GetTu(const Avtp_Crf_t* const pdu)
+uint8_t Avtp_Crf_GetTu(const Avtp_Crf_t *const pdu)
 {
     return (uint8_t)GET_FIELD(AVTP_CRF_FIELD_TU);
 }
 
-uint8_t Avtp_Crf_GetSequenceNum(const Avtp_Crf_t* const pdu)
+uint8_t Avtp_Crf_GetSequenceNum(const Avtp_Crf_t *const pdu)
 {
     return (uint8_t)GET_FIELD(AVTP_CRF_FIELD_SEQUENCE_NUM);
 }
 
-uint8_t Avtp_Crf_GetType(const Avtp_Crf_t* const pdu)
+uint8_t Avtp_Crf_GetType(const Avtp_Crf_t *const pdu)
 {
     return (uint8_t)GET_FIELD(AVTP_CRF_FIELD_TYPE);
 }
 
-uint64_t Avtp_Crf_GetStreamId(const Avtp_Crf_t* const pdu)
+uint64_t Avtp_Crf_GetStreamId(const Avtp_Crf_t *const pdu)
 {
     return GET_FIELD(AVTP_CRF_FIELD_STREAM_ID);
 }
 
-uint8_t Avtp_Crf_GetPull(const Avtp_Crf_t* const pdu)
+uint8_t Avtp_Crf_GetPull(const Avtp_Crf_t *const pdu)
 {
     return (uint8_t)GET_FIELD(AVTP_CRF_FIELD_PULL);
 }
 
-uint32_t Avtp_Crf_GetBaseFrequency(const Avtp_Crf_t* const pdu)
+uint32_t Avtp_Crf_GetBaseFrequency(const Avtp_Crf_t *const pdu)
 {
     return (uint32_t)GET_FIELD(AVTP_CRF_FIELD_BASE_FREQUENCY);
 }
 
-uint16_t Avtp_Crf_GetCrfDataLength(const Avtp_Crf_t* const pdu)
+uint16_t Avtp_Crf_GetCrfDataLength(const Avtp_Crf_t *const pdu)
 {
     return (uint16_t)GET_FIELD(AVTP_CRF_FIELD_CRF_DATA_LENGTH);
 }
 
-uint16_t Avtp_Crf_GetTimestampInterval(const Avtp_Crf_t* const pdu)
+uint16_t Avtp_Crf_GetTimestampInterval(const Avtp_Crf_t *const pdu)
 {
     return (uint16_t)GET_FIELD(AVTP_CRF_FIELD_TIMESTAMP_INTERVAL);
 }
 
-void Avtp_Crf_SetField(Avtp_Crf_t* pdu, Avtp_CrfField_t field, uint64_t value)
+void Avtp_Crf_SetField(Avtp_Crf_t *pdu, Avtp_CrfField_t field, uint64_t value)
 {
     SET_FIELD(field, value);
 }
 
-void Avtp_Crf_SetSubtype(Avtp_Crf_t* pdu, uint8_t value)
+void Avtp_Crf_SetSubtype(Avtp_Crf_t *pdu, uint8_t value)
 {
     SET_FIELD(AVTP_CRF_FIELD_SUBTYPE, value);
 }
 
-void Avtp_Crf_EnableSv(Avtp_Crf_t* pdu)
+void Avtp_Crf_EnableSv(Avtp_Crf_t *pdu)
 {
     SET_FIELD(AVTP_CRF_FIELD_SV, 1);
 }
 
-void Avtp_Crf_DisableSv(Avtp_Crf_t* pdu)
+void Avtp_Crf_DisableSv(Avtp_Crf_t *pdu)
 {
     SET_FIELD(AVTP_CRF_FIELD_SV, 0);
 }
 
-void Avtp_Crf_SetVersion(Avtp_Crf_t* pdu, uint8_t value)
+void Avtp_Crf_SetVersion(Avtp_Crf_t *pdu, uint8_t value)
 {
     SET_FIELD(AVTP_CRF_FIELD_VERSION, value);
 }
 
-void Avtp_Crf_EnableMr(Avtp_Crf_t* pdu)
+void Avtp_Crf_EnableMr(Avtp_Crf_t *pdu)
 {
     SET_FIELD(AVTP_CRF_FIELD_MR, 1);
 }
 
-void Avtp_Crf_DisableMr(Avtp_Crf_t* pdu)
+void Avtp_Crf_DisableMr(Avtp_Crf_t *pdu)
 {
     SET_FIELD(AVTP_CRF_FIELD_MR, 0);
 }
 
-void Avtp_Crf_EnableFs(Avtp_Crf_t* pdu)
+void Avtp_Crf_EnableFs(Avtp_Crf_t *pdu)
 {
     SET_FIELD(AVTP_CRF_FIELD_FS, 1);
 }
 
-void Avtp_Crf_DisableFs(Avtp_Crf_t* pdu)
+void Avtp_Crf_DisableFs(Avtp_Crf_t *pdu)
 {
     SET_FIELD(AVTP_CRF_FIELD_FS, 0);
 }
 
-void Avtp_Crf_EnableTu(Avtp_Crf_t* pdu)
+void Avtp_Crf_EnableTu(Avtp_Crf_t *pdu)
 {
     SET_FIELD(AVTP_CRF_FIELD_TU, 1);
 }
 
-void Avtp_Crf_DisableTu(Avtp_Crf_t* pdu)
+void Avtp_Crf_DisableTu(Avtp_Crf_t *pdu)
 {
     SET_FIELD(AVTP_CRF_FIELD_TU, 0);
 }
 
-void Avtp_Crf_SetSequenceNum(Avtp_Crf_t* pdu, uint8_t value)
+void Avtp_Crf_SetSequenceNum(Avtp_Crf_t *pdu, uint8_t value)
 {
     SET_FIELD(AVTP_CRF_FIELD_SEQUENCE_NUM, value);
 }
 
-void Avtp_Crf_SetType(Avtp_Crf_t* pdu, uint8_t value)
+void Avtp_Crf_SetType(Avtp_Crf_t *pdu, uint8_t value)
 {
     SET_FIELD(AVTP_CRF_FIELD_TYPE, value);
 }
 
-void Avtp_Crf_SetStreamId(Avtp_Crf_t* pdu, uint64_t value)
+void Avtp_Crf_SetStreamId(Avtp_Crf_t *pdu, uint64_t value)
 {
     SET_FIELD(AVTP_CRF_FIELD_STREAM_ID, value);
 }
 
-void Avtp_Crf_SetPull(Avtp_Crf_t* pdu, uint8_t value)
+void Avtp_Crf_SetPull(Avtp_Crf_t *pdu, uint8_t value)
 {
     SET_FIELD(AVTP_CRF_FIELD_PULL, value);
 }
 
-void Avtp_Crf_SetBaseFrequency(Avtp_Crf_t* pdu, uint32_t value)
+void Avtp_Crf_SetBaseFrequency(Avtp_Crf_t *pdu, uint32_t value)
 {
     SET_FIELD(AVTP_CRF_FIELD_BASE_FREQUENCY, value);
 }
 
-void Avtp_Crf_SetCrfDataLength(Avtp_Crf_t* pdu, uint16_t value)
+void Avtp_Crf_SetCrfDataLength(Avtp_Crf_t *pdu, uint16_t value)
 {
     SET_FIELD(AVTP_CRF_FIELD_CRF_DATA_LENGTH, value);
 }
 
-void Avtp_Crf_SetTimestampInterval(Avtp_Crf_t* pdu, uint16_t value)
+void Avtp_Crf_SetTimestampInterval(Avtp_Crf_t *pdu, uint16_t value)
 {
     SET_FIELD(AVTP_CRF_FIELD_TIMESTAMP_INTERVAL, value);
 }
@@ -235,12 +234,12 @@ void Avtp_Crf_SetTimestampInterval(Avtp_Crf_t* pdu, uint16_t value)
  * Legacy API
  *****************************************************************************/
 
-int avtp_crf_pdu_get(const void * const pdu, Avtp_CrfField_t field, uint64_t *val)
+int avtp_crf_pdu_get(const void *const pdu, Avtp_CrfField_t field, uint64_t *val)
 {
     if (pdu == NULL || val == NULL || field >= AVTP_CRF_FIELD_MAX) {
         return -EINVAL;
     } else {
-        *val = Avtp_Crf_GetField((const Avtp_Crf_t* const)pdu, field);
+        *val = Avtp_Crf_GetField((const Avtp_Crf_t *const)pdu, field);
         return 0;
     }
 }
@@ -250,7 +249,7 @@ int avtp_crf_pdu_set(void *pdu, Avtp_CrfField_t field, uint64_t val)
     if (pdu == NULL || field >= AVTP_CRF_FIELD_MAX) {
         return -EINVAL;
     } else {
-        Avtp_Crf_SetField((Avtp_Crf_t*)pdu, field, val);
+        Avtp_Crf_SetField((Avtp_Crf_t *)pdu, field, val);
         return 0;
     }
 }
@@ -260,7 +259,7 @@ int avtp_crf_pdu_init(void *pdu)
     if (pdu == NULL) {
         return -EINVAL;
     } else {
-        Avtp_Crf_Init((Avtp_Crf_t*)pdu);
+        Avtp_Crf_Init((Avtp_Crf_t *)pdu);
         return 0;
     }
 }

--- a/src/avtp/Crf.c
+++ b/src/avtp/Crf.c
@@ -36,7 +36,7 @@
 #include "avtp/CommonHeader.h"
 
 #define GET_FIELD(field) \
-        (Avtp_GetField(Avtp_CrfFieldDescriptors, AVTP_CRF_FIELD_MAX, (uint8_t*)pdu, field))
+        (Avtp_GetField(Avtp_CrfFieldDescriptors, AVTP_CRF_FIELD_MAX, (const uint8_t*)pdu, field))
 #define SET_FIELD(field, value) \
         (Avtp_SetField(Avtp_CrfFieldDescriptors, AVTP_CRF_FIELD_MAX, (uint8_t*)pdu, field, value))
 

--- a/src/avtp/Rvf.c
+++ b/src/avtp/Rvf.c
@@ -36,51 +36,50 @@
 #include "avtp/Utils.h"
 #include "avtp/CommonHeader.h"
 
-#define GET_FIELD(field) \
-        (Avtp_GetField(Avtp_RvfFieldDesc, AVTP_RVF_FIELD_MAX, (const uint8_t*)pdu, field))
-#define SET_FIELD(field, value) \
-        (Avtp_SetField(Avtp_RvfFieldDesc, AVTP_RVF_FIELD_MAX, (uint8_t*)pdu, field, value))
+#define GET_FIELD(field)                                                                           \
+    (Avtp_GetField(Avtp_RvfFieldDesc, AVTP_RVF_FIELD_MAX, (const uint8_t *)pdu, field))
+#define SET_FIELD(field, value)                                                                    \
+    (Avtp_SetField(Avtp_RvfFieldDesc, AVTP_RVF_FIELD_MAX, (uint8_t *)pdu, field, value))
 
 /**
  * This table maps all IEEE 1722 Raw Video Format (RVF) specific header fields
  * to a descriptor.
  */
-static const Avtp_FieldDescriptor_t Avtp_RvfFieldDesc[AVTP_RVF_FIELD_MAX] =
-{
-    [AVTP_RVF_FIELD_SUBTYPE]               = { .quadlet = 0, .offset = 0, .bits = 8 },
-    [AVTP_RVF_FIELD_SV]                    = { .quadlet = 0, .offset = 8, .bits = 1 },
-    [AVTP_RVF_FIELD_VERSION]               = { .quadlet = 0, .offset = 9, .bits = 3 },
-    [AVTP_RVF_FIELD_MR]                    = { .quadlet = 0, .offset = 12, .bits = 1 },
-    [AVTP_RVF_FIELD_RESERVED]              = { .quadlet = 0, .offset = 13, .bits = 2 },
-    [AVTP_RVF_FIELD_TV]                    = { .quadlet = 0, .offset = 15, .bits = 1 },
-    [AVTP_RVF_FIELD_SEQUENCE_NUM]          = { .quadlet = 0, .offset = 16, .bits = 8 },
-    [AVTP_RVF_FIELD_RESERVED_2]            = { .quadlet = 0, .offset = 24, .bits = 7 },
-    [AVTP_RVF_FIELD_TU]                    = { .quadlet = 0, .offset = 31, .bits = 1 },
-    [AVTP_RVF_FIELD_STREAM_ID]             = { .quadlet = 1, .offset = 0, .bits = 64 },
-    [AVTP_RVF_FIELD_AVTP_TIMESTAMP]        = { .quadlet = 3, .offset = 0, .bits = 32 },
-    [AVTP_RVF_FIELD_ACTIVE_PIXELS]         = { .quadlet = 4, .offset = 0, .bits = 16 },
-    [AVTP_RVF_FIELD_TOTAL_LINES]           = { .quadlet = 4, .offset = 16, .bits = 16 },
-    [AVTP_RVF_FIELD_STREAM_DATA_LENGTH]    = { .quadlet = 5, .offset = 0, .bits = 16 },
-    [AVTP_RVF_FIELD_AP]                    = { .quadlet = 5, .offset = 16, .bits = 1 },
-    [AVTP_RVF_FIELD_RESERVED_3]            = { .quadlet = 5, .offset = 17, .bits = 1 },
-    [AVTP_RVF_FIELD_F]                     = { .quadlet = 5, .offset = 18, .bits = 1 },
-    [AVTP_RVF_FIELD_EF]                    = { .quadlet = 5, .offset = 19, .bits = 1 },
-    [AVTP_RVF_FIELD_EVT]                   = { .quadlet = 5, .offset = 20, .bits = 4 },
-    [AVTP_RVF_FIELD_PD]                    = { .quadlet = 5, .offset = 24, .bits = 1 },
-    [AVTP_RVF_FIELD_I]                     = { .quadlet = 5, .offset = 25, .bits = 1 },
-    [AVTP_RVF_FIELD_RESERVED_4]            = { .quadlet = 5, .offset = 26, .bits = 6 },
-    [AVTP_RVF_FIELD_RESERVED_5]            = { .quadlet = 6, .offset = 0, .bits = 8 },
-    [AVTP_RVF_FIELD_PIXEL_DEPTH]           = { .quadlet = 6, .offset = 8, .bits = 4 },
-    [AVTP_RVF_FIELD_PIXEL_FORMAT]          = { .quadlet = 6, .offset = 12, .bits = 4 },
-    [AVTP_RVF_FIELD_FRAME_RATE]            = { .quadlet = 6, .offset = 16, .bits = 8 },
-    [AVTP_RVF_FIELD_COLORSPACE]            = { .quadlet = 6, .offset = 24, .bits = 4 },
-    [AVTP_RVF_FIELD_NUM_LINES]             = { .quadlet = 6, .offset = 28, .bits = 4 },
-    [AVTP_RVF_FIELD_RESERVED_6]            = { .quadlet = 7, .offset = 0, .bits = 8 },
-    [AVTP_RVF_FIELD_I_SEQ_NUM]             = { .quadlet = 7, .offset = 8, .bits = 8 },
-    [AVTP_RVF_FIELD_LINE_NUMBER]           = { .quadlet = 7, .offset = 16, .bits = 16 },
+static const Avtp_FieldDescriptor_t Avtp_RvfFieldDesc[AVTP_RVF_FIELD_MAX] = {
+    [AVTP_RVF_FIELD_SUBTYPE] = {.quadlet = 0, .offset = 0, .bits = 8},
+    [AVTP_RVF_FIELD_SV] = {.quadlet = 0, .offset = 8, .bits = 1},
+    [AVTP_RVF_FIELD_VERSION] = {.quadlet = 0, .offset = 9, .bits = 3},
+    [AVTP_RVF_FIELD_MR] = {.quadlet = 0, .offset = 12, .bits = 1},
+    [AVTP_RVF_FIELD_RESERVED] = {.quadlet = 0, .offset = 13, .bits = 2},
+    [AVTP_RVF_FIELD_TV] = {.quadlet = 0, .offset = 15, .bits = 1},
+    [AVTP_RVF_FIELD_SEQUENCE_NUM] = {.quadlet = 0, .offset = 16, .bits = 8},
+    [AVTP_RVF_FIELD_RESERVED_2] = {.quadlet = 0, .offset = 24, .bits = 7},
+    [AVTP_RVF_FIELD_TU] = {.quadlet = 0, .offset = 31, .bits = 1},
+    [AVTP_RVF_FIELD_STREAM_ID] = {.quadlet = 1, .offset = 0, .bits = 64},
+    [AVTP_RVF_FIELD_AVTP_TIMESTAMP] = {.quadlet = 3, .offset = 0, .bits = 32},
+    [AVTP_RVF_FIELD_ACTIVE_PIXELS] = {.quadlet = 4, .offset = 0, .bits = 16},
+    [AVTP_RVF_FIELD_TOTAL_LINES] = {.quadlet = 4, .offset = 16, .bits = 16},
+    [AVTP_RVF_FIELD_STREAM_DATA_LENGTH] = {.quadlet = 5, .offset = 0, .bits = 16},
+    [AVTP_RVF_FIELD_AP] = {.quadlet = 5, .offset = 16, .bits = 1},
+    [AVTP_RVF_FIELD_RESERVED_3] = {.quadlet = 5, .offset = 17, .bits = 1},
+    [AVTP_RVF_FIELD_F] = {.quadlet = 5, .offset = 18, .bits = 1},
+    [AVTP_RVF_FIELD_EF] = {.quadlet = 5, .offset = 19, .bits = 1},
+    [AVTP_RVF_FIELD_EVT] = {.quadlet = 5, .offset = 20, .bits = 4},
+    [AVTP_RVF_FIELD_PD] = {.quadlet = 5, .offset = 24, .bits = 1},
+    [AVTP_RVF_FIELD_I] = {.quadlet = 5, .offset = 25, .bits = 1},
+    [AVTP_RVF_FIELD_RESERVED_4] = {.quadlet = 5, .offset = 26, .bits = 6},
+    [AVTP_RVF_FIELD_RESERVED_5] = {.quadlet = 6, .offset = 0, .bits = 8},
+    [AVTP_RVF_FIELD_PIXEL_DEPTH] = {.quadlet = 6, .offset = 8, .bits = 4},
+    [AVTP_RVF_FIELD_PIXEL_FORMAT] = {.quadlet = 6, .offset = 12, .bits = 4},
+    [AVTP_RVF_FIELD_FRAME_RATE] = {.quadlet = 6, .offset = 16, .bits = 8},
+    [AVTP_RVF_FIELD_COLORSPACE] = {.quadlet = 6, .offset = 24, .bits = 4},
+    [AVTP_RVF_FIELD_NUM_LINES] = {.quadlet = 6, .offset = 28, .bits = 4},
+    [AVTP_RVF_FIELD_RESERVED_6] = {.quadlet = 7, .offset = 0, .bits = 8},
+    [AVTP_RVF_FIELD_I_SEQ_NUM] = {.quadlet = 7, .offset = 8, .bits = 8},
+    [AVTP_RVF_FIELD_LINE_NUMBER] = {.quadlet = 7, .offset = 16, .bits = 16},
 };
 
-void Avtp_Rvf_Init(Avtp_Rvf_t* pdu)
+void Avtp_Rvf_Init(Avtp_Rvf_t *pdu)
 {
     if (pdu != NULL) {
         memset(pdu, 0, sizeof(Avtp_Rvf_t));
@@ -89,307 +88,307 @@ void Avtp_Rvf_Init(Avtp_Rvf_t* pdu)
     }
 }
 
-uint64_t Avtp_Rvf_GetField(const Avtp_Rvf_t* const pdu, Avtp_RvfField_t field)
+uint64_t Avtp_Rvf_GetField(const Avtp_Rvf_t *const pdu, Avtp_RvfField_t field)
 {
     return GET_FIELD(field);
 }
 
-uint8_t Avtp_Rvf_GetSubtype(const Avtp_Rvf_t* const pdu)
+uint8_t Avtp_Rvf_GetSubtype(const Avtp_Rvf_t *const pdu)
 {
     return (uint8_t)GET_FIELD(AVTP_RVF_FIELD_SUBTYPE);
 }
 
-uint8_t Avtp_Rvf_GetSv(const Avtp_Rvf_t* const pdu)
+uint8_t Avtp_Rvf_GetSv(const Avtp_Rvf_t *const pdu)
 {
     return (uint8_t)GET_FIELD(AVTP_RVF_FIELD_SV);
 }
 
-uint8_t Avtp_Rvf_GetVersion(const Avtp_Rvf_t* const pdu)
+uint8_t Avtp_Rvf_GetVersion(const Avtp_Rvf_t *const pdu)
 {
     return (uint8_t)GET_FIELD(AVTP_RVF_FIELD_VERSION);
 }
 
-uint8_t Avtp_Rvf_GetMr(const Avtp_Rvf_t* const pdu)
+uint8_t Avtp_Rvf_GetMr(const Avtp_Rvf_t *const pdu)
 {
     return (uint8_t)GET_FIELD(AVTP_RVF_FIELD_MR);
 }
 
-uint8_t Avtp_Rvf_GetTv(const Avtp_Rvf_t* const pdu)
+uint8_t Avtp_Rvf_GetTv(const Avtp_Rvf_t *const pdu)
 {
     return (uint8_t)GET_FIELD(AVTP_RVF_FIELD_TV);
 }
 
-uint8_t Avtp_Rvf_GetSequenceNum(const Avtp_Rvf_t* const pdu)
+uint8_t Avtp_Rvf_GetSequenceNum(const Avtp_Rvf_t *const pdu)
 {
     return (uint8_t)GET_FIELD(AVTP_RVF_FIELD_SEQUENCE_NUM);
 }
 
-uint8_t Avtp_Rvf_GetTu(const Avtp_Rvf_t* const pdu)
+uint8_t Avtp_Rvf_GetTu(const Avtp_Rvf_t *const pdu)
 {
     return (uint8_t)GET_FIELD(AVTP_RVF_FIELD_TU);
 }
 
-uint64_t Avtp_Rvf_GetStreamId(const Avtp_Rvf_t* const pdu)
+uint64_t Avtp_Rvf_GetStreamId(const Avtp_Rvf_t *const pdu)
 {
     return GET_FIELD(AVTP_RVF_FIELD_STREAM_ID);
 }
 
-uint32_t Avtp_Rvf_GetAvtpTimestamp(const Avtp_Rvf_t* const pdu)
+uint32_t Avtp_Rvf_GetAvtpTimestamp(const Avtp_Rvf_t *const pdu)
 {
     return (uint32_t)GET_FIELD(AVTP_RVF_FIELD_AVTP_TIMESTAMP);
 }
 
-uint16_t Avtp_Rvf_GetActivePixels(const Avtp_Rvf_t* const pdu)
+uint16_t Avtp_Rvf_GetActivePixels(const Avtp_Rvf_t *const pdu)
 {
     return (uint16_t)GET_FIELD(AVTP_RVF_FIELD_ACTIVE_PIXELS);
 }
 
-uint16_t Avtp_Rvf_GetTotalLines(const Avtp_Rvf_t* const pdu)
+uint16_t Avtp_Rvf_GetTotalLines(const Avtp_Rvf_t *const pdu)
 {
     return (uint16_t)GET_FIELD(AVTP_RVF_FIELD_TOTAL_LINES);
 }
 
-uint16_t Avtp_Rvf_GetStreamDataLength(const Avtp_Rvf_t* const pdu)
+uint16_t Avtp_Rvf_GetStreamDataLength(const Avtp_Rvf_t *const pdu)
 {
     return (uint16_t)GET_FIELD(AVTP_RVF_FIELD_STREAM_DATA_LEN);
 }
 
-uint8_t Avtp_Rvf_GetAp(const Avtp_Rvf_t* const pdu)
+uint8_t Avtp_Rvf_GetAp(const Avtp_Rvf_t *const pdu)
 {
     return (uint8_t)GET_FIELD(AVTP_RVF_FIELD_AP);
 }
 
-uint8_t Avtp_Rvf_GetF(const Avtp_Rvf_t* const pdu)
+uint8_t Avtp_Rvf_GetF(const Avtp_Rvf_t *const pdu)
 {
     return (uint8_t)GET_FIELD(AVTP_RVF_FIELD_F);
 }
 
-uint8_t Avtp_Rvf_GetEf(const Avtp_Rvf_t* const pdu)
+uint8_t Avtp_Rvf_GetEf(const Avtp_Rvf_t *const pdu)
 {
     return (uint8_t)GET_FIELD(AVTP_RVF_FIELD_EF);
 }
 
-uint8_t Avtp_Rvf_GetEvt(const Avtp_Rvf_t* const pdu)
+uint8_t Avtp_Rvf_GetEvt(const Avtp_Rvf_t *const pdu)
 {
     return (uint8_t)GET_FIELD(AVTP_RVF_FIELD_EVT);
 }
 
-uint8_t Avtp_Rvf_GetPd(const Avtp_Rvf_t* const pdu)
+uint8_t Avtp_Rvf_GetPd(const Avtp_Rvf_t *const pdu)
 {
     return (uint8_t)GET_FIELD(AVTP_RVF_FIELD_PD);
 }
 
-uint8_t Avtp_Rvf_GetI(const Avtp_Rvf_t* const pdu)
+uint8_t Avtp_Rvf_GetI(const Avtp_Rvf_t *const pdu)
 {
     return (uint8_t)GET_FIELD(AVTP_RVF_FIELD_I);
 }
 
-Avtp_RvfPixelDepth_t Avtp_Rvf_GetPixelDepth(const Avtp_Rvf_t* const pdu)
+Avtp_RvfPixelDepth_t Avtp_Rvf_GetPixelDepth(const Avtp_Rvf_t *const pdu)
 {
     return (Avtp_RvfPixelDepth_t)GET_FIELD(AVTP_RVF_FIELD_PIXEL_DEPTH);
 }
 
-Avtp_RvfPixelFormat_t Avtp_Rvf_GetPixelFormat(const Avtp_Rvf_t* const pdu)
+Avtp_RvfPixelFormat_t Avtp_Rvf_GetPixelFormat(const Avtp_Rvf_t *const pdu)
 {
     return (Avtp_RvfPixelFormat_t)GET_FIELD(AVTP_RVF_FIELD_PIXEL_FORMAT);
 }
 
-Avtp_RvfFrameRate_t Avtp_Rvf_GetFrameRate(const Avtp_Rvf_t* const pdu)
+Avtp_RvfFrameRate_t Avtp_Rvf_GetFrameRate(const Avtp_Rvf_t *const pdu)
 {
     return (Avtp_RvfFrameRate_t)GET_FIELD(AVTP_RVF_FIELD_FRAME_RATE);
 }
 
-Avtp_RvfColorspace_t Avtp_Rvf_GetColorspace(const Avtp_Rvf_t* const pdu)
+Avtp_RvfColorspace_t Avtp_Rvf_GetColorspace(const Avtp_Rvf_t *const pdu)
 {
     return (Avtp_RvfColorspace_t)GET_FIELD(AVTP_RVF_FIELD_COLORSPACE);
 }
 
-uint8_t Avtp_Rvf_GetNumLines(const Avtp_Rvf_t* const pdu)
+uint8_t Avtp_Rvf_GetNumLines(const Avtp_Rvf_t *const pdu)
 {
     return (uint8_t)GET_FIELD(AVTP_RVF_FIELD_NUM_LINES);
 }
 
-uint8_t Avtp_Rvf_GetISeqNum(const Avtp_Rvf_t* const pdu)
+uint8_t Avtp_Rvf_GetISeqNum(const Avtp_Rvf_t *const pdu)
 {
     return (uint8_t)GET_FIELD(AVTP_RVF_FIELD_I_SEQ_NUM);
 }
 
-uint16_t Avtp_Rvf_GetLineNumber(const Avtp_Rvf_t* const pdu)
+uint16_t Avtp_Rvf_GetLineNumber(const Avtp_Rvf_t *const pdu)
 {
     return (uint16_t)GET_FIELD(AVTP_RVF_FIELD_LINE_NUMBER);
 }
 
-void Avtp_Rvf_SetField(Avtp_Rvf_t* pdu, Avtp_RvfField_t field, uint64_t value)
+void Avtp_Rvf_SetField(Avtp_Rvf_t *pdu, Avtp_RvfField_t field, uint64_t value)
 {
     SET_FIELD(field, value);
 }
 
-void Avtp_Rvf_SetSubtype(Avtp_Rvf_t* pdu, uint8_t value)
+void Avtp_Rvf_SetSubtype(Avtp_Rvf_t *pdu, uint8_t value)
 {
     SET_FIELD(AVTP_RVF_FIELD_SUBTYPE, value);
 }
 
-void Avtp_Rvf_EnableSv(Avtp_Rvf_t* pdu)
+void Avtp_Rvf_EnableSv(Avtp_Rvf_t *pdu)
 {
     SET_FIELD(AVTP_RVF_FIELD_SV, 1);
 }
 
-void Avtp_Rvf_DisableSv(Avtp_Rvf_t* pdu)
+void Avtp_Rvf_DisableSv(Avtp_Rvf_t *pdu)
 {
     SET_FIELD(AVTP_RVF_FIELD_SV, 0);
 }
 
-void Avtp_Rvf_SetVersion(Avtp_Rvf_t* pdu, uint8_t value)
+void Avtp_Rvf_SetVersion(Avtp_Rvf_t *pdu, uint8_t value)
 {
     SET_FIELD(AVTP_RVF_FIELD_VERSION, value);
 }
 
-void Avtp_Rvf_EnableMr(Avtp_Rvf_t* pdu)
+void Avtp_Rvf_EnableMr(Avtp_Rvf_t *pdu)
 {
     SET_FIELD(AVTP_RVF_FIELD_MR, 1);
 }
 
-void Avtp_Rvf_DisableMr(Avtp_Rvf_t* pdu)
+void Avtp_Rvf_DisableMr(Avtp_Rvf_t *pdu)
 {
     SET_FIELD(AVTP_RVF_FIELD_MR, 0);
 }
 
-void Avtp_Rvf_EnableTv(Avtp_Rvf_t* pdu)
+void Avtp_Rvf_EnableTv(Avtp_Rvf_t *pdu)
 {
     SET_FIELD(AVTP_RVF_FIELD_TV, 1);
 }
 
-void Avtp_Rvf_DisableTv(Avtp_Rvf_t* pdu)
+void Avtp_Rvf_DisableTv(Avtp_Rvf_t *pdu)
 {
     SET_FIELD(AVTP_RVF_FIELD_TV, 0);
 }
 
-void Avtp_Rvf_SetSequenceNum(Avtp_Rvf_t* pdu, uint8_t value)
+void Avtp_Rvf_SetSequenceNum(Avtp_Rvf_t *pdu, uint8_t value)
 {
     SET_FIELD(AVTP_RVF_FIELD_SEQ_NUM, value);
 }
 
-void Avtp_Rvf_EnableTu(Avtp_Rvf_t* pdu)
+void Avtp_Rvf_EnableTu(Avtp_Rvf_t *pdu)
 {
     SET_FIELD(AVTP_RVF_FIELD_TU, 1);
 }
 
-void Avtp_Rvf_DisableTu(Avtp_Rvf_t* pdu)
+void Avtp_Rvf_DisableTu(Avtp_Rvf_t *pdu)
 {
     SET_FIELD(AVTP_RVF_FIELD_TU, 0);
 }
 
-void Avtp_Rvf_SetStreamId(Avtp_Rvf_t* pdu, uint64_t value)
+void Avtp_Rvf_SetStreamId(Avtp_Rvf_t *pdu, uint64_t value)
 {
     SET_FIELD(AVTP_RVF_FIELD_STREAM_ID, value);
 }
 
-void Avtp_Rvf_SetAvtpTimestamp(Avtp_Rvf_t* pdu, uint32_t value)
+void Avtp_Rvf_SetAvtpTimestamp(Avtp_Rvf_t *pdu, uint32_t value)
 {
     SET_FIELD(AVTP_RVF_FIELD_AVTP_TIMESTAMP, value);
 }
 
-void Avtp_Rvf_SetActivePixels(Avtp_Rvf_t* pdu, uint16_t value)
+void Avtp_Rvf_SetActivePixels(Avtp_Rvf_t *pdu, uint16_t value)
 {
     SET_FIELD(AVTP_RVF_FIELD_ACTIVE_PIXELS, value);
 }
 
-void Avtp_Rvf_SetTotalLines(Avtp_Rvf_t* pdu, uint16_t value)
+void Avtp_Rvf_SetTotalLines(Avtp_Rvf_t *pdu, uint16_t value)
 {
     SET_FIELD(AVTP_RVF_FIELD_TOTAL_LINES, value);
 }
 
-void Avtp_Rvf_SetStreamDataLength(Avtp_Rvf_t* pdu, uint16_t value)
+void Avtp_Rvf_SetStreamDataLength(Avtp_Rvf_t *pdu, uint16_t value)
 {
     SET_FIELD(AVTP_RVF_FIELD_STREAM_DATA_LEN, value);
 }
 
-void Avtp_Rvf_EnableAp(Avtp_Rvf_t* pdu)
+void Avtp_Rvf_EnableAp(Avtp_Rvf_t *pdu)
 {
     SET_FIELD(AVTP_RVF_FIELD_AP, 1);
 }
 
-void Avtp_Rvf_DisableAp(Avtp_Rvf_t* pdu)
+void Avtp_Rvf_DisableAp(Avtp_Rvf_t *pdu)
 {
     SET_FIELD(AVTP_RVF_FIELD_AP, 0);
 }
 
-void Avtp_Rvf_EnableF(Avtp_Rvf_t* pdu)
+void Avtp_Rvf_EnableF(Avtp_Rvf_t *pdu)
 {
     SET_FIELD(AVTP_RVF_FIELD_F, 1);
 }
 
-void Avtp_Rvf_DisableF(Avtp_Rvf_t* pdu)
+void Avtp_Rvf_DisableF(Avtp_Rvf_t *pdu)
 {
     SET_FIELD(AVTP_RVF_FIELD_F, 0);
 }
 
-void Avtp_Rvf_EnableEf(Avtp_Rvf_t* pdu)
+void Avtp_Rvf_EnableEf(Avtp_Rvf_t *pdu)
 {
     SET_FIELD(AVTP_RVF_FIELD_EF, 1);
 }
 
-void Avtp_Rvf_DisableEf(Avtp_Rvf_t* pdu)
+void Avtp_Rvf_DisableEf(Avtp_Rvf_t *pdu)
 {
     SET_FIELD(AVTP_RVF_FIELD_EF, 0);
 }
 
-void Avtp_Rvf_SetEvt(Avtp_Rvf_t* pdu, uint8_t value)
+void Avtp_Rvf_SetEvt(Avtp_Rvf_t *pdu, uint8_t value)
 {
     SET_FIELD(AVTP_RVF_FIELD_EVT, value);
 }
 
-void Avtp_Rvf_EnablePd(Avtp_Rvf_t* pdu)
+void Avtp_Rvf_EnablePd(Avtp_Rvf_t *pdu)
 {
     SET_FIELD(AVTP_RVF_FIELD_PD, 1);
 }
 
-void Avtp_Rvf_DisablePd(Avtp_Rvf_t* pdu)
+void Avtp_Rvf_DisablePd(Avtp_Rvf_t *pdu)
 {
     SET_FIELD(AVTP_RVF_FIELD_PD, 0);
 }
 
-void Avtp_Rvf_EnableI(Avtp_Rvf_t* pdu)
+void Avtp_Rvf_EnableI(Avtp_Rvf_t *pdu)
 {
     SET_FIELD(AVTP_RVF_FIELD_I, 1);
 }
 
-void Avtp_Rvf_DisableI(Avtp_Rvf_t* pdu)
+void Avtp_Rvf_DisableI(Avtp_Rvf_t *pdu)
 {
     SET_FIELD(AVTP_RVF_FIELD_I, 0);
 }
 
-void Avtp_Rvf_SetPixelDepth(Avtp_Rvf_t* pdu, Avtp_RvfPixelDepth_t value)
+void Avtp_Rvf_SetPixelDepth(Avtp_Rvf_t *pdu, Avtp_RvfPixelDepth_t value)
 {
     SET_FIELD(AVTP_RVF_FIELD_PIXEL_DEPTH, value);
 }
 
-void Avtp_Rvf_SetPixelFormat(Avtp_Rvf_t* pdu, Avtp_RvfPixelFormat_t value)
+void Avtp_Rvf_SetPixelFormat(Avtp_Rvf_t *pdu, Avtp_RvfPixelFormat_t value)
 {
     SET_FIELD(AVTP_RVF_FIELD_PIXEL_FORMAT, value);
 }
 
-void Avtp_Rvf_SetFrameRate(Avtp_Rvf_t* pdu, Avtp_RvfFrameRate_t value)
+void Avtp_Rvf_SetFrameRate(Avtp_Rvf_t *pdu, Avtp_RvfFrameRate_t value)
 {
     SET_FIELD(AVTP_RVF_FIELD_FRAME_RATE, value);
 }
 
-void Avtp_Rvf_SetColorspace(Avtp_Rvf_t* pdu, Avtp_RvfColorspace_t value)
+void Avtp_Rvf_SetColorspace(Avtp_Rvf_t *pdu, Avtp_RvfColorspace_t value)
 {
     SET_FIELD(AVTP_RVF_FIELD_COLORSPACE, value);
 }
 
-void Avtp_Rvf_SetNumLines(Avtp_Rvf_t* pdu, uint8_t value)
+void Avtp_Rvf_SetNumLines(Avtp_Rvf_t *pdu, uint8_t value)
 {
     SET_FIELD(AVTP_RVF_FIELD_NUM_LINES, value);
 }
 
-void Avtp_Rvf_SetISeqNum(Avtp_Rvf_t* pdu, uint8_t value)
+void Avtp_Rvf_SetISeqNum(Avtp_Rvf_t *pdu, uint8_t value)
 {
     SET_FIELD(AVTP_RVF_FIELD_I_SEQ_NUM, value);
 }
 
-void Avtp_Rvf_SetLineNumber(Avtp_Rvf_t* pdu, uint16_t value)
+void Avtp_Rvf_SetLineNumber(Avtp_Rvf_t *pdu, uint16_t value)
 {
     SET_FIELD(AVTP_RVF_FIELD_LINE_NUMBER, value);
 }
@@ -398,32 +397,32 @@ void Avtp_Rvf_SetLineNumber(Avtp_Rvf_t* pdu, uint16_t value)
  * Legacy API
  *****************************************************************************/
 
-int avtp_rvf_pdu_get(const void* const pdu, Avtp_RvfField_t field, uint64_t* val)
+int avtp_rvf_pdu_get(const void *const pdu, Avtp_RvfField_t field, uint64_t *val)
 {
     if (pdu == NULL || val == NULL || field >= AVTP_RVF_FIELD_MAX) {
         return -EINVAL;
     } else {
-        *val = Avtp_Rvf_GetField((const Avtp_Rvf_t* const)pdu, field);
+        *val = Avtp_Rvf_GetField((const Avtp_Rvf_t *const)pdu, field);
         return 0;
     }
 }
 
-int avtp_rvf_pdu_set(void* pdu, Avtp_RvfField_t field, uint64_t val)
+int avtp_rvf_pdu_set(void *pdu, Avtp_RvfField_t field, uint64_t val)
 {
     if (pdu == NULL || field >= AVTP_RVF_FIELD_MAX) {
         return -EINVAL;
     } else {
-        Avtp_Rvf_SetField((Avtp_Rvf_t*)pdu, field, val);
+        Avtp_Rvf_SetField((Avtp_Rvf_t *)pdu, field, val);
         return 0;
     }
 }
 
-int avtp_rvf_pdu_init(void* pdu)
+int avtp_rvf_pdu_init(void *pdu)
 {
     if (pdu == NULL) {
         return -EINVAL;
     } else {
-        Avtp_Rvf_Init((Avtp_Rvf_t*)pdu);
+        Avtp_Rvf_Init((Avtp_Rvf_t *)pdu);
         return 0;
     }
 }

--- a/src/avtp/Rvf.c
+++ b/src/avtp/Rvf.c
@@ -37,7 +37,7 @@
 #include "avtp/CommonHeader.h"
 
 #define GET_FIELD(field) \
-        (Avtp_GetField(Avtp_RvfFieldDesc, AVTP_RVF_FIELD_MAX, (uint8_t*)pdu, field))
+        (Avtp_GetField(Avtp_RvfFieldDesc, AVTP_RVF_FIELD_MAX, (const uint8_t*)pdu, field))
 #define SET_FIELD(field, value) \
         (Avtp_SetField(Avtp_RvfFieldDesc, AVTP_RVF_FIELD_MAX, (uint8_t*)pdu, field, value))
 

--- a/src/avtp/aaf/Aaf.c
+++ b/src/avtp/aaf/Aaf.c
@@ -33,202 +33,202 @@
 #include "avtp/aaf/Aaf.h"
 #include "avtp/Utils.h"
 
-#define GET_FIELD(field) \
-        (Avtp_GetField(Avtp_AafFieldDesc, AVTP_AAF_FIELD_MAX, (const uint8_t*)pdu, field))
-#define SET_FIELD(field, value) \
-        (Avtp_SetField(Avtp_AafFieldDesc, AVTP_AAF_FIELD_MAX, (uint8_t*)pdu, field, value))
+#define GET_FIELD(field)                                                                           \
+    (Avtp_GetField(Avtp_AafFieldDesc, AVTP_AAF_FIELD_MAX, (const uint8_t *)pdu, field))
+#define SET_FIELD(field, value)                                                                    \
+    (Avtp_SetField(Avtp_AafFieldDesc, AVTP_AAF_FIELD_MAX, (uint8_t *)pdu, field, value))
 
-static const Avtp_FieldDescriptor_t Avtp_AafFieldDesc[AVTP_AAF_FIELD_MAX] =
-{
-    [AVTP_AAF_FIELD_SUBTYPE]                    = { .quadlet = 0, .offset =  0, .bits =  8 },
-    [AVTP_AAF_FIELD_SV]                         = { .quadlet = 0, .offset =  8, .bits =  1 },
-    [AVTP_AAF_FIELD_VERSION]                    = { .quadlet = 0, .offset =  9, .bits =  3 },
-    [AVTP_AAF_FIELD_MR]                         = { .quadlet = 0, .offset = 12, .bits =  1 },
-    [AVTP_AAF_FIELD_TV]                         = { .quadlet = 0, .offset = 15, .bits =  1 },
-    [AVTP_AAF_FIELD_SEQUENCE_NUM]               = { .quadlet = 0, .offset = 16, .bits =  8 },
-    [AVTP_AAF_FIELD_TU]                         = { .quadlet = 0, .offset = 31, .bits =  1 },
-    [AVTP_AAF_FIELD_STREAM_ID]                  = { .quadlet = 1, .offset =  0, .bits = 64 },
-    [AVTP_AAF_FIELD_AVTP_TIMESTAMP]             = { .quadlet = 3, .offset =  0, .bits = 32 },
-    [AVTP_AAF_FIELD_FORMAT]                     = { .quadlet = 4, .offset =  0, .bits =  8 },
-    [AVTP_AAF_FIELD_AAF_FORMAT_SPECIFIC_DATA_1] = { .quadlet = 4, .offset =  8, .bits = 24 },
-    [AVTP_AAF_FIELD_STREAM_DATA_LENGTH]         = { .quadlet = 5, .offset =  0, .bits = 16 },
-    [AVTP_AAF_FIELD_AFSD]                       = { .quadlet = 5, .offset = 16, .bits =  3 },
-    [AVTP_AAF_FIELD_SP]                         = { .quadlet = 5, .offset = 19, .bits =  1 },
-    [AVTP_AAF_FIELD_EVT]                        = { .quadlet = 5, .offset = 20, .bits =  4 },
-    [AVTP_AAF_FIELD_AAF_FORMAT_SPECIFIC_DATA_2] = { .quadlet = 5, .offset = 24, .bits =  8 },
+static const Avtp_FieldDescriptor_t Avtp_AafFieldDesc[AVTP_AAF_FIELD_MAX] = {
+    [AVTP_AAF_FIELD_SUBTYPE] = {.quadlet = 0, .offset = 0, .bits = 8},
+    [AVTP_AAF_FIELD_SV] = {.quadlet = 0, .offset = 8, .bits = 1},
+    [AVTP_AAF_FIELD_VERSION] = {.quadlet = 0, .offset = 9, .bits = 3},
+    [AVTP_AAF_FIELD_MR] = {.quadlet = 0, .offset = 12, .bits = 1},
+    [AVTP_AAF_FIELD_TV] = {.quadlet = 0, .offset = 15, .bits = 1},
+    [AVTP_AAF_FIELD_SEQUENCE_NUM] = {.quadlet = 0, .offset = 16, .bits = 8},
+    [AVTP_AAF_FIELD_TU] = {.quadlet = 0, .offset = 31, .bits = 1},
+    [AVTP_AAF_FIELD_STREAM_ID] = {.quadlet = 1, .offset = 0, .bits = 64},
+    [AVTP_AAF_FIELD_AVTP_TIMESTAMP] = {.quadlet = 3, .offset = 0, .bits = 32},
+    [AVTP_AAF_FIELD_FORMAT] = {.quadlet = 4, .offset = 0, .bits = 8},
+    [AVTP_AAF_FIELD_AAF_FORMAT_SPECIFIC_DATA_1] = {.quadlet = 4, .offset = 8, .bits = 24},
+    [AVTP_AAF_FIELD_STREAM_DATA_LENGTH] = {.quadlet = 5, .offset = 0, .bits = 16},
+    [AVTP_AAF_FIELD_AFSD] = {.quadlet = 5, .offset = 16, .bits = 3},
+    [AVTP_AAF_FIELD_SP] = {.quadlet = 5, .offset = 19, .bits = 1},
+    [AVTP_AAF_FIELD_EVT] = {.quadlet = 5, .offset = 20, .bits = 4},
+    [AVTP_AAF_FIELD_AAF_FORMAT_SPECIFIC_DATA_2] = {.quadlet = 5, .offset = 24, .bits = 8},
 };
 
-uint64_t Avtp_Aaf_GetField(const Avtp_Aaf_t* const pdu, Avtp_AafFields_t field)
+uint64_t Avtp_Aaf_GetField(const Avtp_Aaf_t *const pdu, Avtp_AafFields_t field)
 {
-    return Avtp_GetField(Avtp_AafFieldDesc, AVTP_AAF_FIELD_MAX, (const uint8_t*)pdu, (uint8_t) field);
+    return Avtp_GetField(Avtp_AafFieldDesc, AVTP_AAF_FIELD_MAX, (const uint8_t *)pdu,
+                         (uint8_t)field);
 }
 
-uint8_t Avtp_Aaf_GetSubtype(const Avtp_Aaf_t* const pdu)
+uint8_t Avtp_Aaf_GetSubtype(const Avtp_Aaf_t *const pdu)
 {
     return (uint8_t)GET_FIELD(AVTP_AAF_FIELD_SUBTYPE);
 }
 
-uint8_t Avtp_Aaf_GetSv(const Avtp_Aaf_t* const pdu)
+uint8_t Avtp_Aaf_GetSv(const Avtp_Aaf_t *const pdu)
 {
     return (uint8_t)GET_FIELD(AVTP_AAF_FIELD_SV);
 }
 
-uint8_t Avtp_Aaf_GetVersion(const Avtp_Aaf_t* const pdu)
+uint8_t Avtp_Aaf_GetVersion(const Avtp_Aaf_t *const pdu)
 {
     return (uint8_t)GET_FIELD(AVTP_AAF_FIELD_VERSION);
 }
 
-uint8_t Avtp_Aaf_GetMr(const Avtp_Aaf_t* const pdu)
+uint8_t Avtp_Aaf_GetMr(const Avtp_Aaf_t *const pdu)
 {
     return (uint8_t)GET_FIELD(AVTP_AAF_FIELD_MR);
 }
 
-uint8_t Avtp_Aaf_GetTv(const Avtp_Aaf_t* const pdu)
+uint8_t Avtp_Aaf_GetTv(const Avtp_Aaf_t *const pdu)
 {
     return (uint8_t)GET_FIELD(AVTP_AAF_FIELD_TV);
 }
 
-uint8_t Avtp_Aaf_GetSequenceNum(const Avtp_Aaf_t* const pdu)
+uint8_t Avtp_Aaf_GetSequenceNum(const Avtp_Aaf_t *const pdu)
 {
     return (uint8_t)GET_FIELD(AVTP_AAF_FIELD_SEQUENCE_NUM);
 }
 
-uint8_t Avtp_Aaf_GetTu(const Avtp_Aaf_t* const pdu)
+uint8_t Avtp_Aaf_GetTu(const Avtp_Aaf_t *const pdu)
 {
     return (uint8_t)GET_FIELD(AVTP_AAF_FIELD_TU);
 }
 
-uint64_t Avtp_Aaf_GetStreamId(const Avtp_Aaf_t* const pdu)
+uint64_t Avtp_Aaf_GetStreamId(const Avtp_Aaf_t *const pdu)
 {
     return GET_FIELD(AVTP_AAF_FIELD_STREAM_ID);
 }
 
-uint32_t Avtp_Aaf_GetAvtpTimestamp(const Avtp_Aaf_t* const pdu)
+uint32_t Avtp_Aaf_GetAvtpTimestamp(const Avtp_Aaf_t *const pdu)
 {
     return (uint32_t)GET_FIELD(AVTP_AAF_FIELD_AVTP_TIMESTAMP);
 }
 
-uint8_t Avtp_Aaf_GetFormat(const Avtp_Aaf_t* const pdu)
+uint8_t Avtp_Aaf_GetFormat(const Avtp_Aaf_t *const pdu)
 {
     return (uint8_t)GET_FIELD(AVTP_AAF_FIELD_FORMAT);
 }
 
-uint16_t Avtp_Aaf_GetStreamDataLength(const Avtp_Aaf_t* const pdu)
+uint16_t Avtp_Aaf_GetStreamDataLength(const Avtp_Aaf_t *const pdu)
 {
     return (uint16_t)GET_FIELD(AVTP_AAF_FIELD_STREAM_DATA_LENGTH);
 }
 
-uint8_t Avtp_Aaf_GetAfsd(const Avtp_Aaf_t* const pdu)
+uint8_t Avtp_Aaf_GetAfsd(const Avtp_Aaf_t *const pdu)
 {
     return (uint8_t)GET_FIELD(AVTP_AAF_FIELD_AFSD);
 }
 
-uint8_t Avtp_Aaf_GetSp(const Avtp_Aaf_t* const pdu)
+uint8_t Avtp_Aaf_GetSp(const Avtp_Aaf_t *const pdu)
 {
     return (uint8_t)GET_FIELD(AVTP_AAF_FIELD_SP);
 }
 
-uint8_t Avtp_Aaf_GetEvt(const Avtp_Aaf_t* const pdu)
+uint8_t Avtp_Aaf_GetEvt(const Avtp_Aaf_t *const pdu)
 {
     return (uint8_t)GET_FIELD(AVTP_AAF_FIELD_EVT);
 }
 
-void Avtp_Aaf_SetField(Avtp_Aaf_t* pdu, Avtp_AafFields_t field, uint64_t value)
+void Avtp_Aaf_SetField(Avtp_Aaf_t *pdu, Avtp_AafFields_t field, uint64_t value)
 {
-    Avtp_SetField(Avtp_AafFieldDesc, AVTP_AAF_FIELD_MAX, (uint8_t*)pdu, (uint8_t) field, value);
+    Avtp_SetField(Avtp_AafFieldDesc, AVTP_AAF_FIELD_MAX, (uint8_t *)pdu, (uint8_t)field, value);
 }
 
-void Avtp_Aaf_SetSubtype(Avtp_Aaf_t* pdu, uint8_t value)
+void Avtp_Aaf_SetSubtype(Avtp_Aaf_t *pdu, uint8_t value)
 {
     SET_FIELD(AVTP_AAF_FIELD_SUBTYPE, value);
 }
 
-void Avtp_Aaf_EnableSv(Avtp_Aaf_t* pdu)
+void Avtp_Aaf_EnableSv(Avtp_Aaf_t *pdu)
 {
     SET_FIELD(AVTP_AAF_FIELD_SV, 1);
 }
 
-void Avtp_Aaf_DisableSv(Avtp_Aaf_t* pdu)
+void Avtp_Aaf_DisableSv(Avtp_Aaf_t *pdu)
 {
     SET_FIELD(AVTP_AAF_FIELD_SV, 0);
 }
 
-void Avtp_Aaf_SetVersion(Avtp_Aaf_t* pdu, uint8_t value)
+void Avtp_Aaf_SetVersion(Avtp_Aaf_t *pdu, uint8_t value)
 {
     SET_FIELD(AVTP_AAF_FIELD_VERSION, value);
 }
 
-void Avtp_Aaf_EnableMr(Avtp_Aaf_t* pdu)
+void Avtp_Aaf_EnableMr(Avtp_Aaf_t *pdu)
 {
     SET_FIELD(AVTP_AAF_FIELD_MR, 1);
 }
 
-void Avtp_Aaf_DisableMr(Avtp_Aaf_t* pdu)
+void Avtp_Aaf_DisableMr(Avtp_Aaf_t *pdu)
 {
     SET_FIELD(AVTP_AAF_FIELD_MR, 0);
 }
 
-void Avtp_Aaf_EnableTv(Avtp_Aaf_t* pdu)
+void Avtp_Aaf_EnableTv(Avtp_Aaf_t *pdu)
 {
     SET_FIELD(AVTP_AAF_FIELD_TV, 1);
 }
 
-void Avtp_Aaf_DisableTv(Avtp_Aaf_t* pdu)
+void Avtp_Aaf_DisableTv(Avtp_Aaf_t *pdu)
 {
     SET_FIELD(AVTP_AAF_FIELD_TV, 0);
 }
 
-void Avtp_Aaf_SetSequenceNum(Avtp_Aaf_t* pdu, uint8_t value)
+void Avtp_Aaf_SetSequenceNum(Avtp_Aaf_t *pdu, uint8_t value)
 {
     SET_FIELD(AVTP_AAF_FIELD_SEQUENCE_NUM, value);
 }
 
-void Avtp_Aaf_EnableTu(Avtp_Aaf_t* pdu)
+void Avtp_Aaf_EnableTu(Avtp_Aaf_t *pdu)
 {
     SET_FIELD(AVTP_AAF_FIELD_TU, 1);
 }
 
-void Avtp_Aaf_DisableTu(Avtp_Aaf_t* pdu)
+void Avtp_Aaf_DisableTu(Avtp_Aaf_t *pdu)
 {
     SET_FIELD(AVTP_AAF_FIELD_TU, 0);
 }
 
-void Avtp_Aaf_SetStreamId(Avtp_Aaf_t* pdu, uint64_t value)
+void Avtp_Aaf_SetStreamId(Avtp_Aaf_t *pdu, uint64_t value)
 {
     SET_FIELD(AVTP_AAF_FIELD_STREAM_ID, value);
 }
 
-void Avtp_Aaf_SetAvtpTimestamp(Avtp_Aaf_t* pdu, uint32_t value)
+void Avtp_Aaf_SetAvtpTimestamp(Avtp_Aaf_t *pdu, uint32_t value)
 {
     SET_FIELD(AVTP_AAF_FIELD_AVTP_TIMESTAMP, value);
 }
 
-void Avtp_Aaf_SetFormat(Avtp_Aaf_t* pdu, uint8_t value)
+void Avtp_Aaf_SetFormat(Avtp_Aaf_t *pdu, uint8_t value)
 {
     SET_FIELD(AVTP_AAF_FIELD_FORMAT, value);
 }
 
-void Avtp_Aaf_SetStreamDataLength(Avtp_Aaf_t* pdu, uint16_t value)
+void Avtp_Aaf_SetStreamDataLength(Avtp_Aaf_t *pdu, uint16_t value)
 {
     SET_FIELD(AVTP_AAF_FIELD_STREAM_DATA_LENGTH, value);
 }
 
-void Avtp_Aaf_SetAfsd(Avtp_Aaf_t* pdu, uint8_t value)
+void Avtp_Aaf_SetAfsd(Avtp_Aaf_t *pdu, uint8_t value)
 {
     SET_FIELD(AVTP_AAF_FIELD_AFSD, value);
 }
 
-void Avtp_Aaf_EnableSp(Avtp_Aaf_t* pdu)
+void Avtp_Aaf_EnableSp(Avtp_Aaf_t *pdu)
 {
     SET_FIELD(AVTP_AAF_FIELD_SP, 1);
 }
 
-void Avtp_Aaf_DisableSp(Avtp_Aaf_t* pdu)
+void Avtp_Aaf_DisableSp(Avtp_Aaf_t *pdu)
 {
     SET_FIELD(AVTP_AAF_FIELD_SP, 0);
 }
 
-void Avtp_Aaf_SetEvt(Avtp_Aaf_t* pdu, uint8_t value)
+void Avtp_Aaf_SetEvt(Avtp_Aaf_t *pdu, uint8_t value)
 {
     SET_FIELD(AVTP_AAF_FIELD_EVT, value);
 }

--- a/src/avtp/aaf/Aaf.c
+++ b/src/avtp/aaf/Aaf.c
@@ -34,7 +34,7 @@
 #include "avtp/Utils.h"
 
 #define GET_FIELD(field) \
-        (Avtp_GetField(Avtp_AafFieldDesc, AVTP_AAF_FIELD_MAX, (uint8_t*)pdu, field))
+        (Avtp_GetField(Avtp_AafFieldDesc, AVTP_AAF_FIELD_MAX, (const uint8_t*)pdu, field))
 #define SET_FIELD(field, value) \
         (Avtp_SetField(Avtp_AafFieldDesc, AVTP_AAF_FIELD_MAX, (uint8_t*)pdu, field, value))
 
@@ -60,7 +60,7 @@ static const Avtp_FieldDescriptor_t Avtp_AafFieldDesc[AVTP_AAF_FIELD_MAX] =
 
 uint64_t Avtp_Aaf_GetField(const Avtp_Aaf_t* const pdu, Avtp_AafFields_t field)
 {
-    return Avtp_GetField(Avtp_AafFieldDesc, AVTP_AAF_FIELD_MAX, (uint8_t*)pdu, (uint8_t) field);
+    return Avtp_GetField(Avtp_AafFieldDesc, AVTP_AAF_FIELD_MAX, (const uint8_t*)pdu, (uint8_t) field);
 }
 
 uint8_t Avtp_Aaf_GetSubtype(const Avtp_Aaf_t* const pdu)

--- a/src/avtp/aaf/Pcm.c
+++ b/src/avtp/aaf/Pcm.c
@@ -36,7 +36,7 @@
 #include "avtp/Utils.h"
 
 #define GET_FIELD(field) \
-        (Avtp_GetField(Avtp_PcmFieldDesc, AVTP_PCM_FIELD_MAX, (uint8_t*)pdu, field))
+        (Avtp_GetField(Avtp_PcmFieldDesc, AVTP_PCM_FIELD_MAX, (const uint8_t*)pdu, field))
 #define SET_FIELD(field, value) \
         (Avtp_SetField(Avtp_PcmFieldDesc, AVTP_PCM_FIELD_MAX, (uint8_t*)pdu, field, value))
 

--- a/src/avtp/aaf/Pcm.c
+++ b/src/avtp/aaf/Pcm.c
@@ -35,32 +35,31 @@
 #include "avtp/aaf/Pcm.h"
 #include "avtp/Utils.h"
 
-#define GET_FIELD(field) \
-        (Avtp_GetField(Avtp_PcmFieldDesc, AVTP_PCM_FIELD_MAX, (const uint8_t*)pdu, field))
-#define SET_FIELD(field, value) \
-        (Avtp_SetField(Avtp_PcmFieldDesc, AVTP_PCM_FIELD_MAX, (uint8_t*)pdu, field, value))
+#define GET_FIELD(field)                                                                           \
+    (Avtp_GetField(Avtp_PcmFieldDesc, AVTP_PCM_FIELD_MAX, (const uint8_t *)pdu, field))
+#define SET_FIELD(field, value)                                                                    \
+    (Avtp_SetField(Avtp_PcmFieldDesc, AVTP_PCM_FIELD_MAX, (uint8_t *)pdu, field, value))
 
-static const Avtp_FieldDescriptor_t Avtp_PcmFieldDesc[AVTP_PCM_FIELD_MAX] =
-{
-    [AVTP_PCM_FIELD_SUBTYPE]            = { .quadlet = 0, .offset =  0, .bits =  8 },
-    [AVTP_PCM_FIELD_SV]                 = { .quadlet = 0, .offset =  8, .bits =  1 },
-    [AVTP_PCM_FIELD_VERSION]            = { .quadlet = 0, .offset =  9, .bits =  3 },
-    [AVTP_PCM_FIELD_MR]                 = { .quadlet = 0, .offset = 12, .bits =  1 },
-    [AVTP_PCM_FIELD_TV]                 = { .quadlet = 0, .offset = 15, .bits =  1 },
-    [AVTP_PCM_FIELD_SEQUENCE_NUM]       = { .quadlet = 0, .offset = 16, .bits =  8 },
-    [AVTP_PCM_FIELD_TU]                 = { .quadlet = 0, .offset = 31, .bits =  1 },
-    [AVTP_PCM_FIELD_STREAM_ID]          = { .quadlet = 1, .offset =  0, .bits = 64 },
-    [AVTP_PCM_FIELD_AVTP_TIMESTAMP]     = { .quadlet = 3, .offset =  0, .bits = 32 },
-    [AVTP_PCM_FIELD_FORMAT]             = { .quadlet = 4, .offset =  0, .bits =  8 },
-    [AVTP_PCM_FIELD_NSR]                = { .quadlet = 4, .offset =  8, .bits =  4 },
-    [AVTP_PCM_FIELD_CHANNELS_PER_FRAME] = { .quadlet = 4, .offset = 14, .bits = 10 },
-    [AVTP_PCM_FIELD_BIT_DEPTH]          = { .quadlet = 4, .offset = 24, .bits =  8 },
-    [AVTP_PCM_FIELD_STREAM_DATA_LENGTH] = { .quadlet = 5, .offset =  0, .bits = 16 },
-    [AVTP_PCM_FIELD_SP]                 = { .quadlet = 5, .offset = 19, .bits =  1 },
-    [AVTP_PCM_FIELD_EVT]                = { .quadlet = 5, .offset = 20, .bits =  4 },
+static const Avtp_FieldDescriptor_t Avtp_PcmFieldDesc[AVTP_PCM_FIELD_MAX] = {
+    [AVTP_PCM_FIELD_SUBTYPE] = {.quadlet = 0, .offset = 0, .bits = 8},
+    [AVTP_PCM_FIELD_SV] = {.quadlet = 0, .offset = 8, .bits = 1},
+    [AVTP_PCM_FIELD_VERSION] = {.quadlet = 0, .offset = 9, .bits = 3},
+    [AVTP_PCM_FIELD_MR] = {.quadlet = 0, .offset = 12, .bits = 1},
+    [AVTP_PCM_FIELD_TV] = {.quadlet = 0, .offset = 15, .bits = 1},
+    [AVTP_PCM_FIELD_SEQUENCE_NUM] = {.quadlet = 0, .offset = 16, .bits = 8},
+    [AVTP_PCM_FIELD_TU] = {.quadlet = 0, .offset = 31, .bits = 1},
+    [AVTP_PCM_FIELD_STREAM_ID] = {.quadlet = 1, .offset = 0, .bits = 64},
+    [AVTP_PCM_FIELD_AVTP_TIMESTAMP] = {.quadlet = 3, .offset = 0, .bits = 32},
+    [AVTP_PCM_FIELD_FORMAT] = {.quadlet = 4, .offset = 0, .bits = 8},
+    [AVTP_PCM_FIELD_NSR] = {.quadlet = 4, .offset = 8, .bits = 4},
+    [AVTP_PCM_FIELD_CHANNELS_PER_FRAME] = {.quadlet = 4, .offset = 14, .bits = 10},
+    [AVTP_PCM_FIELD_BIT_DEPTH] = {.quadlet = 4, .offset = 24, .bits = 8},
+    [AVTP_PCM_FIELD_STREAM_DATA_LENGTH] = {.quadlet = 5, .offset = 0, .bits = 16},
+    [AVTP_PCM_FIELD_SP] = {.quadlet = 5, .offset = 19, .bits = 1},
+    [AVTP_PCM_FIELD_EVT] = {.quadlet = 5, .offset = 20, .bits = 4},
 };
 
-void Avtp_Pcm_Init(Avtp_Pcm_t* pdu)
+void Avtp_Pcm_Init(Avtp_Pcm_t *pdu)
 {
     if (pdu != NULL) {
         memset(pdu, 0, sizeof(Avtp_Pcm_t));
@@ -69,197 +68,197 @@ void Avtp_Pcm_Init(Avtp_Pcm_t* pdu)
     }
 }
 
-uint64_t Avtp_Pcm_GetField(const Avtp_Pcm_t* const pdu, Avtp_PcmFields_t field)
+uint64_t Avtp_Pcm_GetField(const Avtp_Pcm_t *const pdu, Avtp_PcmFields_t field)
 {
     return GET_FIELD(field);
 }
 
-uint8_t Avtp_Pcm_GetSubtype(const Avtp_Pcm_t* const pdu)
+uint8_t Avtp_Pcm_GetSubtype(const Avtp_Pcm_t *const pdu)
 {
     return (uint8_t)GET_FIELD(AVTP_PCM_FIELD_SUBTYPE);
 }
 
-uint8_t Avtp_Pcm_GetSv(const Avtp_Pcm_t* const pdu)
+uint8_t Avtp_Pcm_GetSv(const Avtp_Pcm_t *const pdu)
 {
     return (uint8_t)GET_FIELD(AVTP_PCM_FIELD_SV);
 }
 
-uint8_t Avtp_Pcm_GetVersion(const Avtp_Pcm_t* const pdu)
+uint8_t Avtp_Pcm_GetVersion(const Avtp_Pcm_t *const pdu)
 {
     return (uint8_t)GET_FIELD(AVTP_PCM_FIELD_VERSION);
 }
 
-uint8_t Avtp_Pcm_GetMr(const Avtp_Pcm_t* const pdu)
+uint8_t Avtp_Pcm_GetMr(const Avtp_Pcm_t *const pdu)
 {
     return (uint8_t)GET_FIELD(AVTP_PCM_FIELD_MR);
 }
 
-uint8_t Avtp_Pcm_GetTv(const Avtp_Pcm_t* const pdu)
+uint8_t Avtp_Pcm_GetTv(const Avtp_Pcm_t *const pdu)
 {
     return (uint8_t)GET_FIELD(AVTP_PCM_FIELD_TV);
 }
 
-uint8_t Avtp_Pcm_GetSequenceNum(const Avtp_Pcm_t* const pdu)
+uint8_t Avtp_Pcm_GetSequenceNum(const Avtp_Pcm_t *const pdu)
 {
     return (uint8_t)GET_FIELD(AVTP_PCM_FIELD_SEQUENCE_NUM);
 }
 
-uint8_t Avtp_Pcm_GetTu(const Avtp_Pcm_t* const pdu)
+uint8_t Avtp_Pcm_GetTu(const Avtp_Pcm_t *const pdu)
 {
     return (uint8_t)GET_FIELD(AVTP_PCM_FIELD_TU);
 }
 
-uint64_t Avtp_Pcm_GetStreamId(const Avtp_Pcm_t* const pdu)
+uint64_t Avtp_Pcm_GetStreamId(const Avtp_Pcm_t *const pdu)
 {
     return GET_FIELD(AVTP_PCM_FIELD_STREAM_ID);
 }
 
-uint32_t Avtp_Pcm_GetAvtpTimestamp(const Avtp_Pcm_t* const pdu)
+uint32_t Avtp_Pcm_GetAvtpTimestamp(const Avtp_Pcm_t *const pdu)
 {
     return (uint32_t)GET_FIELD(AVTP_PCM_FIELD_AVTP_TIMESTAMP);
 }
 
-Avtp_AafFormat_t Avtp_Pcm_GetFormat(const Avtp_Pcm_t* const pdu)
+Avtp_AafFormat_t Avtp_Pcm_GetFormat(const Avtp_Pcm_t *const pdu)
 {
     return (Avtp_AafFormat_t)GET_FIELD(AVTP_PCM_FIELD_FORMAT);
 }
 
-Avtp_AafNsr_t Avtp_Pcm_GetNsr(const Avtp_Pcm_t* const pdu)
+Avtp_AafNsr_t Avtp_Pcm_GetNsr(const Avtp_Pcm_t *const pdu)
 {
     return (Avtp_AafNsr_t)GET_FIELD(AVTP_PCM_FIELD_NSR);
 }
 
-uint16_t Avtp_Pcm_GetChannelsPerFrame(const Avtp_Pcm_t* const pdu)
+uint16_t Avtp_Pcm_GetChannelsPerFrame(const Avtp_Pcm_t *const pdu)
 {
     return (uint16_t)GET_FIELD(AVTP_PCM_FIELD_CHANNELS_PER_FRAME);
 }
 
-uint8_t Avtp_Pcm_GetBitDepth(const Avtp_Pcm_t* const pdu)
+uint8_t Avtp_Pcm_GetBitDepth(const Avtp_Pcm_t *const pdu)
 {
     return (uint8_t)GET_FIELD(AVTP_PCM_FIELD_BIT_DEPTH);
 }
 
-uint16_t Avtp_Pcm_GetStreamDataLength(const Avtp_Pcm_t* const pdu)
+uint16_t Avtp_Pcm_GetStreamDataLength(const Avtp_Pcm_t *const pdu)
 {
     return (uint16_t)GET_FIELD(AVTP_PCM_FIELD_STREAM_DATA_LENGTH);
 }
 
-Avtp_AafSp_t Avtp_Pcm_GetSp(const Avtp_Pcm_t* const pdu)
+Avtp_AafSp_t Avtp_Pcm_GetSp(const Avtp_Pcm_t *const pdu)
 {
     return (Avtp_AafSp_t)GET_FIELD(AVTP_PCM_FIELD_SP);
 }
 
-uint8_t Avtp_Pcm_GetEvt(const Avtp_Pcm_t* const pdu)
+uint8_t Avtp_Pcm_GetEvt(const Avtp_Pcm_t *const pdu)
 {
     return (uint8_t)GET_FIELD(AVTP_PCM_FIELD_EVT);
 }
 
-void Avtp_Pcm_SetField(Avtp_Pcm_t* pdu, Avtp_PcmFields_t field, uint64_t value)
+void Avtp_Pcm_SetField(Avtp_Pcm_t *pdu, Avtp_PcmFields_t field, uint64_t value)
 {
     SET_FIELD(field, value);
 }
 
-void Avtp_Pcm_SetSubtype(Avtp_Pcm_t* pdu, uint8_t value)
+void Avtp_Pcm_SetSubtype(Avtp_Pcm_t *pdu, uint8_t value)
 {
     SET_FIELD(AVTP_PCM_FIELD_SUBTYPE, value);
 }
 
-void Avtp_Pcm_EnableSv(Avtp_Pcm_t* pdu)
+void Avtp_Pcm_EnableSv(Avtp_Pcm_t *pdu)
 {
     SET_FIELD(AVTP_PCM_FIELD_SV, 1);
 }
 
-void Avtp_Pcm_DisableSv(Avtp_Pcm_t* pdu)
+void Avtp_Pcm_DisableSv(Avtp_Pcm_t *pdu)
 {
     SET_FIELD(AVTP_PCM_FIELD_SV, 0);
 }
 
-void Avtp_Pcm_SetVersion(Avtp_Pcm_t* pdu, uint8_t value)
+void Avtp_Pcm_SetVersion(Avtp_Pcm_t *pdu, uint8_t value)
 {
     SET_FIELD(AVTP_PCM_FIELD_VERSION, value);
 }
 
-void Avtp_Pcm_EnableMr(Avtp_Pcm_t* pdu)
+void Avtp_Pcm_EnableMr(Avtp_Pcm_t *pdu)
 {
     SET_FIELD(AVTP_PCM_FIELD_MR, 1);
 }
 
-void Avtp_Pcm_DisableMr(Avtp_Pcm_t* pdu)
+void Avtp_Pcm_DisableMr(Avtp_Pcm_t *pdu)
 {
     SET_FIELD(AVTP_PCM_FIELD_MR, 0);
 }
 
-void Avtp_Pcm_EnableTv(Avtp_Pcm_t* pdu)
+void Avtp_Pcm_EnableTv(Avtp_Pcm_t *pdu)
 {
     SET_FIELD(AVTP_PCM_FIELD_TV, 1);
 }
 
-void Avtp_Pcm_DisableTv(Avtp_Pcm_t* pdu)
+void Avtp_Pcm_DisableTv(Avtp_Pcm_t *pdu)
 {
     SET_FIELD(AVTP_PCM_FIELD_TV, 0);
 }
 
-void Avtp_Pcm_SetSequenceNum(Avtp_Pcm_t* pdu, uint8_t value)
+void Avtp_Pcm_SetSequenceNum(Avtp_Pcm_t *pdu, uint8_t value)
 {
     SET_FIELD(AVTP_PCM_FIELD_SEQUENCE_NUM, value);
 }
 
-void Avtp_Pcm_EnableTu(Avtp_Pcm_t* pdu)
+void Avtp_Pcm_EnableTu(Avtp_Pcm_t *pdu)
 {
     SET_FIELD(AVTP_PCM_FIELD_TU, 1);
 }
 
-void Avtp_Pcm_DisableTu(Avtp_Pcm_t* pdu)
+void Avtp_Pcm_DisableTu(Avtp_Pcm_t *pdu)
 {
     SET_FIELD(AVTP_PCM_FIELD_TU, 0);
 }
 
-void Avtp_Pcm_SetStreamId(Avtp_Pcm_t* pdu, uint64_t value)
+void Avtp_Pcm_SetStreamId(Avtp_Pcm_t *pdu, uint64_t value)
 {
     SET_FIELD(AVTP_PCM_FIELD_STREAM_ID, value);
 }
 
-void Avtp_Pcm_SetAvtpTimestamp(Avtp_Pcm_t* pdu, uint32_t value)
+void Avtp_Pcm_SetAvtpTimestamp(Avtp_Pcm_t *pdu, uint32_t value)
 {
     SET_FIELD(AVTP_PCM_FIELD_AVTP_TIMESTAMP, value);
 }
 
-void Avtp_Pcm_SetFormat(Avtp_Pcm_t* pdu, Avtp_AafFormat_t value)
+void Avtp_Pcm_SetFormat(Avtp_Pcm_t *pdu, Avtp_AafFormat_t value)
 {
     SET_FIELD(AVTP_PCM_FIELD_FORMAT, value);
 }
 
-void Avtp_Pcm_SetNsr(Avtp_Pcm_t* pdu, Avtp_AafNsr_t value)
+void Avtp_Pcm_SetNsr(Avtp_Pcm_t *pdu, Avtp_AafNsr_t value)
 {
     SET_FIELD(AVTP_PCM_FIELD_NSR, value);
 }
 
-void Avtp_Pcm_SetChannelsPerFrame(Avtp_Pcm_t* pdu, uint16_t value)
+void Avtp_Pcm_SetChannelsPerFrame(Avtp_Pcm_t *pdu, uint16_t value)
 {
     SET_FIELD(AVTP_PCM_FIELD_CHANNELS_PER_FRAME, value);
 }
 
-void Avtp_Pcm_SetBitDepth(Avtp_Pcm_t* pdu, uint8_t value)
+void Avtp_Pcm_SetBitDepth(Avtp_Pcm_t *pdu, uint8_t value)
 {
     SET_FIELD(AVTP_PCM_FIELD_BIT_DEPTH, value);
 }
 
-void Avtp_Pcm_SetStreamDataLength(Avtp_Pcm_t* pdu, uint16_t value)
+void Avtp_Pcm_SetStreamDataLength(Avtp_Pcm_t *pdu, uint16_t value)
 {
     SET_FIELD(AVTP_PCM_FIELD_STREAM_DATA_LENGTH, value);
 }
 
-void Avtp_Pcm_EnableSp(Avtp_Pcm_t* pdu)
+void Avtp_Pcm_EnableSp(Avtp_Pcm_t *pdu)
 {
     SET_FIELD(AVTP_PCM_FIELD_SP, 1);
 }
 
-void Avtp_Pcm_DisableSp(Avtp_Pcm_t* pdu)
+void Avtp_Pcm_DisableSp(Avtp_Pcm_t *pdu)
 {
     SET_FIELD(AVTP_PCM_FIELD_SP, 0);
 }
 
-void Avtp_Pcm_SetEvt(Avtp_Pcm_t* pdu, uint8_t value)
+void Avtp_Pcm_SetEvt(Avtp_Pcm_t *pdu, uint8_t value)
 {
     SET_FIELD(AVTP_PCM_FIELD_EVT, value);
 }
@@ -268,23 +267,22 @@ void Avtp_Pcm_SetEvt(Avtp_Pcm_t* pdu, uint8_t value)
  * Legacy API (deprecated)
  *****************************************************************************/
 
-int avtp_aaf_pdu_get(const void * const pdu, Avtp_PcmFields_t field, uint64_t *val)
+int avtp_aaf_pdu_get(const void *const pdu, Avtp_PcmFields_t field, uint64_t *val)
 {
     if (pdu == NULL || val == NULL || field >= AVTP_PCM_FIELD_MAX) {
         return -EINVAL;
     } else {
-        *val = Avtp_Pcm_GetField((const Avtp_Pcm_t* const)pdu, field);
+        *val = Avtp_Pcm_GetField((const Avtp_Pcm_t *const)pdu, field);
         return 0;
     }
 }
 
-int avtp_aaf_pdu_set(void *pdu, Avtp_PcmFields_t field,
-                                uint64_t val)
+int avtp_aaf_pdu_set(void *pdu, Avtp_PcmFields_t field, uint64_t val)
 {
     if (pdu == NULL || field >= AVTP_PCM_FIELD_MAX) {
         return -EINVAL;
     } else {
-        Avtp_Pcm_SetField((Avtp_Pcm_t*)pdu, field, val);
+        Avtp_Pcm_SetField((Avtp_Pcm_t *)pdu, field, val);
         return 0;
     }
 }

--- a/src/avtp/acf/custom/Vss.c
+++ b/src/avtp/acf/custom/Vss.c
@@ -37,7 +37,7 @@
 #include "avtp/Defines.h"
 
 #define GET_FIELD(field)                                                                           \
-    (Avtp_GetField(Avtp_VssFieldDesc, AVTP_VSS_FIELD_MAX, (uint8_t *)pdu, field))
+    (Avtp_GetField(Avtp_VssFieldDesc, AVTP_VSS_FIELD_MAX, (const uint8_t *)pdu, field))
 #define SET_FIELD(field, value)                                                                    \
     (Avtp_SetField(Avtp_VssFieldDesc, AVTP_VSS_FIELD_MAX, (uint8_t *)pdu, field, value))
 

--- a/src/avtp/acf/custom/VssBrief.c
+++ b/src/avtp/acf/custom/VssBrief.c
@@ -63,7 +63,7 @@ uint64_t Avtp_VssBrief_GetField(const Avtp_VssBrief_t* const vss_pdu,
                             Avtp_VssBriefFields_t field)
 {
     return Avtp_GetField(Avtp_VssBriefFieldDesc, AVTP_VSS_BRIEF_FIELD_MAX,
-                         (uint8_t *) vss_pdu, (uint8_t) field);
+                         (const uint8_t *) vss_pdu, (uint8_t) field);
 }
 
 void Avtp_VssBrief_SetField(Avtp_VssBrief_t* vss_pdu,

--- a/src/avtp/acf/custom/VssBrief.c
+++ b/src/avtp/acf/custom/VssBrief.c
@@ -38,37 +38,34 @@
 /**
  * This table maps all IEEE 1722 ACF VSS header fields to a descriptor.
  */
-static const Avtp_FieldDescriptor_t Avtp_VssBriefFieldDesc[AVTP_VSS_BRIEF_FIELD_MAX] =
-{
+static const Avtp_FieldDescriptor_t Avtp_VssBriefFieldDesc[AVTP_VSS_BRIEF_FIELD_MAX] = {
     /* ACF common header fields */
-    [AVTP_VSS_BRIEF_FIELD_ACF_MSG_TYPE]       = { .quadlet = 0, .offset =  0, .bits = 7 },
-    [AVTP_VSS_BRIEF_FIELD_ACF_MSG_LENGTH]     = { .quadlet = 0, .offset =  7, .bits = 9 },
+    [AVTP_VSS_BRIEF_FIELD_ACF_MSG_TYPE] = {.quadlet = 0, .offset = 0, .bits = 7},
+    [AVTP_VSS_BRIEF_FIELD_ACF_MSG_LENGTH] = {.quadlet = 0, .offset = 7, .bits = 9},
     /* ACF VSS header fields */
-    [AVTP_VSS_BRIEF_FIELD_PAD]                = { .quadlet = 0, .offset = 16, .bits =  2 },
-    [AVTP_VSS_BRIEF_FIELD_MTV]                = { .quadlet = 0, .offset = 18, .bits =  1 },
-    [AVTP_VSS_BRIEF_FIELD_ADDR_MODE]          = { .quadlet = 0, .offset = 19, .bits =  2 },
-    [AVTP_VSS_BRIEF_FIELD_VSS_OP]             = { .quadlet = 0, .offset = 21, .bits =  3 },
-    [AVTP_VSS_BRIEF_FIELD_VSS_DATATYPE]       = { .quadlet = 0, .offset = 24, .bits =  8 }
-};
+    [AVTP_VSS_BRIEF_FIELD_PAD] = {.quadlet = 0, .offset = 16, .bits = 2},
+    [AVTP_VSS_BRIEF_FIELD_MTV] = {.quadlet = 0, .offset = 18, .bits = 1},
+    [AVTP_VSS_BRIEF_FIELD_ADDR_MODE] = {.quadlet = 0, .offset = 19, .bits = 2},
+    [AVTP_VSS_BRIEF_FIELD_VSS_OP] = {.quadlet = 0, .offset = 21, .bits = 3},
+    [AVTP_VSS_BRIEF_FIELD_VSS_DATATYPE] = {.quadlet = 0, .offset = 24, .bits = 8}};
 
-void Avtp_VssBrief_Init(Avtp_VssBrief_t* vss_pdu) {
+void Avtp_VssBrief_Init(Avtp_VssBrief_t *vss_pdu)
+{
 
-    if(vss_pdu != NULL) {
+    if (vss_pdu != NULL) {
         memset(vss_pdu, 0, sizeof(Avtp_VssBrief_t));
         Avtp_VssBrief_SetField(vss_pdu, AVTP_VSS_BRIEF_FIELD_ACF_MSG_TYPE, AVTP_ACF_TYPE_VSS_BRIEF);
     }
 }
 
-uint64_t Avtp_VssBrief_GetField(const Avtp_VssBrief_t* const vss_pdu,
-                            Avtp_VssBriefFields_t field)
+uint64_t Avtp_VssBrief_GetField(const Avtp_VssBrief_t *const vss_pdu, Avtp_VssBriefFields_t field)
 {
-    return Avtp_GetField(Avtp_VssBriefFieldDesc, AVTP_VSS_BRIEF_FIELD_MAX,
-                         (const uint8_t *) vss_pdu, (uint8_t) field);
+    return Avtp_GetField(Avtp_VssBriefFieldDesc, AVTP_VSS_BRIEF_FIELD_MAX, (const uint8_t *)vss_pdu,
+                         (uint8_t)field);
 }
 
-void Avtp_VssBrief_SetField(Avtp_VssBrief_t* vss_pdu,
-                            Avtp_VssBriefFields_t field, uint64_t value)
+void Avtp_VssBrief_SetField(Avtp_VssBrief_t *vss_pdu, Avtp_VssBriefFields_t field, uint64_t value)
 {
-    Avtp_SetField(Avtp_VssBriefFieldDesc, AVTP_VSS_BRIEF_FIELD_MAX,
-                         (uint8_t *) vss_pdu, (uint8_t) field, value);
+    Avtp_SetField(Avtp_VssBriefFieldDesc, AVTP_VSS_BRIEF_FIELD_MAX, (uint8_t *)vss_pdu,
+                  (uint8_t)field, value);
 }

--- a/src/avtp/cvf/Cvf.c
+++ b/src/avtp/cvf/Cvf.c
@@ -34,36 +34,35 @@
 #include "avtp/Utils.h"
 #include "avtp/CommonHeader.h"
 
-#define GET_FIELD(field) \
-        (Avtp_GetField(fieldDescriptors, AVTP_CVF_FIELD_MAX, (const uint8_t*)pdu, field))
-#define SET_FIELD(field, value) \
-        (Avtp_SetField(fieldDescriptors, AVTP_CVF_FIELD_MAX, (uint8_t*)pdu, field, value))
+#define GET_FIELD(field)                                                                           \
+    (Avtp_GetField(fieldDescriptors, AVTP_CVF_FIELD_MAX, (const uint8_t *)pdu, field))
+#define SET_FIELD(field, value)                                                                    \
+    (Avtp_SetField(fieldDescriptors, AVTP_CVF_FIELD_MAX, (uint8_t *)pdu, field, value))
 
-static const Avtp_FieldDescriptor_t fieldDescriptors[AVTP_CVF_FIELD_MAX] =
-{
-    [AVTP_CVF_FIELD_SUBTYPE]            = { .quadlet = 0, .offset = 0, .bits = 8 },
-    [AVTP_CVF_FIELD_SV]                 = { .quadlet = 0, .offset = 8, .bits = 1 },
-    [AVTP_CVF_FIELD_VERSION]            = { .quadlet = 0, .offset = 9, .bits = 3 },
-    [AVTP_CVF_FIELD_MR]                 = { .quadlet = 0, .offset = 12, .bits = 1 },
-    [AVTP_CVF_FIELD_RESERVED]           = { .quadlet = 0, .offset = 13, .bits = 2 },
-    [AVTP_CVF_FIELD_TV]                 = { .quadlet = 0, .offset = 15, .bits = 1 },
-    [AVTP_CVF_FIELD_SEQUENCE_NUM]       = { .quadlet = 0, .offset = 16, .bits = 8 },
-    [AVTP_CVF_FIELD_RESERVED_2]         = { .quadlet = 0, .offset = 24, .bits = 7 },
-    [AVTP_CVF_FIELD_TU]                 = { .quadlet = 0, .offset = 31, .bits = 1 },
-    [AVTP_CVF_FIELD_STREAM_ID]          = { .quadlet = 1, .offset = 0, .bits = 64 },
-    [AVTP_CVF_FIELD_AVTP_TIMESTAMP]     = { .quadlet = 3, .offset = 0, .bits = 32 },
-    [AVTP_CVF_FIELD_FORMAT]             = { .quadlet = 4, .offset = 0, .bits = 8 },
-    [AVTP_CVF_FIELD_FORMAT_SUBTYPE]     = { .quadlet = 4, .offset = 8, .bits = 8 },
-    [AVTP_CVF_FIELD_RESERVED_3]         = { .quadlet = 4, .offset = 16, .bits = 16 },
-    [AVTP_CVF_FIELD_STREAM_DATA_LENGTH] = { .quadlet = 5, .offset = 0, .bits = 16 },
-    [AVTP_CVF_FIELD_RESERVED_4]         = { .quadlet = 5, .offset = 16, .bits = 2 },
-    [AVTP_CVF_FIELD_PTV]                = { .quadlet = 5, .offset = 18, .bits = 1 },
-    [AVTP_CVF_FIELD_M]                  = { .quadlet = 5, .offset = 19, .bits = 1 },
-    [AVTP_CVF_FIELD_EVT]                = { .quadlet = 5, .offset = 20, .bits = 4 },
-    [AVTP_CVF_FIELD_RESERVED_5]         = { .quadlet = 5, .offset = 24, .bits = 8 },
+static const Avtp_FieldDescriptor_t fieldDescriptors[AVTP_CVF_FIELD_MAX] = {
+    [AVTP_CVF_FIELD_SUBTYPE] = {.quadlet = 0, .offset = 0, .bits = 8},
+    [AVTP_CVF_FIELD_SV] = {.quadlet = 0, .offset = 8, .bits = 1},
+    [AVTP_CVF_FIELD_VERSION] = {.quadlet = 0, .offset = 9, .bits = 3},
+    [AVTP_CVF_FIELD_MR] = {.quadlet = 0, .offset = 12, .bits = 1},
+    [AVTP_CVF_FIELD_RESERVED] = {.quadlet = 0, .offset = 13, .bits = 2},
+    [AVTP_CVF_FIELD_TV] = {.quadlet = 0, .offset = 15, .bits = 1},
+    [AVTP_CVF_FIELD_SEQUENCE_NUM] = {.quadlet = 0, .offset = 16, .bits = 8},
+    [AVTP_CVF_FIELD_RESERVED_2] = {.quadlet = 0, .offset = 24, .bits = 7},
+    [AVTP_CVF_FIELD_TU] = {.quadlet = 0, .offset = 31, .bits = 1},
+    [AVTP_CVF_FIELD_STREAM_ID] = {.quadlet = 1, .offset = 0, .bits = 64},
+    [AVTP_CVF_FIELD_AVTP_TIMESTAMP] = {.quadlet = 3, .offset = 0, .bits = 32},
+    [AVTP_CVF_FIELD_FORMAT] = {.quadlet = 4, .offset = 0, .bits = 8},
+    [AVTP_CVF_FIELD_FORMAT_SUBTYPE] = {.quadlet = 4, .offset = 8, .bits = 8},
+    [AVTP_CVF_FIELD_RESERVED_3] = {.quadlet = 4, .offset = 16, .bits = 16},
+    [AVTP_CVF_FIELD_STREAM_DATA_LENGTH] = {.quadlet = 5, .offset = 0, .bits = 16},
+    [AVTP_CVF_FIELD_RESERVED_4] = {.quadlet = 5, .offset = 16, .bits = 2},
+    [AVTP_CVF_FIELD_PTV] = {.quadlet = 5, .offset = 18, .bits = 1},
+    [AVTP_CVF_FIELD_M] = {.quadlet = 5, .offset = 19, .bits = 1},
+    [AVTP_CVF_FIELD_EVT] = {.quadlet = 5, .offset = 20, .bits = 4},
+    [AVTP_CVF_FIELD_RESERVED_5] = {.quadlet = 5, .offset = 24, .bits = 8},
 };
 
-void Avtp_Cvf_Init(Avtp_Cvf_t* pdu)
+void Avtp_Cvf_Init(Avtp_Cvf_t *pdu)
 {
     if (pdu != NULL) {
         memset(pdu, 0, sizeof(Avtp_Cvf_t));
@@ -73,192 +72,192 @@ void Avtp_Cvf_Init(Avtp_Cvf_t* pdu)
     }
 }
 
-uint64_t Avtp_Cvf_GetField(const Avtp_Cvf_t* const pdu, Avtp_CvfField_t field)
+uint64_t Avtp_Cvf_GetField(const Avtp_Cvf_t *const pdu, Avtp_CvfField_t field)
 {
     return GET_FIELD(field);
 }
 
-uint8_t Avtp_Cvf_GetSubtype(const Avtp_Cvf_t* const pdu)
+uint8_t Avtp_Cvf_GetSubtype(const Avtp_Cvf_t *const pdu)
 {
     return (uint8_t)GET_FIELD(AVTP_CVF_FIELD_SUBTYPE);
 }
 
-uint8_t Avtp_Cvf_GetSv(const Avtp_Cvf_t* const pdu)
+uint8_t Avtp_Cvf_GetSv(const Avtp_Cvf_t *const pdu)
 {
     return (uint8_t)GET_FIELD(AVTP_CVF_FIELD_SV);
 }
 
-uint8_t Avtp_Cvf_GetVersion(const Avtp_Cvf_t* const pdu)
+uint8_t Avtp_Cvf_GetVersion(const Avtp_Cvf_t *const pdu)
 {
     return (uint8_t)GET_FIELD(AVTP_CVF_FIELD_VERSION);
 }
 
-uint8_t Avtp_Cvf_GetMr(const Avtp_Cvf_t* const pdu)
+uint8_t Avtp_Cvf_GetMr(const Avtp_Cvf_t *const pdu)
 {
     return (uint8_t)GET_FIELD(AVTP_CVF_FIELD_MR);
 }
 
-uint8_t Avtp_Cvf_GetTv(const Avtp_Cvf_t* const pdu)
+uint8_t Avtp_Cvf_GetTv(const Avtp_Cvf_t *const pdu)
 {
     return (uint8_t)GET_FIELD(AVTP_CVF_FIELD_TV);
 }
 
-uint8_t Avtp_Cvf_GetSequenceNum(const Avtp_Cvf_t* const pdu)
+uint8_t Avtp_Cvf_GetSequenceNum(const Avtp_Cvf_t *const pdu)
 {
     return (uint8_t)GET_FIELD(AVTP_CVF_FIELD_SEQUENCE_NUM);
 }
 
-uint8_t Avtp_Cvf_GetTu(const Avtp_Cvf_t* const pdu)
+uint8_t Avtp_Cvf_GetTu(const Avtp_Cvf_t *const pdu)
 {
     return (uint8_t)GET_FIELD(AVTP_CVF_FIELD_TU);
 }
 
-uint64_t Avtp_Cvf_GetStreamId(const Avtp_Cvf_t* const pdu)
+uint64_t Avtp_Cvf_GetStreamId(const Avtp_Cvf_t *const pdu)
 {
     return GET_FIELD(AVTP_CVF_FIELD_STREAM_ID);
 }
 
-uint32_t Avtp_Cvf_GetAvtpTimestamp(const Avtp_Cvf_t* const pdu)
+uint32_t Avtp_Cvf_GetAvtpTimestamp(const Avtp_Cvf_t *const pdu)
 {
     return (uint32_t)GET_FIELD(AVTP_CVF_FIELD_AVTP_TIMESTAMP);
 }
 
-Avtp_CvfFormat_t Avtp_Cvf_GetFormat(const Avtp_Cvf_t* const pdu)
+Avtp_CvfFormat_t Avtp_Cvf_GetFormat(const Avtp_Cvf_t *const pdu)
 {
     return (Avtp_CvfFormat_t)GET_FIELD(AVTP_CVF_FIELD_FORMAT);
 }
 
-Avtp_CvfFormatSubtype_t Avtp_Cvf_GetFormatSubtype(const Avtp_Cvf_t* const pdu)
+Avtp_CvfFormatSubtype_t Avtp_Cvf_GetFormatSubtype(const Avtp_Cvf_t *const pdu)
 {
     return (Avtp_CvfFormatSubtype_t)GET_FIELD(AVTP_CVF_FIELD_FORMAT_SUBTYPE);
 }
 
-uint16_t Avtp_Cvf_GetStreamDataLength(const Avtp_Cvf_t* const pdu)
+uint16_t Avtp_Cvf_GetStreamDataLength(const Avtp_Cvf_t *const pdu)
 {
     return (uint16_t)GET_FIELD(AVTP_CVF_FIELD_STREAM_DATA_LENGTH);
 }
 
-uint8_t Avtp_Cvf_GetPtv(const Avtp_Cvf_t* const pdu)
+uint8_t Avtp_Cvf_GetPtv(const Avtp_Cvf_t *const pdu)
 {
     return (uint8_t)GET_FIELD(AVTP_CVF_FIELD_PTV);
 }
 
-uint8_t Avtp_Cvf_GetM(const Avtp_Cvf_t* const pdu)
+uint8_t Avtp_Cvf_GetM(const Avtp_Cvf_t *const pdu)
 {
     return (uint8_t)GET_FIELD(AVTP_CVF_FIELD_M);
 }
 
-uint8_t Avtp_Cvf_GetEvt(const Avtp_Cvf_t* const pdu)
+uint8_t Avtp_Cvf_GetEvt(const Avtp_Cvf_t *const pdu)
 {
     return (uint8_t)GET_FIELD(AVTP_CVF_FIELD_EVT);
 }
 
-void Avtp_Cvf_SetField(Avtp_Cvf_t* pdu, Avtp_CvfField_t field, uint64_t value)
+void Avtp_Cvf_SetField(Avtp_Cvf_t *pdu, Avtp_CvfField_t field, uint64_t value)
 {
     SET_FIELD(field, value);
 }
 
-void Avtp_Cvf_SetSubtype(Avtp_Cvf_t* pdu, uint8_t value)
+void Avtp_Cvf_SetSubtype(Avtp_Cvf_t *pdu, uint8_t value)
 {
     SET_FIELD(AVTP_CVF_FIELD_SUBTYPE, value);
 }
 
-void Avtp_Cvf_EnableSv(Avtp_Cvf_t* pdu)
+void Avtp_Cvf_EnableSv(Avtp_Cvf_t *pdu)
 {
     SET_FIELD(AVTP_CVF_FIELD_SV, 1);
 }
 
-void Avtp_Cvf_DisableSv(Avtp_Cvf_t* pdu)
+void Avtp_Cvf_DisableSv(Avtp_Cvf_t *pdu)
 {
     SET_FIELD(AVTP_CVF_FIELD_SV, 0);
 }
 
-void Avtp_Cvf_SetVersion(Avtp_Cvf_t* pdu, uint8_t value)
+void Avtp_Cvf_SetVersion(Avtp_Cvf_t *pdu, uint8_t value)
 {
     SET_FIELD(AVTP_CVF_FIELD_VERSION, value);
 }
 
-void Avtp_Cvf_EnableMr(Avtp_Cvf_t* pdu)
+void Avtp_Cvf_EnableMr(Avtp_Cvf_t *pdu)
 {
     SET_FIELD(AVTP_CVF_FIELD_MR, 1);
 }
 
-void Avtp_Cvf_DisableMr(Avtp_Cvf_t* pdu)
+void Avtp_Cvf_DisableMr(Avtp_Cvf_t *pdu)
 {
     SET_FIELD(AVTP_CVF_FIELD_MR, 0);
 }
 
-void Avtp_Cvf_EnableTv(Avtp_Cvf_t* pdu)
+void Avtp_Cvf_EnableTv(Avtp_Cvf_t *pdu)
 {
     SET_FIELD(AVTP_CVF_FIELD_TV, 1);
 }
 
-void Avtp_Cvf_DisableTv(Avtp_Cvf_t* pdu)
+void Avtp_Cvf_DisableTv(Avtp_Cvf_t *pdu)
 {
     SET_FIELD(AVTP_CVF_FIELD_TV, 0);
 }
 
-void Avtp_Cvf_SetSequenceNum(Avtp_Cvf_t* pdu, uint8_t value)
+void Avtp_Cvf_SetSequenceNum(Avtp_Cvf_t *pdu, uint8_t value)
 {
     SET_FIELD(AVTP_CVF_FIELD_SEQUENCE_NUM, value);
 }
 
-void Avtp_Cvf_EnableTu(Avtp_Cvf_t* pdu)
+void Avtp_Cvf_EnableTu(Avtp_Cvf_t *pdu)
 {
     SET_FIELD(AVTP_CVF_FIELD_TU, 1);
 }
 
-void Avtp_Cvf_DisableTu(Avtp_Cvf_t* pdu)
+void Avtp_Cvf_DisableTu(Avtp_Cvf_t *pdu)
 {
     SET_FIELD(AVTP_CVF_FIELD_TU, 0);
 }
 
-void Avtp_Cvf_SetStreamId(Avtp_Cvf_t* pdu, uint64_t value)
+void Avtp_Cvf_SetStreamId(Avtp_Cvf_t *pdu, uint64_t value)
 {
     SET_FIELD(AVTP_CVF_FIELD_STREAM_ID, value);
 }
 
-void Avtp_Cvf_SetAvtpTimestamp(Avtp_Cvf_t* pdu, uint32_t value)
+void Avtp_Cvf_SetAvtpTimestamp(Avtp_Cvf_t *pdu, uint32_t value)
 {
     SET_FIELD(AVTP_CVF_FIELD_AVTP_TIMESTAMP, value);
 }
 
-void Avtp_Cvf_SetFormat(Avtp_Cvf_t* pdu, Avtp_CvfFormat_t value)
+void Avtp_Cvf_SetFormat(Avtp_Cvf_t *pdu, Avtp_CvfFormat_t value)
 {
     SET_FIELD(AVTP_CVF_FIELD_FORMAT, value);
 }
 
-void Avtp_Cvf_SetFormatSubtype(Avtp_Cvf_t* pdu, Avtp_CvfFormatSubtype_t value)
+void Avtp_Cvf_SetFormatSubtype(Avtp_Cvf_t *pdu, Avtp_CvfFormatSubtype_t value)
 {
     SET_FIELD(AVTP_CVF_FIELD_FORMAT_SUBTYPE, value);
 }
 
-void Avtp_Cvf_SetStreamDataLength(Avtp_Cvf_t* pdu, uint16_t value)
+void Avtp_Cvf_SetStreamDataLength(Avtp_Cvf_t *pdu, uint16_t value)
 {
     SET_FIELD(AVTP_CVF_FIELD_STREAM_DATA_LENGTH, value);
 }
 
-void Avtp_Cvf_EnablePtv(Avtp_Cvf_t* pdu)
+void Avtp_Cvf_EnablePtv(Avtp_Cvf_t *pdu)
 {
     SET_FIELD(AVTP_CVF_FIELD_PTV, 1);
 }
 
-void Avtp_Cvf_DisablePtv(Avtp_Cvf_t* pdu)
+void Avtp_Cvf_DisablePtv(Avtp_Cvf_t *pdu)
 {
     SET_FIELD(AVTP_CVF_FIELD_PTV, 0);
 }
 
-void Avtp_Cvf_EnableM(Avtp_Cvf_t* pdu)
+void Avtp_Cvf_EnableM(Avtp_Cvf_t *pdu)
 {
     SET_FIELD(AVTP_CVF_FIELD_M, 1);
 }
 
-void Avtp_Cvf_DisableM(Avtp_Cvf_t* pdu)
+void Avtp_Cvf_DisableM(Avtp_Cvf_t *pdu)
 {
     SET_FIELD(AVTP_CVF_FIELD_M, 0);
 }
 
-void Avtp_Cvf_SetEvt(Avtp_Cvf_t* pdu, uint8_t value)
+void Avtp_Cvf_SetEvt(Avtp_Cvf_t *pdu, uint8_t value)
 {
     SET_FIELD(AVTP_CVF_FIELD_EVT, value);
 }
@@ -267,27 +266,27 @@ void Avtp_Cvf_SetEvt(Avtp_Cvf_t* pdu, uint8_t value)
  * Legacy API (deprecated)
  *****************************************************************************/
 
-int avtp_cvf_pdu_get(const void* const pdu, Avtp_CvfField_t field, uint64_t *val)
+int avtp_cvf_pdu_get(const void *const pdu, Avtp_CvfField_t field, uint64_t *val)
 {
     if (pdu == NULL || val == NULL || field >= AVTP_CVF_FIELD_MAX) {
         return -EINVAL;
     } else {
-        *val = Avtp_Cvf_GetField((const Avtp_Cvf_t* const)pdu, field);
+        *val = Avtp_Cvf_GetField((const Avtp_Cvf_t *const)pdu, field);
         return 0;
     }
 }
 
-int avtp_cvf_pdu_set(void* pdu, Avtp_CvfField_t field, uint64_t val)
+int avtp_cvf_pdu_set(void *pdu, Avtp_CvfField_t field, uint64_t val)
 {
     if (pdu == NULL || field >= AVTP_CVF_FIELD_MAX) {
         return -EINVAL;
     } else {
-        Avtp_Cvf_SetField((Avtp_Cvf_t*)pdu, field, val);
+        Avtp_Cvf_SetField((Avtp_Cvf_t *)pdu, field, val);
         return 0;
     }
 }
 
-int avtp_cvf_pdu_init(void* pdu, uint8_t format_subtype)
+int avtp_cvf_pdu_init(void *pdu, uint8_t format_subtype)
 {
     if (pdu == NULL) {
         return -EINVAL;

--- a/src/avtp/cvf/Cvf.c
+++ b/src/avtp/cvf/Cvf.c
@@ -35,7 +35,7 @@
 #include "avtp/CommonHeader.h"
 
 #define GET_FIELD(field) \
-        (Avtp_GetField(fieldDescriptors, AVTP_CVF_FIELD_MAX, (uint8_t*)pdu, field))
+        (Avtp_GetField(fieldDescriptors, AVTP_CVF_FIELD_MAX, (const uint8_t*)pdu, field))
 #define SET_FIELD(field, value) \
         (Avtp_SetField(fieldDescriptors, AVTP_CVF_FIELD_MAX, (uint8_t*)pdu, field, value))
 

--- a/src/avtp/cvf/H264.c
+++ b/src/avtp/cvf/H264.c
@@ -35,7 +35,7 @@
 #include "avtp/CommonHeader.h"
 
 #define GET_FIELD(field) \
-        (Avtp_GetField(fieldDescriptors, AVTP_H264_FIELD_MAX, (uint8_t*)pdu, field))
+        (Avtp_GetField(fieldDescriptors, AVTP_H264_FIELD_MAX, (const uint8_t*)pdu, field))
 #define SET_FIELD(field, value) \
         (Avtp_SetField(fieldDescriptors, AVTP_H264_FIELD_MAX, (uint8_t*)pdu, field, value))
 

--- a/src/avtp/cvf/H264.c
+++ b/src/avtp/cvf/H264.c
@@ -10,7 +10,7 @@
  *      notice, this list of conditions and the following disclaimer in the
  *      documentation and/or other materials provided with the distribution.
  *    * Neither the name of COVESA, Intel Corporation nor the names of its
- *      contributors  may be used to endorse or promote products derived from 
+ *      contributors  may be used to endorse or promote products derived from
  *      this software without specific prior written permission.
  *
  * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
@@ -34,39 +34,38 @@
 #include "avtp/Utils.h"
 #include "avtp/CommonHeader.h"
 
-#define GET_FIELD(field) \
-        (Avtp_GetField(fieldDescriptors, AVTP_H264_FIELD_MAX, (const uint8_t*)pdu, field))
-#define SET_FIELD(field, value) \
-        (Avtp_SetField(fieldDescriptors, AVTP_H264_FIELD_MAX, (uint8_t*)pdu, field, value))
+#define GET_FIELD(field)                                                                           \
+    (Avtp_GetField(fieldDescriptors, AVTP_H264_FIELD_MAX, (const uint8_t *)pdu, field))
+#define SET_FIELD(field, value)                                                                    \
+    (Avtp_SetField(fieldDescriptors, AVTP_H264_FIELD_MAX, (uint8_t *)pdu, field, value))
 
-static const Avtp_FieldDescriptor_t fieldDescriptors[AVTP_H264_FIELD_MAX] =
-{
-    [AVTP_H264_FIELD_TIMESTAMP] = { .quadlet = 0, .offset = 0, .bits = 32 },
+static const Avtp_FieldDescriptor_t fieldDescriptors[AVTP_H264_FIELD_MAX] = {
+    [AVTP_H264_FIELD_TIMESTAMP] = {.quadlet = 0, .offset = 0, .bits = 32},
 };
 
-void Avtp_H264_Init(Avtp_H264_t* pdu)
+void Avtp_H264_Init(Avtp_H264_t *pdu)
 {
     if (pdu != NULL) {
         memset(pdu, 0, sizeof(Avtp_H264_t));
     }
 }
 
-uint64_t Avtp_H264_GetField(const Avtp_H264_t* const pdu, Avtp_H264Field_t field)
+uint64_t Avtp_H264_GetField(const Avtp_H264_t *const pdu, Avtp_H264Field_t field)
 {
     return GET_FIELD(field);
 }
 
-uint32_t Avtp_H264_GetTimestamp(const Avtp_H264_t* const pdu)
+uint32_t Avtp_H264_GetTimestamp(const Avtp_H264_t *const pdu)
 {
     return (uint32_t)GET_FIELD(AVTP_H264_FIELD_TIMESTAMP);
 }
 
-void Avtp_H264_SetField(Avtp_H264_t* pdu, Avtp_H264Field_t field, uint64_t value)
+void Avtp_H264_SetField(Avtp_H264_t *pdu, Avtp_H264Field_t field, uint64_t value)
 {
     SET_FIELD(field, value);
 }
 
-void Avtp_H264_SetTimestamp(Avtp_H264_t* pdu, uint32_t value)
+void Avtp_H264_SetTimestamp(Avtp_H264_t *pdu, uint32_t value)
 {
     SET_FIELD(AVTP_H264_FIELD_TIMESTAMP, value);
 }

--- a/src/avtp/cvf/Jpeg2000.c
+++ b/src/avtp/cvf/Jpeg2000.c
@@ -35,7 +35,7 @@
 #include "avtp/CommonHeader.h"
 
 #define GET_FIELD(field) \
-        (Avtp_GetField(fieldDescriptors, AVTP_JPEG2000_FIELD_MAX, (uint8_t*)pdu, field))
+        (Avtp_GetField(fieldDescriptors, AVTP_JPEG2000_FIELD_MAX, (const uint8_t*)pdu, field))
 #define SET_FIELD(field, value) \
         (Avtp_SetField(fieldDescriptors, AVTP_JPEG2000_FIELD_MAX, (uint8_t*)pdu, field, value))
 

--- a/src/avtp/cvf/Jpeg2000.c
+++ b/src/avtp/cvf/Jpeg2000.c
@@ -34,111 +34,110 @@
 #include "avtp/Utils.h"
 #include "avtp/CommonHeader.h"
 
-#define GET_FIELD(field) \
-        (Avtp_GetField(fieldDescriptors, AVTP_JPEG2000_FIELD_MAX, (const uint8_t*)pdu, field))
-#define SET_FIELD(field, value) \
-        (Avtp_SetField(fieldDescriptors, AVTP_JPEG2000_FIELD_MAX, (uint8_t*)pdu, field, value))
+#define GET_FIELD(field)                                                                           \
+    (Avtp_GetField(fieldDescriptors, AVTP_JPEG2000_FIELD_MAX, (const uint8_t *)pdu, field))
+#define SET_FIELD(field, value)                                                                    \
+    (Avtp_SetField(fieldDescriptors, AVTP_JPEG2000_FIELD_MAX, (uint8_t *)pdu, field, value))
 
-static const Avtp_FieldDescriptor_t fieldDescriptors[AVTP_JPEG2000_FIELD_MAX] =
-{
-    [AVTP_JPEG2000_FIELD_TP]                = { .quadlet = 0, .offset = 0, .bits = 2 },
-    [AVTP_JPEG2000_FIELD_MHF]               = { .quadlet = 0, .offset = 2, .bits = 2 },
-    [AVTP_JPEG2000_FIELD_MH_ID]             = { .quadlet = 0, .offset = 4, .bits = 3 },
-    [AVTP_JPEG2000_FIELD_T]                 = { .quadlet = 0, .offset = 7, .bits = 1 },
-    [AVTP_JPEG2000_FIELD_PRIORITY]          = { .quadlet = 0, .offset = 8, .bits = 8 },
-    [AVTP_JPEG2000_FIELD_TILE_NUMBER]       = { .quadlet = 0, .offset = 16, .bits = 16 },
-    [AVTP_JPEG2000_FIELD_RESERVED]          = { .quadlet = 1, .offset = 0, .bits = 8 },
-    [AVTP_JPEG2000_FIELD_FRAGMENT_OFFSET]   = { .quadlet = 1, .offset = 8, .bits = 24 },
+static const Avtp_FieldDescriptor_t fieldDescriptors[AVTP_JPEG2000_FIELD_MAX] = {
+    [AVTP_JPEG2000_FIELD_TP] = {.quadlet = 0, .offset = 0, .bits = 2},
+    [AVTP_JPEG2000_FIELD_MHF] = {.quadlet = 0, .offset = 2, .bits = 2},
+    [AVTP_JPEG2000_FIELD_MH_ID] = {.quadlet = 0, .offset = 4, .bits = 3},
+    [AVTP_JPEG2000_FIELD_T] = {.quadlet = 0, .offset = 7, .bits = 1},
+    [AVTP_JPEG2000_FIELD_PRIORITY] = {.quadlet = 0, .offset = 8, .bits = 8},
+    [AVTP_JPEG2000_FIELD_TILE_NUMBER] = {.quadlet = 0, .offset = 16, .bits = 16},
+    [AVTP_JPEG2000_FIELD_RESERVED] = {.quadlet = 1, .offset = 0, .bits = 8},
+    [AVTP_JPEG2000_FIELD_FRAGMENT_OFFSET] = {.quadlet = 1, .offset = 8, .bits = 24},
 };
 
-void Avtp_Jpeg2000_Init(Avtp_Jpeg2000_t* pdu)
+void Avtp_Jpeg2000_Init(Avtp_Jpeg2000_t *pdu)
 {
     if (pdu != NULL) {
         memset(pdu, 0, sizeof(Avtp_Jpeg2000_t));
     }
 }
 
-uint64_t Avtp_Jpeg2000_GetField(const Avtp_Jpeg2000_t* const pdu, Avtp_Jpeg2000Field_t field)
+uint64_t Avtp_Jpeg2000_GetField(const Avtp_Jpeg2000_t *const pdu, Avtp_Jpeg2000Field_t field)
 {
     return GET_FIELD(field);
 }
 
-uint8_t Avtp_Jpeg2000_GetTp(const Avtp_Jpeg2000_t* const pdu)
+uint8_t Avtp_Jpeg2000_GetTp(const Avtp_Jpeg2000_t *const pdu)
 {
     return (uint8_t)GET_FIELD(AVTP_JPEG2000_FIELD_TP);
 }
 
-uint8_t Avtp_Jpeg2000_GetMhf(const Avtp_Jpeg2000_t* const pdu)
+uint8_t Avtp_Jpeg2000_GetMhf(const Avtp_Jpeg2000_t *const pdu)
 {
     return (uint8_t)GET_FIELD(AVTP_JPEG2000_FIELD_MHF);
 }
 
-uint8_t Avtp_Jpeg2000_GetMhId(const Avtp_Jpeg2000_t* const pdu)
+uint8_t Avtp_Jpeg2000_GetMhId(const Avtp_Jpeg2000_t *const pdu)
 {
     return (uint8_t)GET_FIELD(AVTP_JPEG2000_FIELD_MH_ID);
 }
 
-uint8_t Avtp_Jpeg2000_GetT(const Avtp_Jpeg2000_t* const pdu)
+uint8_t Avtp_Jpeg2000_GetT(const Avtp_Jpeg2000_t *const pdu)
 {
     return (uint8_t)GET_FIELD(AVTP_JPEG2000_FIELD_T);
 }
 
-uint8_t Avtp_Jpeg2000_GetPriority(const Avtp_Jpeg2000_t* const pdu)
+uint8_t Avtp_Jpeg2000_GetPriority(const Avtp_Jpeg2000_t *const pdu)
 {
     return (uint8_t)GET_FIELD(AVTP_JPEG2000_FIELD_PRIORITY);
 }
 
-uint16_t Avtp_Jpeg2000_GetTileNumber(const Avtp_Jpeg2000_t* const pdu)
+uint16_t Avtp_Jpeg2000_GetTileNumber(const Avtp_Jpeg2000_t *const pdu)
 {
     return (uint16_t)GET_FIELD(AVTP_JPEG2000_FIELD_TILE_NUMBER);
 }
 
-uint32_t Avtp_Jpeg2000_GetFragmentOffset(const Avtp_Jpeg2000_t* const pdu)
+uint32_t Avtp_Jpeg2000_GetFragmentOffset(const Avtp_Jpeg2000_t *const pdu)
 {
     return (uint32_t)GET_FIELD(AVTP_JPEG2000_FIELD_FRAGMENT_OFFSET);
 }
 
-void Avtp_Jpeg2000_SetField(Avtp_Jpeg2000_t* pdu, Avtp_Jpeg2000Field_t field, uint64_t value)
+void Avtp_Jpeg2000_SetField(Avtp_Jpeg2000_t *pdu, Avtp_Jpeg2000Field_t field, uint64_t value)
 {
     SET_FIELD(field, value);
 }
 
-void Avtp_Jpeg2000_SetTp(Avtp_Jpeg2000_t* pdu, uint8_t value)
+void Avtp_Jpeg2000_SetTp(Avtp_Jpeg2000_t *pdu, uint8_t value)
 {
     SET_FIELD(AVTP_JPEG2000_FIELD_TP, value);
 }
 
-void Avtp_Jpeg2000_SetMhf(Avtp_Jpeg2000_t* pdu, uint8_t value)
+void Avtp_Jpeg2000_SetMhf(Avtp_Jpeg2000_t *pdu, uint8_t value)
 {
     SET_FIELD(AVTP_JPEG2000_FIELD_MHF, value);
 }
 
-void Avtp_Jpeg2000_SetMhId(Avtp_Jpeg2000_t* pdu, uint8_t value)
+void Avtp_Jpeg2000_SetMhId(Avtp_Jpeg2000_t *pdu, uint8_t value)
 {
     SET_FIELD(AVTP_JPEG2000_FIELD_MH_ID, value);
 }
 
-void Avtp_Jpeg2000_EnableT(Avtp_Jpeg2000_t* pdu)
+void Avtp_Jpeg2000_EnableT(Avtp_Jpeg2000_t *pdu)
 {
     SET_FIELD(AVTP_JPEG2000_FIELD_T, 1);
 }
 
-void Avtp_Jpeg2000_DisableT(Avtp_Jpeg2000_t* pdu)
+void Avtp_Jpeg2000_DisableT(Avtp_Jpeg2000_t *pdu)
 {
     SET_FIELD(AVTP_JPEG2000_FIELD_T, 0);
 }
 
-void Avtp_Jpeg2000_SetPriority(Avtp_Jpeg2000_t* pdu, uint8_t value)
+void Avtp_Jpeg2000_SetPriority(Avtp_Jpeg2000_t *pdu, uint8_t value)
 {
     SET_FIELD(AVTP_JPEG2000_FIELD_PRIORITY, value);
 }
 
-void Avtp_Jpeg2000_SetTileNumber(Avtp_Jpeg2000_t* pdu, uint16_t value)
+void Avtp_Jpeg2000_SetTileNumber(Avtp_Jpeg2000_t *pdu, uint16_t value)
 {
     SET_FIELD(AVTP_JPEG2000_FIELD_TILE_NUMBER, value);
 }
 
-void Avtp_Jpeg2000_SetFragmentOffset(Avtp_Jpeg2000_t* pdu, uint32_t value)
+void Avtp_Jpeg2000_SetFragmentOffset(Avtp_Jpeg2000_t *pdu, uint32_t value)
 {
     SET_FIELD(AVTP_JPEG2000_FIELD_FRAGMENT_OFFSET, value);
 }

--- a/src/avtp/cvf/Mjpeg.c
+++ b/src/avtp/cvf/Mjpeg.c
@@ -10,7 +10,7 @@
  *      notice, this list of conditions and the following disclaimer in the
  *      documentation and/or other materials provided with the distribution.
  *    * Neither the name of COVESA, Intel Corporation nor the names of its
- *      contributors  may be used to endorse or promote products derived from 
+ *      contributors  may be used to endorse or promote products derived from
  *      this software without specific prior written permission.
  *
  * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
@@ -34,94 +34,93 @@
 #include "avtp/Utils.h"
 #include "avtp/CommonHeader.h"
 
-#define GET_FIELD(field) \
-        (Avtp_GetField(fieldDescriptors, AVTP_MJPEG_FIELD_MAX, (const uint8_t*)pdu, field))
-#define SET_FIELD(field, value) \
-        (Avtp_SetField(fieldDescriptors, AVTP_MJPEG_FIELD_MAX, (uint8_t*)pdu, field, value))
+#define GET_FIELD(field)                                                                           \
+    (Avtp_GetField(fieldDescriptors, AVTP_MJPEG_FIELD_MAX, (const uint8_t *)pdu, field))
+#define SET_FIELD(field, value)                                                                    \
+    (Avtp_SetField(fieldDescriptors, AVTP_MJPEG_FIELD_MAX, (uint8_t *)pdu, field, value))
 
-static const Avtp_FieldDescriptor_t fieldDescriptors[AVTP_MJPEG_FIELD_MAX] =
-{
-    [AVTP_MJPEG_FIELD_TYPE_SPECIFIC]    = { .quadlet = 0, .offset = 0, .bits = 8 },
-    [AVTP_MJPEG_FIELD_FRAGMENT_OFFSET]  = { .quadlet = 0, .offset = 8, .bits = 24 },
-    [AVTP_MJPEG_FIELD_TYPE]             = { .quadlet = 1, .offset = 0, .bits = 8 },
-    [AVTP_MJPEG_FIELD_Q]                = { .quadlet = 1, .offset = 8, .bits = 8 },
-    [AVTP_MJPEG_FIELD_WIDTH]            = { .quadlet = 1, .offset = 16, .bits = 8 },
-    [AVTP_MJPEG_FIELD_HEIGHT]           = { .quadlet = 1, .offset = 24, .bits = 8 },
+static const Avtp_FieldDescriptor_t fieldDescriptors[AVTP_MJPEG_FIELD_MAX] = {
+    [AVTP_MJPEG_FIELD_TYPE_SPECIFIC] = {.quadlet = 0, .offset = 0, .bits = 8},
+    [AVTP_MJPEG_FIELD_FRAGMENT_OFFSET] = {.quadlet = 0, .offset = 8, .bits = 24},
+    [AVTP_MJPEG_FIELD_TYPE] = {.quadlet = 1, .offset = 0, .bits = 8},
+    [AVTP_MJPEG_FIELD_Q] = {.quadlet = 1, .offset = 8, .bits = 8},
+    [AVTP_MJPEG_FIELD_WIDTH] = {.quadlet = 1, .offset = 16, .bits = 8},
+    [AVTP_MJPEG_FIELD_HEIGHT] = {.quadlet = 1, .offset = 24, .bits = 8},
 };
 
-void Avtp_Mjpeg_Init(Avtp_Mjpeg_t* pdu)
+void Avtp_Mjpeg_Init(Avtp_Mjpeg_t *pdu)
 {
     if (pdu != NULL) {
         memset(pdu, 0, sizeof(Avtp_Mjpeg_t));
     }
 }
 
-uint64_t Avtp_Mjpeg_GetField(const Avtp_Mjpeg_t* const pdu, Avtp_MjpegField_t field)
+uint64_t Avtp_Mjpeg_GetField(const Avtp_Mjpeg_t *const pdu, Avtp_MjpegField_t field)
 {
     return GET_FIELD(field);
 }
 
-uint8_t Avtp_Mjpeg_GetTypeSpecific(const Avtp_Mjpeg_t* const pdu)
+uint8_t Avtp_Mjpeg_GetTypeSpecific(const Avtp_Mjpeg_t *const pdu)
 {
     return (uint8_t)GET_FIELD(AVTP_MJPEG_FIELD_TYPE_SPECIFIC);
 }
 
-uint32_t Avtp_Mjpeg_GetFragmentOffset(const Avtp_Mjpeg_t* const pdu)
+uint32_t Avtp_Mjpeg_GetFragmentOffset(const Avtp_Mjpeg_t *const pdu)
 {
     return (uint32_t)GET_FIELD(AVTP_MJPEG_FIELD_FRAGMENT_OFFSET);
 }
 
-uint8_t Avtp_Mjpeg_GetType(const Avtp_Mjpeg_t* const pdu)
+uint8_t Avtp_Mjpeg_GetType(const Avtp_Mjpeg_t *const pdu)
 {
     return (uint8_t)GET_FIELD(AVTP_MJPEG_FIELD_TYPE);
 }
 
-uint8_t Avtp_Mjpeg_GetQ(const Avtp_Mjpeg_t* const pdu)
+uint8_t Avtp_Mjpeg_GetQ(const Avtp_Mjpeg_t *const pdu)
 {
     return (uint8_t)GET_FIELD(AVTP_MJPEG_FIELD_Q);
 }
 
-uint8_t Avtp_Mjpeg_GetWidth(const Avtp_Mjpeg_t* const pdu)
+uint8_t Avtp_Mjpeg_GetWidth(const Avtp_Mjpeg_t *const pdu)
 {
     return (uint8_t)GET_FIELD(AVTP_MJPEG_FIELD_WIDTH);
 }
 
-uint8_t Avtp_Mjpeg_GetHeight(const Avtp_Mjpeg_t* const pdu)
+uint8_t Avtp_Mjpeg_GetHeight(const Avtp_Mjpeg_t *const pdu)
 {
     return (uint8_t)GET_FIELD(AVTP_MJPEG_FIELD_HEIGHT);
 }
 
-void Avtp_Mjpeg_SetField(Avtp_Mjpeg_t* pdu, Avtp_MjpegField_t field, uint64_t value)
+void Avtp_Mjpeg_SetField(Avtp_Mjpeg_t *pdu, Avtp_MjpegField_t field, uint64_t value)
 {
     SET_FIELD(field, value);
 }
 
-void Avtp_Mjpeg_SetTypeSpecific(Avtp_Mjpeg_t* pdu, uint8_t value)
+void Avtp_Mjpeg_SetTypeSpecific(Avtp_Mjpeg_t *pdu, uint8_t value)
 {
     SET_FIELD(AVTP_MJPEG_FIELD_TYPE_SPECIFIC, value);
 }
 
-void Avtp_Mjpeg_SetFragmentOffset(Avtp_Mjpeg_t* pdu, uint32_t value)
+void Avtp_Mjpeg_SetFragmentOffset(Avtp_Mjpeg_t *pdu, uint32_t value)
 {
     SET_FIELD(AVTP_MJPEG_FIELD_FRAGMENT_OFFSET, value);
 }
 
-void Avtp_Mjpeg_SetType(Avtp_Mjpeg_t* pdu, uint8_t value)
+void Avtp_Mjpeg_SetType(Avtp_Mjpeg_t *pdu, uint8_t value)
 {
     SET_FIELD(AVTP_MJPEG_FIELD_TYPE, value);
 }
 
-void Avtp_Mjpeg_SetQ(Avtp_Mjpeg_t* pdu, uint8_t value)
+void Avtp_Mjpeg_SetQ(Avtp_Mjpeg_t *pdu, uint8_t value)
 {
     SET_FIELD(AVTP_MJPEG_FIELD_Q, value);
 }
 
-void Avtp_Mjpeg_SetWidth(Avtp_Mjpeg_t* pdu, uint8_t value)
+void Avtp_Mjpeg_SetWidth(Avtp_Mjpeg_t *pdu, uint8_t value)
 {
     SET_FIELD(AVTP_MJPEG_FIELD_WIDTH, value);
 }
 
-void Avtp_Mjpeg_SetHeight(Avtp_Mjpeg_t* pdu, uint8_t value)
+void Avtp_Mjpeg_SetHeight(Avtp_Mjpeg_t *pdu, uint8_t value)
 {
     SET_FIELD(AVTP_MJPEG_FIELD_HEIGHT, value);
 }

--- a/src/avtp/cvf/Mjpeg.c
+++ b/src/avtp/cvf/Mjpeg.c
@@ -35,7 +35,7 @@
 #include "avtp/CommonHeader.h"
 
 #define GET_FIELD(field) \
-        (Avtp_GetField(fieldDescriptors, AVTP_MJPEG_FIELD_MAX, (uint8_t*)pdu, field))
+        (Avtp_GetField(fieldDescriptors, AVTP_MJPEG_FIELD_MAX, (const uint8_t*)pdu, field))
 #define SET_FIELD(field, value) \
         (Avtp_SetField(fieldDescriptors, AVTP_MJPEG_FIELD_MAX, (uint8_t*)pdu, field, value))
 


### PR DESCRIPTION
This fixes #184 

This does
 - fix the issues in the ACF formats
 - Add compiler flag -Wcast-qual so these will be treated as errors in the future
     - only enabled for library code. Not examples
     - fixed const cast everywhere else to make the code compile again 

Needed to format many files that have not been touched since we enforced formatting. Check this commit https://github.com/COVESA/Open1722/pull/185/changes/60cab4f7e8c5b4cd35ae762b5d4f91cb0c2c92a2#diff-04502f868b4be389f6797767f484da9d5e38499904944d2674808cdaeba80082


for a less noisy review