### PR TITLE
Upgrade/can examples

### DIFF
--- a/examples/acf-can/acf-can-common.c
+++ b/examples/acf-can/acf-can-common.c
@@ -115,17 +115,6 @@ int setup_can_socket(const char *can_ifname, Avtp_CanVariant_t can_variant)
 }
 #endif
 
-static int is_valid_acf_packet(uint8_t *acf_pdu)
-{
-    Avtp_AcfCommon_t *pdu = (Avtp_AcfCommon_t *)acf_pdu;
-    uint8_t acf_msg_type = Avtp_AcfCommon_GetAcfMsgType(pdu);
-    if (acf_msg_type != AVTP_ACF_TYPE_CAN) {
-        return 0;
-    }
-
-    return 1;
-}
-
 static int init_cf_pdu(uint8_t *pdu, uint64_t stream_id, int use_tscf, int seq_num)
 {
     int res;
@@ -305,10 +294,6 @@ int avtp_to_can(uint8_t *pdu, frame_t *can_frames, Avtp_CanVariant_t can_variant
 
         acf_pdu = &pdu[proc_bytes];
 
-        if (!is_valid_acf_packet(acf_pdu)) {
-            return -1;
-        }
-
         /* Verify the CAN-specific invariants now that the ACF message
          * type is confirmed: the encoded message length must fit the
          * remaining buffer, and the resulting payload size must match
@@ -331,7 +316,7 @@ int avtp_to_can(uint8_t *pdu, frame_t *can_frames, Avtp_CanVariant_t can_variant
             LOG_ERR("Error: Number of CAN frames in ACF exceeds maximum allowed.\n");
             return -1;
         }
-        frame_t *frame = &(can_frames[i++]);
+        frame_t *frame = &(can_frames[i]);
 
         // Handle EFF Flag
         if (AVTP_CAN(IsEff)((AVTP_CAN(t) *)acf_pdu)) {
@@ -374,6 +359,8 @@ int avtp_to_can(uint8_t *pdu, frame_t *can_frames, Avtp_CanVariant_t can_variant
 #endif
             memcpy(frame->cc.data, can_payload, can_payload_length);
         }
+
+        i++;
     }
 
     return i;

--- a/examples/acf-can/acf-can-common.c
+++ b/examples/acf-can/acf-can-common.c
@@ -191,10 +191,10 @@ static int prepare_acf_packet(uint8_t *acf_pdu, frame_t *frame, Avtp_CanVariant_
     clock_gettime(CLOCK_REALTIME, &now);
     AVTP_CAN(SetMessageTimestamp)(pdu, (uint64_t)now.tv_nsec + (uint64_t)(now.tv_sec * 1e9));
     AVTP_CAN(SetMtv)(pdu, true);
+#endif
     if (can_id & CAN_RTR_FLAG) {
         AVTP_CAN(SetRtr)(pdu, true);
     }
-#endif
 
     if (can_variant == AVTP_CAN_FD) {
         if (frame->fd.flags & CANFD_BRS) {

--- a/examples/acf-can/acf-can-common.c
+++ b/examples/acf-can/acf-can-common.c
@@ -180,11 +180,10 @@ static int prepare_acf_packet(uint8_t *acf_pdu, frame_t *frame, Avtp_CanVariant_
     // Build the ACF CAN PDU (initializes the header, copies the payload and
     // finalizes the length/pad fields)
     if (can_variant == AVTP_CAN_FD)
-        AVTP_CAN(CreateAcfMessage)(pdu, can_id & CAN_EFF_MASK, frame->fd.data, can_payload_length,
-                                  can_variant);
-    else
-        AVTP_CAN(CreateAcfMessage)(pdu, can_id & CAN_EFF_MASK, frame->cc.data, can_payload_length,
-                                  can_variant);
+        AVTP_CAN(CreateAcfMessage)
+    (pdu, can_id & CAN_EFF_MASK, frame->fd.data, can_payload_length, can_variant);
+    else AVTP_CAN(CreateAcfMessage)(pdu, can_id & CAN_EFF_MASK, frame->cc.data, can_payload_length,
+                                    can_variant);
 
 #if (AVTP_CAN_API == AVTP_CAN_API_CANV2) || (AVTP_CAN_API == AVTP_CAN_API_CAN)
     // Set optional header fields after building the frame

--- a/examples/acf-can/acf-can-common.c
+++ b/examples/acf-can/acf-can-common.c
@@ -166,7 +166,7 @@ static int prepare_acf_packet(uint8_t *acf_pdu, frame_t *frame, Avtp_CanVariant_
     canid_t can_id;
     uint8_t can_payload_length;
 
-    Avtp_Can_t *pdu = (Avtp_Can_t *)acf_pdu;
+    AVTP_CAN(t) *pdu = (AVTP_CAN(t) *)acf_pdu;
 
     // Set required CAN Flags
 #ifdef __linux__
@@ -180,30 +180,32 @@ static int prepare_acf_packet(uint8_t *acf_pdu, frame_t *frame, Avtp_CanVariant_
     // Build the ACF CAN PDU (initializes the header, copies the payload and
     // finalizes the length/pad fields)
     if (can_variant == AVTP_CAN_FD)
-        Avtp_Can_CreateAcfMessage(pdu, can_id & CAN_EFF_MASK, frame->fd.data, can_payload_length,
+        AVTP_CAN(CreateAcfMessage)(pdu, can_id & CAN_EFF_MASK, frame->fd.data, can_payload_length,
                                   can_variant);
     else
-        Avtp_Can_CreateAcfMessage(pdu, can_id & CAN_EFF_MASK, frame->cc.data, can_payload_length,
+        AVTP_CAN(CreateAcfMessage)(pdu, can_id & CAN_EFF_MASK, frame->cc.data, can_payload_length,
                                   can_variant);
 
+#if (AVTP_CAN_API == AVTP_CAN_API_CANV2) || (AVTP_CAN_API == AVTP_CAN_API_CAN)
     // Set optional header fields after building the frame
     struct timespec now;
     clock_gettime(CLOCK_REALTIME, &now);
-    Avtp_Can_SetMessageTimestamp(pdu, (uint64_t)now.tv_nsec + (uint64_t)(now.tv_sec * 1e9));
-    Avtp_Can_SetMtv(pdu, true);
+    AVTP_CAN(SetMessageTimestamp)(pdu, (uint64_t)now.tv_nsec + (uint64_t)(now.tv_sec * 1e9));
+    AVTP_CAN(SetMtv)(pdu, true);
     if (can_id & CAN_RTR_FLAG) {
-        Avtp_Can_SetRtr(pdu, true);
+        AVTP_CAN(SetRtr)(pdu, true);
     }
+#endif
 
     if (can_variant == AVTP_CAN_FD) {
         if (frame->fd.flags & CANFD_BRS) {
-            Avtp_Can_SetBrs(pdu, true);
+            AVTP_CAN(SetBrs)(pdu, true);
         }
         if (frame->fd.flags & CANFD_FDF) {
-            Avtp_Can_SetFdf(pdu, true);
+            AVTP_CAN(SetFdf)(pdu, true);
         }
         if (frame->fd.flags & CANFD_ESI) {
-            Avtp_Can_SetEsi(pdu, true);
+            AVTP_CAN(SetEsi)(pdu, true);
         }
     }
 
@@ -314,16 +316,16 @@ int avtp_to_can(uint8_t *pdu, frame_t *can_frames, Avtp_CanVariant_t can_variant
          * the CAN/CAN-FD bound encoded by the FDF bit. Without this
          * guard a malformed frame could feed garbage values to the
          * consumers below. */
-        if (!Avtp_Can_IsValid((Avtp_Can_t *)acf_pdu, msg_length - proc_bytes)) {
+        if (!AVTP_CAN(IsValid)((AVTP_CAN(t) *)acf_pdu, msg_length - proc_bytes)) {
             LOG_ERR("Error: ACF CAN frame failed validation, ignoring frame.\n");
             return -1;
         }
 
-        canid_t can_id = Avtp_Can_GetCanIdentifier((Avtp_Can_t *)acf_pdu);
-        const uint8_t *can_payload = Avtp_Can_GetPayload((Avtp_Can_t *)acf_pdu);
+        canid_t can_id = AVTP_CAN(GetCanIdentifier)((AVTP_CAN(t) *)acf_pdu);
+        const uint8_t *can_payload = AVTP_CAN(GetPayload)((AVTP_CAN(t) *)acf_pdu);
         uint16_t acf_msg_length =
             Avtp_AcfCommon_GetAcfMsgLengthInBytes((Avtp_AcfCommon_t *)acf_pdu);
-        uint16_t can_payload_length = Avtp_Can_GetPayloadLength((Avtp_Can_t *)acf_pdu);
+        uint16_t can_payload_length = AVTP_CAN(GetPayloadLength)((AVTP_CAN(t) *)acf_pdu);
         proc_bytes += acf_msg_length;
 
         if (i >= MAX_CAN_FRAMES_IN_ACF) {
@@ -333,7 +335,7 @@ int avtp_to_can(uint8_t *pdu, frame_t *can_frames, Avtp_CanVariant_t can_variant
         frame_t *frame = &(can_frames[i++]);
 
         // Handle EFF Flag
-        if (Avtp_Can_IsEff((Avtp_Can_t *)acf_pdu)) {
+        if (AVTP_CAN(IsEff)((AVTP_CAN(t) *)acf_pdu)) {
             can_id |= CAN_EFF_FLAG;
         } else if (can_id > 0x7FF) {
             LOG_ERR("Error: CAN ID is > 0x7FF but the EFF bit is not set.\n");
@@ -341,18 +343,18 @@ int avtp_to_can(uint8_t *pdu, frame_t *can_frames, Avtp_CanVariant_t can_variant
         }
 
         // Handle RTR Flag
-        if (Avtp_Can_IsRtr((Avtp_Can_t *)acf_pdu)) {
+        if (AVTP_CAN(IsRtr)((AVTP_CAN(t) *)acf_pdu)) {
             can_id |= CAN_RTR_FLAG;
         }
 
         if (can_variant == AVTP_CAN_FD) {
-            if (Avtp_Can_IsBrs((Avtp_Can_t *)acf_pdu)) {
+            if (AVTP_CAN(IsBrs)((AVTP_CAN(t) *)acf_pdu)) {
                 frame->fd.flags |= CANFD_BRS;
             }
-            if (Avtp_Can_IsFdf((Avtp_Can_t *)acf_pdu)) {
+            if (AVTP_CAN(IsFdf)((AVTP_CAN(t) *)acf_pdu)) {
                 frame->fd.flags |= CANFD_FDF;
             }
-            if (Avtp_Can_IsEsi((Avtp_Can_t *)acf_pdu)) {
+            if (AVTP_CAN(IsEsi)((AVTP_CAN(t) *)acf_pdu)) {
                 frame->fd.flags |= CANFD_ESI;
             }
 #ifdef __linux__

--- a/examples/acf-can/acf-can-common.h
+++ b/examples/acf-can/acf-can-common.h
@@ -45,18 +45,18 @@
 #include "avtp/acf/CanBrief.h"
 #include "avtp/acf/CanBriefV2.h"
 
-#define AVTP_CAN_API_CAN      1
-#define AVTP_CAN_API_CANV2    2
+#define AVTP_CAN_API_CAN 1
+#define AVTP_CAN_API_CANV2 2
 #define AVTP_CAN_API_CANBRIEF 3
 #define AVTP_CAN_API_CANBRIEFV2 4
 
-#define MAX_ETH_PDU_SIZE                1500
-#define MAX_CAN_FRAMES_IN_ACF           15
+#define MAX_ETH_PDU_SIZE 1500
+#define MAX_CAN_FRAMES_IN_ACF 15
 
 #ifdef __linux__
 typedef struct can_frame can_frame_t;
 typedef struct canfd_frame canfd_frame_t;
-#elif defined (__ZEPHYR__)
+#elif defined(__ZEPHYR__)
 typedef struct can_frame can_frame_t;
 typedef struct can_frame canfd_frame_t;
 #endif
@@ -92,7 +92,7 @@ typedef union {
  * @param can_variant CAN or CAN-FD
  * @returns CAN socket on success else the error
  */
-int setup_can_socket(const char* can_ifname, Avtp_CanVariant_t can_variant);
+int setup_can_socket(const char *can_ifname, Avtp_CanVariant_t can_variant);
 #endif
 
 /**
@@ -107,9 +107,8 @@ int setup_can_socket(const char* can_ifname, Avtp_CanVariant_t can_variant);
  * @param exp_udp_seqnum: Expected UDP Encapsulation sequence num.
  * @return Number of CAN messages received
  */
-int avtp_to_can(uint8_t* pdu, frame_t* can_frames, Avtp_CanVariant_t can_variant,
-                int use_udp, uint64_t stream_id, uint8_t* exp_cf_seqnum,
-                uint32_t* exp_udp_seqnum);
+int avtp_to_can(uint8_t *pdu, frame_t *can_frames, Avtp_CanVariant_t can_variant, int use_udp,
+                uint64_t stream_id, uint8_t *exp_cf_seqnum, uint32_t *exp_udp_seqnum);
 
 /**
  * Function that converts AVTP Frames to CAN
@@ -125,6 +124,6 @@ int avtp_to_can(uint8_t* pdu, frame_t* can_frames, Avtp_CanVariant_t can_variant
  * @param udp_seq_num: UDP Encapsulation sequence num.
  * @return Length of the PDU
  */
-int can_to_avtp(frame_t* can_frames, Avtp_CanVariant_t can_variant, uint8_t* pdu,
-                     int use_udp, int use_tscf, uint64_t stream_id,
-                     uint8_t num_acf_msgs, uint8_t cf_seq_num, uint32_t udp_seq_num);
+int can_to_avtp(frame_t *can_frames, Avtp_CanVariant_t can_variant, uint8_t *pdu, int use_udp,
+                int use_tscf, uint64_t stream_id, uint8_t num_acf_msgs, uint8_t cf_seq_num,
+                uint32_t udp_seq_num);

--- a/examples/acf-can/acf-can-common.h
+++ b/examples/acf-can/acf-can-common.h
@@ -73,6 +73,8 @@ typedef struct can_frame canfd_frame_t;
 #define AVTP_CAN(t) Avtp_CanBrief_##t
 #elif AVTP_CAN_API == AVTP_CAN_API_CANBRIEFV2
 #define AVTP_CAN(t) Avtp_CanBriefV2_##t
+#else
+#error "Invalid AVTP_CAN_API value."
 #endif
 
 /* CAN CC/FD frame union */

--- a/examples/acf-can/acf-can-common.h
+++ b/examples/acf-can/acf-can-common.h
@@ -41,6 +41,14 @@
 #endif
 
 #include "avtp/acf/Can.h"
+#include "avtp/acf/CanV2.h"
+#include "avtp/acf/CanBrief.h"
+#include "avtp/acf/CanBriefV2.h"
+
+#define AVTP_CAN_API_CAN      1
+#define AVTP_CAN_API_CANV2    2
+#define AVTP_CAN_API_CANBRIEF 3
+#define AVTP_CAN_API_CANBRIEFV2 4
 
 #define MAX_ETH_PDU_SIZE                1500
 #define MAX_CAN_FRAMES_IN_ACF           15
@@ -51,6 +59,20 @@ typedef struct canfd_frame canfd_frame_t;
 #elif defined (__ZEPHYR__)
 typedef struct can_frame can_frame_t;
 typedef struct can_frame canfd_frame_t;
+#endif
+
+#ifndef AVTP_CAN_API
+#define AVTP_CAN_API AVTP_CAN_API_CAN
+#endif
+
+#if AVTP_CAN_API == AVTP_CAN_API_CAN
+#define AVTP_CAN(t) Avtp_Can_##t
+#elif AVTP_CAN_API == AVTP_CAN_API_CANV2
+#define AVTP_CAN(t) Avtp_CanV2_##t
+#elif AVTP_CAN_API == AVTP_CAN_API_CANBRIEF
+#define AVTP_CAN(t) Avtp_CanBrief_##t
+#elif AVTP_CAN_API == AVTP_CAN_API_CANBRIEFV2
+#define AVTP_CAN(t) Avtp_CanBriefV2_##t
 #endif
 
 /* CAN CC/FD frame union */

--- a/examples/acf-can/linux/CMakeLists.txt
+++ b/examples/acf-can/linux/CMakeLists.txt
@@ -39,30 +39,30 @@ add_executable(acf-can-bridge EXCLUDE_FROM_ALL acf-can-bridge.c ../acf-can-commo
 target_link_libraries(acf-can-bridge open1722 open1722examples)
 target_include_directories(acf-can-bridge PUBLIC ${PROJECT_SOURCE_DIR}/include ../ ../../)
 
-add_executable(acf-can-talker-canv2 EXCLUDE_FROM_ALL acf-can-talker.c ../acf-can-common.c)
-target_compile_definitions(acf-can-talker-canv2 PRIVATE AVTP_CAN_API=AVTP_CAN_API_CANV2)
-target_link_libraries(acf-can-talker-canv2 open1722 open1722examples)
-target_include_directories(acf-can-talker-canv2 PUBLIC ${PROJECT_SOURCE_DIR}/include ../ ../../)
+add_executable(acf-canv2-talker EXCLUDE_FROM_ALL acf-can-talker.c ../acf-can-common.c)
+target_compile_definitions(acf-canv2-talker PRIVATE AVTP_CAN_API=AVTP_CAN_API_CANV2)
+target_link_libraries(acf-canv2-talker open1722 open1722examples)
+target_include_directories(acf-canv2-talker PUBLIC ${PROJECT_SOURCE_DIR}/include ../ ../../)
 
-add_executable(acf-can-listener-canv2 EXCLUDE_FROM_ALL acf-can-listener.c ../acf-can-common.c)
-target_compile_definitions(acf-can-listener-canv2 PRIVATE AVTP_CAN_API=AVTP_CAN_API_CANV2)
-target_link_libraries(acf-can-listener-canv2 open1722 open1722examples)
-target_include_directories(acf-can-listener-canv2 PUBLIC ${PROJECT_SOURCE_DIR}/include ../ ../../)
+add_executable(acf-canv2-listener EXCLUDE_FROM_ALL acf-can-listener.c ../acf-can-common.c)
+target_compile_definitions(acf-canv2-listener PRIVATE AVTP_CAN_API=AVTP_CAN_API_CANV2)
+target_link_libraries(acf-canv2-listener open1722 open1722examples)
+target_include_directories(acf-canv2-listener PUBLIC ${PROJECT_SOURCE_DIR}/include ../ ../../)
 
-add_executable(acf-can-bridge-canv2 EXCLUDE_FROM_ALL acf-can-bridge.c ../acf-can-common.c)
-target_compile_definitions(acf-can-bridge-canv2 PRIVATE AVTP_CAN_API=AVTP_CAN_API_CANV2)
-target_link_libraries(acf-can-bridge-canv2 open1722 open1722examples)
-target_include_directories(acf-can-bridge-canv2 PUBLIC ${PROJECT_SOURCE_DIR}/include ../ ../../)
+add_executable(acf-canv2-bridge EXCLUDE_FROM_ALL acf-can-bridge.c ../acf-can-common.c)
+target_compile_definitions(acf-canv2-bridge PRIVATE AVTP_CAN_API=AVTP_CAN_API_CANV2)
+target_link_libraries(acf-canv2-bridge open1722 open1722examples)
+target_include_directories(acf-canv2-bridge PUBLIC ${PROJECT_SOURCE_DIR}/include ../ ../../)
 
 add_dependencies(examples acf-can-talker acf-can-listener acf-can-bridge 
-                acf-can-talker-canv2 acf-can-listener-canv2 acf-can-bridge-canv2)
+                acf-canv2-talker acf-canv2-listener acf-canv2-bridge)
 
 install(TARGETS
     acf-can-listener
     acf-can-talker
     acf-can-bridge
-    acf-can-listener-canv2
-    acf-can-talker-canv2
-    acf-can-bridge-canv2
+    acf-canv2-listener
+    acf-canv2-talker
+    acf-canv2-bridge
     RUNTIME DESTINATION bin
     OPTIONAL)

--- a/examples/acf-can/linux/CMakeLists.txt
+++ b/examples/acf-can/linux/CMakeLists.txt
@@ -54,8 +54,40 @@ target_compile_definitions(acf-canv2-bridge PRIVATE AVTP_CAN_API=AVTP_CAN_API_CA
 target_link_libraries(acf-canv2-bridge open1722 open1722examples)
 target_include_directories(acf-canv2-bridge PUBLIC ${PROJECT_SOURCE_DIR}/include ../ ../../)
 
+add_executable(acf-can-brief-talker EXCLUDE_FROM_ALL acf-can-talker.c ../acf-can-common.c)
+target_compile_definitions(acf-can-brief-talker PRIVATE AVTP_CAN_API=AVTP_CAN_API_CANBRIEF)
+target_link_libraries(acf-can-brief-talker open1722 open1722examples)
+target_include_directories(acf-can-brief-talker PUBLIC ${PROJECT_SOURCE_DIR}/include ../ ../../)
+
+add_executable(acf-can-brief-listener EXCLUDE_FROM_ALL acf-can-listener.c ../acf-can-common.c)
+target_compile_definitions(acf-can-brief-listener PRIVATE AVTP_CAN_API=AVTP_CAN_API_CANBRIEF)
+target_link_libraries(acf-can-brief-listener open1722 open1722examples)
+target_include_directories(acf-can-brief-listener PUBLIC ${PROJECT_SOURCE_DIR}/include ../ ../../)
+
+add_executable(acf-can-brief-bridge EXCLUDE_FROM_ALL acf-can-bridge.c ../acf-can-common.c)
+target_compile_definitions(acf-can-brief-bridge PRIVATE AVTP_CAN_API=AVTP_CAN_API_CANBRIEF)
+target_link_libraries(acf-can-brief-bridge open1722 open1722examples)
+target_include_directories(acf-can-brief-bridge PUBLIC ${PROJECT_SOURCE_DIR}/include ../ ../../)
+
+add_executable(acf-can-brief-v2-talker EXCLUDE_FROM_ALL acf-can-talker.c ../acf-can-common.c)
+target_compile_definitions(acf-can-brief-v2-talker PRIVATE AVTP_CAN_API=AVTP_CAN_API_CANBRIEFV2)
+target_link_libraries(acf-can-brief-v2-talker open1722 open1722examples)
+target_include_directories(acf-can-brief-v2-talker PUBLIC ${PROJECT_SOURCE_DIR}/include ../ ../../)
+
+add_executable(acf-can-brief-v2-listener EXCLUDE_FROM_ALL acf-can-listener.c ../acf-can-common.c)
+target_compile_definitions(acf-can-brief-v2-listener PRIVATE AVTP_CAN_API=AVTP_CAN_API_CANBRIEFV2)
+target_link_libraries(acf-can-brief-v2-listener open1722 open1722examples)
+target_include_directories(acf-can-brief-v2-listener PUBLIC ${PROJECT_SOURCE_DIR}/include ../ ../../)
+
+add_executable(acf-can-brief-v2-bridge EXCLUDE_FROM_ALL acf-can-bridge.c ../acf-can-common.c)
+target_compile_definitions(acf-can-brief-v2-bridge PRIVATE AVTP_CAN_API=AVTP_CAN_API_CANBRIEFV2)
+target_link_libraries(acf-can-brief-v2-bridge open1722 open1722examples)
+target_include_directories(acf-can-brief-v2-bridge PUBLIC ${PROJECT_SOURCE_DIR}/include ../ ../../)
+
 add_dependencies(examples acf-can-talker acf-can-listener acf-can-bridge 
-                acf-canv2-talker acf-canv2-listener acf-canv2-bridge)
+                acf-canv2-talker acf-canv2-listener acf-canv2-bridge
+                acf-can-brief-talker acf-can-brief-listener acf-can-brief-bridge
+                acf-can-brief-v2-talker acf-can-brief-v2-listener acf-can-brief-v2-bridge)
 
 install(TARGETS
     acf-can-listener
@@ -64,5 +96,11 @@ install(TARGETS
     acf-canv2-listener
     acf-canv2-talker
     acf-canv2-bridge
+    acf-can-brief-listener
+    acf-can-brief-talker
+    acf-can-brief-bridge
+    acf-can-brief-v2-listener
+    acf-can-brief-v2-talker
+    acf-can-brief-v2-bridge
     RUNTIME DESTINATION bin
     OPTIONAL)

--- a/examples/acf-can/linux/CMakeLists.txt
+++ b/examples/acf-can/linux/CMakeLists.txt
@@ -39,11 +39,30 @@ add_executable(acf-can-bridge EXCLUDE_FROM_ALL acf-can-bridge.c ../acf-can-commo
 target_link_libraries(acf-can-bridge open1722 open1722examples)
 target_include_directories(acf-can-bridge PUBLIC ${PROJECT_SOURCE_DIR}/include ../ ../../)
 
-add_dependencies(examples acf-can-talker acf-can-listener acf-can-bridge)
+add_executable(acf-can-talker-canv2 EXCLUDE_FROM_ALL acf-can-talker.c ../acf-can-common.c)
+target_compile_definitions(acf-can-talker-canv2 PRIVATE AVTP_CAN_API=AVTP_CAN_API_CANV2)
+target_link_libraries(acf-can-talker-canv2 open1722 open1722examples)
+target_include_directories(acf-can-talker-canv2 PUBLIC ${PROJECT_SOURCE_DIR}/include ../ ../../)
+
+add_executable(acf-can-listener-canv2 EXCLUDE_FROM_ALL acf-can-listener.c ../acf-can-common.c)
+target_compile_definitions(acf-can-listener-canv2 PRIVATE AVTP_CAN_API=AVTP_CAN_API_CANV2)
+target_link_libraries(acf-can-listener-canv2 open1722 open1722examples)
+target_include_directories(acf-can-listener-canv2 PUBLIC ${PROJECT_SOURCE_DIR}/include ../ ../../)
+
+add_executable(acf-can-bridge-canv2 EXCLUDE_FROM_ALL acf-can-bridge.c ../acf-can-common.c)
+target_compile_definitions(acf-can-bridge-canv2 PRIVATE AVTP_CAN_API=AVTP_CAN_API_CANV2)
+target_link_libraries(acf-can-bridge-canv2 open1722 open1722examples)
+target_include_directories(acf-can-bridge-canv2 PUBLIC ${PROJECT_SOURCE_DIR}/include ../ ../../)
+
+add_dependencies(examples acf-can-talker acf-can-listener acf-can-bridge 
+                acf-can-talker-canv2 acf-can-listener-canv2 acf-can-bridge-canv2)
 
 install(TARGETS
     acf-can-listener
     acf-can-talker
     acf-can-bridge
+    acf-can-listener-canv2
+    acf-can-talker-canv2
+    acf-can-bridge-canv2
     RUNTIME DESTINATION bin
     OPTIONAL)

--- a/examples/acf-can/linux/README.md
+++ b/examples/acf-can/linux/README.md
@@ -12,7 +12,7 @@ All these applications support IEEE 1722 over Ethernet (layer 2) as well as over
 - `AVTP_CAN_API_CANV2`: For the new IEEE 1722-2025 format for encapsulating CAN/CAN-FD frames
 - `AVTP_CAN_API_CANBRIEFV2`: For the new brief format of IEEE 1722-2025 for encapsulating CAN/CAN-FD frames
 
-The chosen format has to match between the talker and listener applications. The build system builds the applications using ACF CAN (_acf-can-listener_, _acf-can-talker_, _acf-can-bridge_) and ACF CANV2 (_acf-can-talker-canv2_, _acf-can-listener-canv2_, _acf-can-bridge-canv2_) formats. User can extend the build system to build the applications using other formats as well.
+The chosen format has to match between the talker and listener applications. The build system builds the applications using all available formats for the listener, talker and bridge applications. User can extend the build system to build the applications using other formats as well.
 
 The built applications can be used along with Linux CAN utilities. On Ubuntu/Debian Linux distributions, these utilities can be installed using the package manager `apt install can-utils`
 

--- a/examples/acf-can/linux/README.md
+++ b/examples/acf-can/linux/README.md
@@ -4,6 +4,7 @@ Following applications are available in this folder:
 - _acf-can-listener_: Parses received IEEE 1722 ACF frames and puts our the encapsulated CAN/CAN-FD frames onto the CAN bus
 - _acf-can-talker_: Creates IEEE 1722 ACF frames out of received CAN frames and sends them out on the network interface
 - _acf-can-bridge_: Combines the _acf-can-talker_ and _acf-can-listener_ to create a two way bridge between a CAN interface and an Ethernet network interface
+The names of the applications may differ based on the selected format for encapsulating CAN/CAN-FD frames. E.g., _acf_canv2-listener_ is the name of the listener application using the new IEEE 1722-2025 format for encapsulating CAN/CAN-FD frames.
 
 All these applications support IEEE 1722 over Ethernet (layer 2) as well as over UDP (layer 4). IEEE 1722-2025 specification includes multiple formats for encapsulating CAN/CAN-FD frames. The required format can be selected at compile time by defining the macro `AVTP_CAN_API` to one of the following values:
 - `AVTP_CAN_API_CAN`: For the original IEEE 1722-2016 format for encapsulating CAN/CAN-FD frames

--- a/examples/acf-can/linux/README.md
+++ b/examples/acf-can/linux/README.md
@@ -7,9 +7,9 @@ Following applications are available in this folder:
 
 All these applications support IEEE 1722 over Ethernet (layer 2) as well as over UDP (layer 4). IEEE 1722-2025 specification includes multiple formats for encapsulating CAN/CAN-FD frames. The required format can be selected at compile time by defining the macro `AVTP_CAN_API` to one of the following values:
 - `AVTP_CAN_API_CAN`: For the original IEEE 1722-2016 format for encapsulating CAN/CAN-FD frames
-- `AVTP_CAN_API_CAN_BRIEF`: For the brief format of IEEE 1722-2016 for encapsulating CAN/CAN-FD frames
+- `AVTP_CAN_API_CANBRIEF`: For the brief format of IEEE 1722-2016 for encapsulating CAN/CAN-FD frames
 - `AVTP_CAN_API_CANV2`: For the new IEEE 1722-2025 format for encapsulating CAN/CAN-FD frames
-- `AVTP_CAN_API_CAN_BRIEFV2`: For the new brief format of IEEE 1722-2025 for encapsulating CAN/CAN-FD frames
+- `AVTP_CAN_API_CANBRIEFV2`: For the new brief format of IEEE 1722-2025 for encapsulating CAN/CAN-FD frames
 
 The chosen format has to match between the talker and listener applications. The build system builds the applications using ACF CAN (_acf-can-listener_, _acf-can-talker_, _acf-can-bridge_) and ACF CANV2 (_acf-can-talker-canv2_, _acf-can-listener-canv2_, _acf-can-bridge-canv2_) formats. User can extend the build system to build the applications using other formats as well.
 

--- a/examples/acf-can/linux/README.md
+++ b/examples/acf-can/linux/README.md
@@ -5,8 +5,15 @@ Following applications are available in this folder:
 - _acf-can-talker_: Creates IEEE 1722 ACF frames out of received CAN frames and sends them out on the network interface
 - _acf-can-bridge_: Combines the _acf-can-talker_ and _acf-can-listener_ to create a two way bridge between a CAN interface and an Ethernet network interface
 
-All these applications support IEEE 1722 over Ethernet (layer 2) as well as over UDP (layer 4).
-These applications can be used along with Linux CAN utilities. On Ubuntu/Debian Linux distributions, these utilities can be installed using the package manager `apt install can-utils`
+All these applications support IEEE 1722 over Ethernet (layer 2) as well as over UDP (layer 4). IEEE 1722-2025 specification includes multiple formats for encapsulating CAN/CAN-FD frames. The required format can be selected at compile time by defining the macro `AVTP_CAN_API` to one of the following values:
+- `AVTP_CAN_API_CAN`: For the original IEEE 1722-2016 format for encapsulating CAN/CAN-FD frames
+- `AVTP_CAN_API_CAN_BRIEF`: For the brief format of IEEE 1722-2016 for encapsulating CAN/CAN-FD frames
+- `AVTP_CAN_API_CANV2`: For the new IEEE 1722-2025 format for encapsulating CAN/CAN-FD frames
+- `AVTP_CAN_API_CAN_BRIEFV2`: For the new brief format of IEEE 1722-2025 for encapsulating CAN/CAN-FD frames
+
+The chosen format has to match between the talker and listener applications. The build system builds the applications using ACF CAN (_acf-can-listener_, _acf-can-talker_, _acf-can-bridge_) and ACF CANV2 (_acf-can-talker-canv2_, _acf-can-listener-canv2_, _acf-can-bridge-canv2_) formats. User can extend the build system to build the applications using other formats as well.
+
+The built applications can be used along with Linux CAN utilities. On Ubuntu/Debian Linux distributions, these utilities can be installed using the package manager `apt install can-utils`
 
 ## acf-can-talker
 _acf-can-talker_ receives frames on a (virtual) CAN interface and sends out the corresponding IEEE 1722 ACF messages. The parameters for its usage are as follows:

--- a/examples/acf-can/linux/acf-can-bridge.c
+++ b/examples/acf-can/linux/acf-can-bridge.c
@@ -45,12 +45,12 @@
 #include "common/common.h"
 #include "acf-can-common.h"
 
-#define ARGPARSE_CAN_FD_OPTION      500
-#define ARGPARSE_CAN_IF_OPTION      501
-#define ARGPARSE_TALKER_ID_OPTION      502
-#define ARGPARSE_LISTENER_ID_OPTION     503
-#define TALKER_STREAM_ID            0xAABBCCDDEEFF0001
-#define LISTENER_STREAM_ID  	    0xAABBCCDDEEFF0001
+#define ARGPARSE_CAN_FD_OPTION 500
+#define ARGPARSE_CAN_IF_OPTION 501
+#define ARGPARSE_TALKER_ID_OPTION 502
+#define ARGPARSE_LISTENER_ID_OPTION 503
+#define TALKER_STREAM_ID 0xAABBCCDDEEFF0001
+#define LISTENER_STREAM_ID 0xAABBCCDDEEFF0001
 
 static char ifname[IFNAMSIZ];
 static uint8_t macaddr[ETH_ALEN];
@@ -68,10 +68,10 @@ static uint64_t listener_stream_id = LISTENER_STREAM_ID;
 static char ip_addr_str[100];
 
 int eth_socket, can_socket;
-struct sockaddr* dest_addr;
+struct sockaddr *dest_addr;
 
 static char doc[] =
-        "\nacf-can-bridge -- a program for bridging a CAN interface with an Ethernet interface using IEEE 1722.\
+    "\nacf-can-bridge -- a program for bridging a CAN interface with an Ethernet interface using IEEE 1722.\
         \vEXAMPLES\n\
         acf-can-bridge -i eth0 -d aa:bb:cc:dd:ee:ff --canif can1\n\
         \t(Bridge eth0 with can1 using Open1722 using Ethernet)\n\
@@ -80,7 +80,7 @@ static char doc[] =
 
 static struct argp_option options[] = {
     {"tscf", 't', 0, 0, "Use TSCF"},
-    {"udp", 'u', 0, 0, "Use UDP" },
+    {"udp", 'u', 0, 0, "Use UDP"},
     {"fd", ARGPARSE_CAN_FD_OPTION, 0, 0, "Use CAN-FD"},
     {"count", 'c', "COUNT", 0, "Set count of CAN messages per Ethernet frame"},
     {"canif", ARGPARSE_CAN_IF_OPTION, "CAN_IF", 0, "CAN interface"},
@@ -88,10 +88,10 @@ static struct argp_option options[] = {
     {"dst-addr", 'd', "MACADDR", 0, "Stream destination MAC address (If Ethernet)"},
     {"dst-nw-addr", 'n', "NW_ADDR", 0, "Stream destination network address and port (If UDP)"},
     {"udp-port", 'p', "UDP_PORT", 0, "UDP Port to listen on (if UDP)"},
-    {"listener-stream-id", ARGPARSE_LISTENER_ID_OPTION, "STREAM_ID", 0, "Stream ID for listener stream"},
+    {"listener-stream-id", ARGPARSE_LISTENER_ID_OPTION, "STREAM_ID", 0,
+     "Stream ID for listener stream"},
     {"talker-stream-id", ARGPARSE_TALKER_ID_OPTION, "STREAM_ID", 0, "Stream ID for talker stream"},
-    { 0 }
-};
+    {0}};
 
 static error_t parser(int key, char *arg, struct argp_state *state)
 {
@@ -124,9 +124,8 @@ static error_t parser(int key, char *arg, struct argp_state *state)
         strncpy(ifname, arg, sizeof(ifname) - 1);
         break;
     case 'd':
-        res = sscanf(arg, "%hhx:%hhx:%hhx:%hhx:%hhx:%hhx",
-                &macaddr[0], &macaddr[1], &macaddr[2],
-                &macaddr[3], &macaddr[4], &macaddr[5]);
+        res = sscanf(arg, "%hhx:%hhx:%hhx:%hhx:%hhx:%hhx", &macaddr[0], &macaddr[1], &macaddr[2],
+                     &macaddr[3], &macaddr[4], &macaddr[5]);
         if (res != 6) {
             fprintf(stderr, "Invalid MAC address\n");
             exit(EXIT_FAILURE);
@@ -163,9 +162,10 @@ static error_t parser(int key, char *arg, struct argp_state *state)
     return 0;
 }
 
-static struct argp argp = { options, parser, NULL, doc};
+static struct argp argp = {options, parser, NULL, doc};
 
-void* can_to_avtp_runnable(void* args) {
+void *can_to_avtp_runnable(void *args)
+{
 
     uint8_t cf_seq_num = 0;
     uint32_t udp_seq_num = 0;
@@ -176,14 +176,14 @@ void* can_to_avtp_runnable(void* args) {
     int res;
 
     // Start an infinite loop to keep converting CAN frames to AVTP frames
-    for(;;) {
+    for (;;) {
 
         // Read acf_num_msgs number of CAN frames from the CAN socket
         int i = 0;
         while (i < num_acf_msgs) {
             // Get payload -- will 'spin' here until we get the requested number
             //                of CAN frames.
-            if(can_variant == AVTP_CAN_FD){
+            if (can_variant == AVTP_CAN_FD) {
                 res = read(can_socket, &(can_frames[i].fd), sizeof(struct canfd_frame));
             } else {
                 res = read(can_socket, &(can_frames[i].cc), sizeof(struct can_frame));
@@ -196,16 +196,16 @@ void* can_to_avtp_runnable(void* args) {
         }
 
         // Pack all the read frames into an AVTP frame
-        pdu_length = can_to_avtp(can_frames, can_variant, pdu, use_udp, use_tscf,
-                                    talker_stream_id, num_acf_msgs, cf_seq_num++, udp_seq_num++);
+        pdu_length = can_to_avtp(can_frames, can_variant, pdu, use_udp, use_tscf, talker_stream_id,
+                                 num_acf_msgs, cf_seq_num++, udp_seq_num++);
 
         // Send the packed frame out
         if (use_udp) {
-            res = sendto(eth_socket, pdu, pdu_length, 0,
-                    (struct sockaddr *) dest_addr, sizeof(struct sockaddr_in));
+            res = sendto(eth_socket, pdu, pdu_length, 0, (struct sockaddr *)dest_addr,
+                         sizeof(struct sockaddr_in));
         } else {
-            res = sendto(eth_socket, pdu, pdu_length, 0,
-                         (struct sockaddr *) dest_addr, sizeof(struct sockaddr_ll));
+            res = sendto(eth_socket, pdu, pdu_length, 0, (struct sockaddr *)dest_addr,
+                         sizeof(struct sockaddr_ll));
         }
         if (res < 0) {
             perror("Failed to send data");
@@ -215,7 +215,8 @@ void* can_to_avtp_runnable(void* args) {
     return NULL;
 }
 
-void* avtp_to_can_runnable(void* args) {
+void *avtp_to_can_runnable(void *args)
+{
 
     uint16_t pdu_length = 0, cf_length = 0;
     int8_t num_can_msgs = 0;
@@ -225,7 +226,7 @@ void* avtp_to_can_runnable(void* args) {
     frame_t can_frames[MAX_CAN_FRAMES_IN_ACF];
 
     // Start an infinite loop to keep converting AVTP frames to CAN frames
-    for(;;) {
+    for (;;) {
 
         pdu_length = recv(eth_socket, pdu, MAX_ETH_PDU_SIZE, 0);
         if (pdu_length < 0 || pdu_length > MAX_ETH_PDU_SIZE) {
@@ -233,8 +234,8 @@ void* avtp_to_can_runnable(void* args) {
             continue;
         }
 
-        num_can_msgs = avtp_to_can(pdu, can_frames, can_variant, use_udp,
-                             listener_stream_id, &exp_cf_seqnum, &exp_udp_seqnum);
+        num_can_msgs = avtp_to_can(pdu, can_frames, can_variant, use_udp, listener_stream_id,
+                                   &exp_cf_seqnum, &exp_udp_seqnum);
         if (num_can_msgs <= 0) {
             continue;
         }
@@ -248,8 +249,7 @@ void* avtp_to_can_runnable(void* args) {
             else if (can_variant == AVTP_CAN_CLASSIC)
                 res = write(can_socket, &can_frames[i].cc, sizeof(struct can_frame));
 
-            if(res < 0)
-            {
+            if (res < 0) {
                 perror("Failed to write to CAN bus");
             }
         }
@@ -269,50 +269,54 @@ int main(int argc, char *argv[])
 
     // Print current configuration
     printf("acf-can-bridge configuration:\n");
-    if(use_tscf)
+    if (use_tscf)
         printf("\tUsing TSCF\n");
     else
         printf("\tUsing NTSCF\n");
-    if(can_variant == AVTP_CAN_CLASSIC)
+    if (can_variant == AVTP_CAN_CLASSIC)
         printf("\tUsing Classic CAN interface: %s\n", can_ifname);
-    else if(can_variant == AVTP_CAN_FD)
+    else if (can_variant == AVTP_CAN_FD)
         printf("\tUsing CAN FD interface: %s\n", can_ifname);
-    if(use_udp) {
+    if (use_udp) {
         printf("\tUsing UDP\n");
-        printf("\tDestination IP: %s, Send port: %d, listening port: %d\n", ip_addr_str, udp_send_port, udp_listen_port);
+        printf("\tDestination IP: %s, Send port: %d, listening port: %d\n", ip_addr_str,
+               udp_send_port, udp_listen_port);
     } else {
         printf("\tUsing Ethernet\n");
         printf("\tNetwork Interface: %s\n", ifname);
-        printf("\tDestination MAC Address: %02x:%02x:%02x:%02x:%02x:%02x\n", macaddr[0], macaddr[1], macaddr[2],
-                                                        macaddr[3], macaddr[4], macaddr[5]);
+        printf("\tDestination MAC Address: %02x:%02x:%02x:%02x:%02x:%02x\n", macaddr[0], macaddr[1],
+               macaddr[2], macaddr[3], macaddr[4], macaddr[5]);
     }
-    printf("\tListener Stream ID: 0x%lx, Talker Stream ID: 0x%lx\n", listener_stream_id, talker_stream_id);
+    printf("\tListener Stream ID: 0x%lx, Talker Stream ID: 0x%lx\n", listener_stream_id,
+           talker_stream_id);
     printf("\tNumber of ACF messages per AVTP frame in talker stream: %d\n", num_acf_msgs);
 
     // Create an appropriate sockets: UDP or Ethernet raw
     // Setup the socket for sending to the destination
     if (use_udp) {
         eth_socket = create_listener_socket_udp(udp_listen_port);
-        if (eth_socket < 0) return 1;
+        if (eth_socket < 0)
+            return 1;
 
         // Prepare socket for sending to the destination
-        res = setup_udp_socket_address((struct in_addr*) ip_addr,
-                                       udp_send_port, &sk_udp_addr);
-        dest_addr = (struct sockaddr*) &sk_udp_addr;
+        res = setup_udp_socket_address((struct in_addr *)ip_addr, udp_send_port, &sk_udp_addr);
+        dest_addr = (struct sockaddr *)&sk_udp_addr;
     } else {
         eth_socket = create_listener_socket(ifname, macaddr, ETH_P_TSN);
-        if (eth_socket < 0) return 1;
+        if (eth_socket < 0)
+            return 1;
 
         // Prepare socket for sending
-        res = setup_socket_address(eth_socket, ifname, macaddr,
-                                   ETH_P_TSN, &sk_ll_addr);
-        dest_addr = (struct sockaddr*) &sk_ll_addr;
+        res = setup_socket_address(eth_socket, ifname, macaddr, ETH_P_TSN, &sk_ll_addr);
+        dest_addr = (struct sockaddr *)&sk_ll_addr;
     }
-    if (res < 0) return 1;
+    if (res < 0)
+        return 1;
 
     // Open a CAN socket for reading frames
     can_socket = setup_can_socket(can_ifname, can_variant);
-    if (can_socket < 0) return 1;
+    if (can_socket < 0)
+        return 1;
 
     pthread_t can_to_avtp_thread, avtp_to_can_thread;
 

--- a/examples/acf-can/linux/acf-can-bridge.c
+++ b/examples/acf-can/linux/acf-can-bridge.c
@@ -43,12 +43,6 @@
 #include <pthread.h>
 
 #include "common/common.h"
-#include "avtp/Udp.h"
-#include "avtp/acf/Ntscf.h"
-#include "avtp/acf/Tscf.h"
-#include "avtp/acf/AcfCommon.h"
-#include "avtp/acf/Can.h"
-#include "avtp/CommonHeader.h"
 #include "acf-can-common.h"
 
 #define ARGPARSE_CAN_FD_OPTION      500

--- a/examples/acf-can/linux/acf-can-bridge.c
+++ b/examples/acf-can/linux/acf-can-bridge.c
@@ -79,7 +79,7 @@ static char doc[] =
         \t(Bridge eth0 with can1 using Open1722 over UDP)";
 
 static struct argp_option options[] = {
-    {"tscf", 't', 0, 0, "Use TSCF"},
+    {"tscf", 't', 0, 0, "Use TSCF v0 (Default: NTSCF v0)"},
     {"udp", 'u', 0, 0, "Use UDP"},
     {"fd", ARGPARSE_CAN_FD_OPTION, 0, 0, "Use CAN-FD"},
     {"count", 'c', "COUNT", 0, "Set count of CAN messages per Ethernet frame"},
@@ -270,9 +270,9 @@ int main(int argc, char *argv[])
     // Print current configuration
     printf("acf-can-bridge configuration:\n");
     if (use_tscf)
-        printf("\tUsing TSCF\n");
+        printf("\tUsing TSCF v0\n");
     else
-        printf("\tUsing NTSCF\n");
+        printf("\tUsing NTSCF v0\n");
     if (can_variant == AVTP_CAN_CLASSIC)
         printf("\tUsing Classic CAN interface: %s\n", can_ifname);
     else if (can_variant == AVTP_CAN_FD)

--- a/examples/acf-can/linux/acf-can-listener.c
+++ b/examples/acf-can/linux/acf-can-listener.c
@@ -42,10 +42,10 @@
 #include "common/common.h"
 #include "acf-can-common.h"
 
-#define ARGPARSE_CAN_FD_OPTION          500
-#define ARGPARSE_CAN_IF_OPTION          501
-#define ARGPARSE_LISTENER_ID_OPTION     503
-#define STREAM_ID                       0xAABBCCDDEEFF0001
+#define ARGPARSE_CAN_FD_OPTION 500
+#define ARGPARSE_CAN_IF_OPTION 501
+#define ARGPARSE_LISTENER_ID_OPTION 503
+#define STREAM_ID 0xAABBCCDDEEFF0001
 
 static char ifname[IFNAMSIZ];
 static uint8_t macaddr[ETH_ALEN];
@@ -56,7 +56,7 @@ static char can_ifname[IFNAMSIZ];
 static uint64_t listener_stream_id = STREAM_ID;
 
 static char doc[] =
-        "\nacf-can-listener -- a program to receive CAN messages from a remote CAN bus over Ethernet using Open1722.\
+    "\nacf-can-listener -- a program to receive CAN messages from a remote CAN bus over Ethernet using Open1722.\
         \vEXAMPLES\n\
         acf-can-listener -i eth0 -d aa:bb:cc:dd:ee:ff --canif can1\n\
         \t(tunnel Open1722 CAN messages received from eth0 to can1)\n\
@@ -64,15 +64,14 @@ static char doc[] =
         \t(tunnel Open1722 CAN messages received over UDP from port 17220 to can1)";
 
 static struct argp_option options[] = {
-    {"udp", 'u', 0, 0, "Use UDP (Default: Ethernet)" },
+    {"udp", 'u', 0, 0, "Use UDP (Default: Ethernet)"},
     {"fd", ARGPARSE_CAN_FD_OPTION, 0, 0, "Use CAN-FD"},
     {"canif", ARGPARSE_CAN_IF_OPTION, "CAN_IF", 0, "CAN interface"},
     {"ifname", 'i', "IFNAME", 0, "Network interface (If Ethernet)"},
     {"dst-addr", 'd', "MACADDR", 0, "Stream destination MAC address (If Ethernet)"},
     {"udp-port", 'p', "UDP_PORT", 0, "UDP Port to listen on (if UDP)"},
     {"stream-id", ARGPARSE_LISTENER_ID_OPTION, "STREAM_ID", 0, "Stream ID for listener stream"},
-    { 0 }
-};
+    {0}};
 
 static error_t parser(int key, char *arg, struct argp_state *state)
 {
@@ -95,9 +94,8 @@ static error_t parser(int key, char *arg, struct argp_state *state)
         strncpy(ifname, arg, sizeof(ifname) - 1);
         break;
     case 'd':
-        res = sscanf(arg, "%hhx:%hhx:%hhx:%hhx:%hhx:%hhx",
-                &macaddr[0], &macaddr[1], &macaddr[2],
-                &macaddr[3], &macaddr[4], &macaddr[5]);
+        res = sscanf(arg, "%hhx:%hhx:%hhx:%hhx:%hhx:%hhx", &macaddr[0], &macaddr[1], &macaddr[2],
+                     &macaddr[3], &macaddr[4], &macaddr[5]);
         if (res != 6) {
             fprintf(stderr, "Invalid MAC address\n");
             exit(EXIT_FAILURE);
@@ -115,7 +113,7 @@ static error_t parser(int key, char *arg, struct argp_state *state)
     return 0;
 }
 
-static struct argp argp = { options, parser, NULL, doc};
+static struct argp argp = {options, parser, NULL, doc};
 
 int main(int argc, char *argv[])
 {
@@ -133,11 +131,11 @@ int main(int argc, char *argv[])
     argp_parse(&argp, argc, argv, 0, NULL, NULL);
     // Print current configuration
     printf("acf-can-listener configuration:\n");
-    if(can_variant == AVTP_CAN_CLASSIC)
+    if (can_variant == AVTP_CAN_CLASSIC)
         printf("\tUsing Classic CAN interface: %s\n", can_ifname);
-    else if(can_variant == AVTP_CAN_FD)
+    else if (can_variant == AVTP_CAN_FD)
         printf("\tUsing CAN FD interface: %s\n", can_ifname);
-    if(use_udp) {
+    if (use_udp) {
         printf("\tUsing UDP\n");
         printf("\tListening port: %d\n", udp_port);
     } else {
@@ -158,10 +156,11 @@ int main(int argc, char *argv[])
 
     // Open a CAN socket for reading frames
     can_socket = setup_can_socket(can_ifname, can_variant);
-    if (can_socket < 0) goto err;
+    if (can_socket < 0)
+        goto err;
 
     // Start an infinite loop to keep converting AVTP frames to CAN frames
-    for(;;) {
+    for (;;) {
 
         pdu_length = recv(fd, pdu, MAX_ETH_PDU_SIZE, 0);
         if (pdu_length < 0 || pdu_length > MAX_ETH_PDU_SIZE) {
@@ -169,8 +168,8 @@ int main(int argc, char *argv[])
             continue;
         }
 
-        num_can_msgs = avtp_to_can(pdu, can_frames, can_variant, use_udp,
-                             listener_stream_id, &exp_cf_seqnum, &exp_udp_seqnum);
+        num_can_msgs = avtp_to_can(pdu, can_frames, can_variant, use_udp, listener_stream_id,
+                                   &exp_cf_seqnum, &exp_udp_seqnum);
         if (num_can_msgs < 0) {
             continue;
         }
@@ -184,8 +183,7 @@ int main(int argc, char *argv[])
             else if (can_variant == AVTP_CAN_CLASSIC)
                 res = write(can_socket, &can_frames[i].cc, sizeof(struct can_frame));
 
-            if(res < 0)
-            {
+            if (res < 0) {
                 perror("Failed to write to CAN bus");
                 continue;
             }
@@ -197,5 +195,4 @@ int main(int argc, char *argv[])
 err:
     close(fd);
     return 1;
-
 }

--- a/examples/acf-can/linux/acf-can-listener.c
+++ b/examples/acf-can/linux/acf-can-listener.c
@@ -40,12 +40,6 @@
 #include <sys/ioctl.h>
 
 #include "common/common.h"
-#include "avtp/Udp.h"
-#include "avtp/acf/Ntscf.h"
-#include "avtp/acf/Tscf.h"
-#include "avtp/acf/AcfCommon.h"
-#include "avtp/acf/Can.h"
-#include "avtp/CommonHeader.h"
 #include "acf-can-common.h"
 
 #define ARGPARSE_CAN_FD_OPTION          500

--- a/examples/acf-can/linux/acf-can-talker.c
+++ b/examples/acf-can/linux/acf-can-talker.c
@@ -42,16 +42,16 @@
 #include "common/common.h"
 #include "acf-can-common.h"
 
-#define STREAM_ID                   0xAABBCCDDEEFF0001
-#define CAN_PAYLOAD_MAX_SIZE        16*4
-#define ARGPARSE_CAN_FD_OPTION      500
-#define ARGPARSE_CAN_IF_OPTION      501
-#define ARGPARSE_TALKER_ID_OPTION      502
+#define STREAM_ID 0xAABBCCDDEEFF0001
+#define CAN_PAYLOAD_MAX_SIZE 16 * 4
+#define ARGPARSE_CAN_FD_OPTION 500
+#define ARGPARSE_CAN_IF_OPTION 501
+#define ARGPARSE_TALKER_ID_OPTION 502
 
 static char ifname[IFNAMSIZ];
 static uint8_t macaddr[ETH_ALEN];
 static uint8_t ip_addr[sizeof(struct in_addr)];
-static uint32_t udp_port=17220;
+static uint32_t udp_port = 17220;
 static int priority = -1;
 static uint8_t use_tscf = 0;
 static uint8_t use_udp = 0;
@@ -62,7 +62,7 @@ static uint64_t talker_stream_id = STREAM_ID;
 static char ip_addr_str[100];
 
 static char doc[] =
-        "\nacf-can-talker -- a program to send CAN messages to a remote CAN bus over Ethernet using Open1722.\
+    "\nacf-can-talker -- a program to send CAN messages to a remote CAN bus over Ethernet using Open1722.\
          \vEXAMPLES\n\
          acf-can-talker -i eth0 -d aa:bb:cc:ee:dd:ff --canif vcan0\n\
          \t(tunnel transactions from CAN vcan0 over Ethernet eth0)\n\n\
@@ -71,7 +71,7 @@ static char doc[] =
 
 static struct argp_option options[] = {
     {"tscf", 't', 0, 0, "Use TSCF (Default: NTSCF)"},
-    {"udp", 'u', 0, 0, "Use UDP (Default: Ethernet)" },
+    {"udp", 'u', 0, 0, "Use UDP (Default: Ethernet)"},
     {"fd", ARGPARSE_CAN_FD_OPTION, 0, 0, "Use CAN-FD"},
     {"count", 'c', "COUNT", 0, "Set count of CAN messages per Ethernet frame"},
     {"canif", ARGPARSE_CAN_IF_OPTION, "CAN_IF", 0, "CAN interface"},
@@ -79,8 +79,7 @@ static struct argp_option options[] = {
     {"dst-addr", 'd', "MACADDR", 0, "Stream destination MAC address (If Ethernet)"},
     {"dst-nw-addr", 'n', "NW_ADDR", 0, "Stream destination network address and port (If UDP)"},
     {"stream-id", ARGPARSE_TALKER_ID_OPTION, "STREAM_ID", 0, "Stream ID for talker stream"},
-    { 0 }
-};
+    {0}};
 
 static error_t parser(int key, char *arg, struct argp_state *state)
 {
@@ -110,9 +109,8 @@ static error_t parser(int key, char *arg, struct argp_state *state)
         strncpy(ifname, arg, sizeof(ifname) - 1);
         break;
     case 'd':
-        res = sscanf(arg, "%hhx:%hhx:%hhx:%hhx:%hhx:%hhx",
-                &macaddr[0], &macaddr[1], &macaddr[2],
-                &macaddr[3], &macaddr[4], &macaddr[5]);
+        res = sscanf(arg, "%hhx:%hhx:%hhx:%hhx:%hhx:%hhx", &macaddr[0], &macaddr[1], &macaddr[2],
+                     &macaddr[3], &macaddr[4], &macaddr[5]);
         if (res != 6) {
             fprintf(stderr, "Invalid MAC address\n");
             exit(EXIT_FAILURE);
@@ -142,14 +140,14 @@ static error_t parser(int key, char *arg, struct argp_state *state)
     return 0;
 }
 
-static struct argp argp = { options, parser, NULL, doc};
+static struct argp argp = {options, parser, NULL, doc};
 
 int main(int argc, char *argv[])
 {
-    int fd, res, can_socket=0;
+    int fd, res, can_socket = 0;
     struct sockaddr_ll sk_ll_addr;
     struct sockaddr_in sk_udp_addr;
-    struct sockaddr* dest_addr;
+    struct sockaddr *dest_addr;
     uint8_t cf_seq_num = 0;
     uint32_t udp_seq_num = 0;
 
@@ -159,22 +157,22 @@ int main(int argc, char *argv[])
 
     argp_parse(&argp, argc, argv, 0, NULL, NULL);
     printf("acf-talker-configuration:\n");
-    if(use_tscf)
+    if (use_tscf)
         printf("\tUsing TSCF\n");
     else
         printf("\tUsing NTSCF\n");
-    if(can_variant == AVTP_CAN_CLASSIC)
+    if (can_variant == AVTP_CAN_CLASSIC)
         printf("\tUsing Classic CAN interface: %s\n", can_ifname);
-    else if(can_variant == AVTP_CAN_FD)
+    else if (can_variant == AVTP_CAN_FD)
         printf("\tUsing CAN FD interface: %s\n", can_ifname);
-    if(use_udp) {
+    if (use_udp) {
         printf("\tUsing UDP\n");
         printf("\tDestination IP: %s, Send port: %d\n", ip_addr_str, udp_port);
     } else {
         printf("\tUsing Ethernet\n");
         printf("\tNetwork Interface: %s\n", ifname);
-        printf("\tDestination MAC Address: %02x:%02x:%02x:%02x:%02x:%02x\n", macaddr[0], macaddr[1], macaddr[2],
-                                                        macaddr[3], macaddr[4], macaddr[5]);
+        printf("\tDestination MAC Address: %02x:%02x:%02x:%02x:%02x:%02x\n", macaddr[0], macaddr[1],
+               macaddr[2], macaddr[3], macaddr[4], macaddr[5]);
     }
     printf("\tTalker Stream ID: 0x%lx\n", talker_stream_id);
     printf("\tNumber of ACF messages per AVTP frame in talker stream: %d\n", num_acf_msgs);
@@ -183,33 +181,35 @@ int main(int argc, char *argv[])
     // Setup the socket for sending to the destination
     if (use_udp) {
         fd = create_talker_socket_udp(priority);
-        if (fd < 0) return fd;
+        if (fd < 0)
+            return fd;
 
-        res = setup_udp_socket_address((struct in_addr*) ip_addr,
-                                       udp_port, &sk_udp_addr);
-        dest_addr = (struct sockaddr*) &sk_udp_addr;
+        res = setup_udp_socket_address((struct in_addr *)ip_addr, udp_port, &sk_udp_addr);
+        dest_addr = (struct sockaddr *)&sk_udp_addr;
     } else {
         fd = create_talker_socket(priority);
-        if (fd < 0) return fd;
-        res = setup_socket_address(fd, ifname, macaddr,
-                                   ETH_P_TSN, &sk_ll_addr);
-        dest_addr = (struct sockaddr*) &sk_ll_addr;
+        if (fd < 0)
+            return fd;
+        res = setup_socket_address(fd, ifname, macaddr, ETH_P_TSN, &sk_ll_addr);
+        dest_addr = (struct sockaddr *)&sk_ll_addr;
     }
-    if (res < 0) goto err;
+    if (res < 0)
+        goto err;
 
     // Open a CAN socket for reading frames
     can_socket = setup_can_socket(can_ifname, can_variant);
-    if (can_socket < 0) goto err;
+    if (can_socket < 0)
+        goto err;
 
     // Start an infinite loop to keep converting CAN frames to AVTP frames
-    for(;;) {
+    for (;;) {
 
         // Read acf_num_msgs number of CAN frames from the CAN socket
         int i = 0;
         while (i < num_acf_msgs) {
             // Get payload -- will 'spin' here until we get the requested number
             //                of CAN frames.
-            if(can_variant == AVTP_CAN_FD){
+            if (can_variant == AVTP_CAN_FD) {
                 res = read(can_socket, &(can_frames[i].fd), sizeof(struct canfd_frame));
             } else {
                 res = read(can_socket, &(can_frames[i].cc), sizeof(struct can_frame));
@@ -222,16 +222,16 @@ int main(int argc, char *argv[])
         }
 
         // Pack all the read frames into an AVTP frame
-        pdu_length = can_to_avtp(can_frames, can_variant, pdu, use_udp, use_tscf,
-                                    talker_stream_id, num_acf_msgs, cf_seq_num++, udp_seq_num++);
+        pdu_length = can_to_avtp(can_frames, can_variant, pdu, use_udp, use_tscf, talker_stream_id,
+                                 num_acf_msgs, cf_seq_num++, udp_seq_num++);
 
         // Send the packed frame out
         if (use_udp) {
-            res = sendto(fd, pdu, pdu_length, 0,
-                    (struct sockaddr *) dest_addr, sizeof(struct sockaddr_in));
+            res = sendto(fd, pdu, pdu_length, 0, (struct sockaddr *)dest_addr,
+                         sizeof(struct sockaddr_in));
         } else {
-            res = sendto(fd, pdu, pdu_length, 0,
-                         (struct sockaddr *) dest_addr, sizeof(struct sockaddr_ll));
+            res = sendto(fd, pdu, pdu_length, 0, (struct sockaddr *)dest_addr,
+                         sizeof(struct sockaddr_ll));
         }
         if (res < 0) {
             perror("Failed to send data");
@@ -241,5 +241,4 @@ int main(int argc, char *argv[])
 err:
     close(fd);
     return 1;
-
 }

--- a/examples/acf-can/linux/acf-can-talker.c
+++ b/examples/acf-can/linux/acf-can-talker.c
@@ -70,7 +70,7 @@ static char doc[] =
          \t(tunnel transactions from vcan1 interface using UDP)";
 
 static struct argp_option options[] = {
-    {"tscf", 't', 0, 0, "Use TSCF (Default: NTSCF)"},
+    {"tscf", 't', 0, 0, "Use TSCF v0 (Default: NTSCF v0)"},
     {"udp", 'u', 0, 0, "Use UDP (Default: Ethernet)"},
     {"fd", ARGPARSE_CAN_FD_OPTION, 0, 0, "Use CAN-FD"},
     {"count", 'c', "COUNT", 0, "Set count of CAN messages per Ethernet frame"},
@@ -158,9 +158,9 @@ int main(int argc, char *argv[])
     argp_parse(&argp, argc, argv, 0, NULL, NULL);
     printf("acf-talker-configuration:\n");
     if (use_tscf)
-        printf("\tUsing TSCF\n");
+        printf("\tUsing TSCF v0\n");
     else
-        printf("\tUsing NTSCF\n");
+        printf("\tUsing NTSCF v0\n");
     if (can_variant == AVTP_CAN_CLASSIC)
         printf("\tUsing Classic CAN interface: %s\n", can_ifname);
     else if (can_variant == AVTP_CAN_FD)

--- a/examples/acf-can/zephyr/acf-can-bridge.c
+++ b/examples/acf-can/zephyr/acf-can-bridge.c
@@ -72,7 +72,7 @@ static uint64_t talker_stream_id;
 static Avtp_CanVariant_t can_variant = AVTP_CAN_CLASSIC;
 
 int eth_socket = 0;
-struct sockaddr* dest_addr;
+struct sockaddr *dest_addr;
 struct sockaddr_ll sk_ll_addr;
 struct sockaddr_in sk_udp_addr;
 const struct device *const can_dev = DEVICE_DT_GET(DT_CHOSEN(zephyr_canbus));
@@ -87,15 +87,14 @@ K_THREAD_STACK_DEFINE(avtp_to_can_stack, THREAD_STACK_SIZE);
 static int init_can_dev()
 {
     int ret;
-    if  (!device_is_ready(can_dev)) {
+    if (!device_is_ready(can_dev)) {
         printf("CAN: Device %s not ready.\n", can_dev->name);
         return -1;
     }
-    ret = can_start (can_dev);
+    ret = can_start(can_dev);
     if (ret != 0) {
         printf("Error starting CAN controller [%d]", ret);
-    }
-    else {
+    } else {
         printf("Starting CAN controller [%d]\n", ret);
     }
 
@@ -107,20 +106,20 @@ static int init_can_dev()
 static int init_can_rx()
 {
     // This is a generic receive filter that will accept all frames
-    struct can_filter rx_filter={.id=1,.mask=0,.flags=0};
+    struct can_filter rx_filter = {.id = 1, .mask = 0, .flags = 0};
     int filter_id;
     filter_id = can_add_rx_filter_msgq(can_dev, &rx_msgq, &rx_filter);
-    if(filter_id == -ENOSPC) {
+    if (filter_id == -ENOSPC) {
         printf("ENOSPC: there are no free filters\n");
     }
-        if(filter_id == -ENOTSUP) {
+    if (filter_id == -ENOTSUP) {
         printf("ENOTSUP: the requested filter type is not supported\n");
     }
     return filter_id;
 }
 
-static void iface_up_handler(struct net_mgmt_event_callback *cb,
-                 uint64_t mgmt_event, struct net_if *iface)
+static void iface_up_handler(struct net_mgmt_event_callback *cb, uint64_t mgmt_event,
+                             struct net_if *iface)
 {
     if (mgmt_event == NET_EVENT_IF_UP) {
         k_sem_give(&iface_up);
@@ -135,8 +134,7 @@ static void wait_for_interface(void)
         return;
     }
 
-    net_mgmt_init_event_callback(&iface_up_cb, iface_up_handler,
-                     NET_EVENT_IF_UP);
+    net_mgmt_init_event_callback(&iface_up_cb, iface_up_handler, NET_EVENT_IF_UP);
     net_mgmt_add_event_callback(&iface_up_cb);
 
     // Wait for the interface to come up.
@@ -145,12 +143,13 @@ static void wait_for_interface(void)
     net_mgmt_del_event_callback(&iface_up_cb);
 }
 
-static int create_listener_socket_udp(uint32_t udp_port) {
+static int create_listener_socket_udp(uint32_t udp_port)
+{
 
     int fd, res;
     struct sockaddr_in sk_addr;
 
-    //create a UDP socket
+    // create a UDP socket
     fd = socket(AF_INET, SOCK_DGRAM, IPPROTO_UDP);
     if (fd < 0) {
         perror("Failed to open socket");
@@ -158,12 +157,12 @@ static int create_listener_socket_udp(uint32_t udp_port) {
     }
 
     // Initialize the socket
-    memset((char *) &sk_addr, 0, sizeof(sk_addr));
+    memset((char *)&sk_addr, 0, sizeof(sk_addr));
     sk_addr.sin_family = AF_INET;
     sk_addr.sin_port = htons(udp_port);
     sk_addr.sin_addr.s_addr = htonl(INADDR_ANY);
 
-    res = bind(fd, (struct sockaddr *) &sk_addr, sizeof(sk_addr));
+    res = bind(fd, (struct sockaddr *)&sk_addr, sizeof(sk_addr));
     if (res < 0) {
         perror("Couldn't bind() to port");
         close(fd);
@@ -173,7 +172,7 @@ static int create_listener_socket_udp(uint32_t udp_port) {
     return fd;
 }
 
-static int create_listener_socket(uint8_t* macaddr, int protocol)
+static int create_listener_socket(uint8_t *macaddr, int protocol)
 {
     int fd, res;
     struct sockaddr_ll sk_addr = {0};
@@ -188,7 +187,7 @@ static int create_listener_socket(uint8_t* macaddr, int protocol)
     sk_addr.sll_ifindex = net_if_get_by_iface(net_if_get_default());
     memcpy(&sk_addr.sll_addr, macaddr, NET_ETH_ADDR_LEN);
 
-    res = bind(fd, (struct sockaddr *) &sk_addr, sizeof(sk_addr));
+    res = bind(fd, (struct sockaddr *)&sk_addr, sizeof(sk_addr));
     if (res < 0) {
         perror("Couldn't bind() to interface");
         goto err;
@@ -201,7 +200,8 @@ err:
     return -1;
 }
 
-void can_to_avtp_runnable(void* p1, void* p2, void* p3) {
+void can_to_avtp_runnable(void *p1, void *p2, void *p3)
+{
 
     uint8_t cf_seq_num = 0;
     uint32_t udp_seq_num = 0;
@@ -221,14 +221,14 @@ void can_to_avtp_runnable(void* p1, void* p2, void* p3) {
         }
         sk_udp_addr.sin_addr = ip_addr;
         sk_udp_addr.sin_port = htons(udp_send_port);
-        dest_addr = (struct sockaddr*) &sk_udp_addr;
+        dest_addr = (struct sockaddr *)&sk_udp_addr;
     } else {
         sk_ll_addr.sll_family = AF_PACKET;
         sk_ll_addr.sll_protocol = htons(ETH_P_TSN);
         sk_ll_addr.sll_halen = NET_ETH_ADDR_LEN;
         sk_ll_addr.sll_ifindex = net_if_get_by_iface(net_if_get_default());
         memcpy(sk_ll_addr.sll_addr, macaddr, NET_ETH_ADDR_LEN);
-        dest_addr = (struct sockaddr*) &sk_ll_addr;
+        dest_addr = (struct sockaddr *)&sk_ll_addr;
     }
 
     if (!eth_socket) {
@@ -237,7 +237,7 @@ void can_to_avtp_runnable(void* p1, void* p2, void* p3) {
     }
 
     // Start an infinite loop to keep converting CAN frames to AVTP frames
-    for(;;) {
+    for (;;) {
 
         // Read acf_num_msgs number of CAN frames from the CAN socket
         int i = 0;
@@ -254,16 +254,16 @@ void can_to_avtp_runnable(void* p1, void* p2, void* p3) {
         }
 
         // Pack all the read frames into an AVTP frame
-        pdu_length = can_to_avtp(can_frames, can_variant, pdu, use_udp, use_tscf,
-                                    talker_stream_id, num_acf_msgs, cf_seq_num++, udp_seq_num++);
+        pdu_length = can_to_avtp(can_frames, can_variant, pdu, use_udp, use_tscf, talker_stream_id,
+                                 num_acf_msgs, cf_seq_num++, udp_seq_num++);
 
         // Send the packed frame out over Ethernet
         if (use_udp) {
-            res = sendto(eth_socket, pdu, pdu_length, 0,
-                    (struct sockaddr *) dest_addr, sizeof(struct sockaddr_in));
+            res = sendto(eth_socket, pdu, pdu_length, 0, (struct sockaddr *)dest_addr,
+                         sizeof(struct sockaddr_in));
         } else {
-            res = sendto(eth_socket, pdu, pdu_length, 0,
-                         (struct sockaddr *) dest_addr, sizeof(struct sockaddr_ll));
+            res = sendto(eth_socket, pdu, pdu_length, 0, (struct sockaddr *)dest_addr,
+                         sizeof(struct sockaddr_ll));
         }
         if (res < 0) {
             perror("Failed to send data");
@@ -273,7 +273,8 @@ void can_to_avtp_runnable(void* p1, void* p2, void* p3) {
     return;
 }
 
-void avtp_to_can_runnable(void* p1, void* p2, void* p3) {
+void avtp_to_can_runnable(void *p1, void *p2, void *p3)
+{
 
     uint16_t pdu_length = 0;
     int8_t num_can_msgs = 0;
@@ -295,7 +296,7 @@ void avtp_to_can_runnable(void* p1, void* p2, void* p3) {
     fds[0].events = POLLIN;
 
     // Start an infinite loop to keep converting AVTP frames to CAN frames
-    for(;;) {
+    for (;;) {
         // Wait for data with a timeout (e.g., 500ms)
         ret = poll(fds, 1, 500);
 
@@ -317,8 +318,8 @@ void avtp_to_can_runnable(void* p1, void* p2, void* p3) {
                 continue;
             }
 
-            num_can_msgs = avtp_to_can(pdu, can_frames, can_variant, use_udp,
-                                listener_stream_id, &exp_cf_seqnum, &exp_udp_seqnum);
+            num_can_msgs = avtp_to_can(pdu, can_frames, can_variant, use_udp, listener_stream_id,
+                                       &exp_cf_seqnum, &exp_udp_seqnum);
             if (num_can_msgs <= 0) {
                 continue;
             }
@@ -328,8 +329,7 @@ void avtp_to_can_runnable(void* p1, void* p2, void* p3) {
             for (int8_t i = 0; i < num_can_msgs; i++) {
                 int res;
                 res = can_send(can_dev, &(can_frames[i].cc), K_NO_WAIT, NULL, NULL);
-                if(res < 0)
-                {
+                if (res < 0) {
                     perror("Failed to write to CAN bus");
                 }
             }
@@ -353,43 +353,43 @@ int main(void)
 
     // Print current configuration
     printf("acf-can-bridge configuration:\n");
-    if(use_tscf)
-        printf("\tUsing TSCF\n");
+    if (use_tscf)
+        printf("\tUsing TSCF v0\n");
     else
-        printf("\tUsing NTSCF\n");
-    if(can_variant == AVTP_CAN_CLASSIC)
+        printf("\tUsing NTSCF v0\n");
+    if (can_variant == AVTP_CAN_CLASSIC)
         printf("\tUsing Classic CAN\n");
-    else if(can_variant == AVTP_CAN_FD)
+    else if (can_variant == AVTP_CAN_FD)
         printf("\tUsing CAN FD\n");
-    if(use_udp) {
+    if (use_udp) {
         printf("\tUsing UDP\n");
         printf("\tDestination IP: %s, Send port: %d, listening port: %d\n",
-                CONFIG_ACF_CAN_BRIDGE_SEND_IP_ADDR, udp_send_port, udp_listen_port);
+               CONFIG_ACF_CAN_BRIDGE_SEND_IP_ADDR, udp_send_port, udp_listen_port);
     } else {
         printf("\tUsing Ethernet\n");
         res = sscanf(CONFIG_ACF_CAN_BRIDGE_SEND_MAC_ADDR, "%hhx:%hhx:%hhx:%hhx:%hhx:%hhx",
-                &macaddr[0], &macaddr[1], &macaddr[2],
-                &macaddr[3], &macaddr[4], &macaddr[5]);
+                     &macaddr[0], &macaddr[1], &macaddr[2], &macaddr[3], &macaddr[4], &macaddr[5]);
         if (res != 6) {
             fprintf(stderr, "Invalid MAC address\n");
             exit(EXIT_FAILURE);
         }
-        printf("\tDestination MAC Address: %02x:%02x:%02x:%02x:%02x:%02x\n", macaddr[0], macaddr[1], macaddr[2],
-                                                        macaddr[3], macaddr[4], macaddr[5]);
+        printf("\tDestination MAC Address: %02x:%02x:%02x:%02x:%02x:%02x\n", macaddr[0], macaddr[1],
+               macaddr[2], macaddr[3], macaddr[4], macaddr[5]);
     }
-    printf("\tListener Stream ID: 0x%"PRIx64", Talker Stream ID: 0x%"PRIx64"\n", listener_stream_id, talker_stream_id);
+    printf("\tListener Stream ID: 0x%" PRIx64 ", Talker Stream ID: 0x%" PRIx64 "\n",
+           listener_stream_id, talker_stream_id);
     printf("\tNumber of ACF messages per AVTP frame in talker stream: %d\n", num_acf_msgs);
 
     // Open a CAN socket for reading frames
     // init CAN Dev
     res = init_can_dev();
-    if (res < 0){
+    if (res < 0) {
         printf("Failed to init CAN device\n");
         return -1;
     }
     // init CAN RX
     res = init_can_rx();
-    if (res < 0){
+    if (res < 0) {
         return -1;
     }
 
@@ -403,22 +403,20 @@ int main(void)
     } else {
         eth_socket = create_listener_socket(macaddr, ETH_P_TSN);
     }
-    if (eth_socket < 0) return -1;
+    if (eth_socket < 0)
+        return -1;
 
     k_tid_t t_id;
     t_id = k_thread_create(&avtp_to_can_thread, avtp_to_can_stack,
-                    K_THREAD_STACK_SIZEOF(avtp_to_can_stack),
-                    avtp_to_can_runnable, NULL, NULL, NULL,
-                    THREAD_PRIORITY_AVTP_TO_CAN, 0, K_NO_WAIT);
+                           K_THREAD_STACK_SIZEOF(avtp_to_can_stack), avtp_to_can_runnable, NULL,
+                           NULL, NULL, THREAD_PRIORITY_AVTP_TO_CAN, 0, K_NO_WAIT);
     k_thread_name_set(t_id, "avtp_to_can_thread");
     t_id = k_thread_create(&can_to_avtp_thread, can_to_avtp_stack,
-                    K_THREAD_STACK_SIZEOF(can_to_avtp_stack),
-                    can_to_avtp_runnable, NULL, NULL, NULL,
-                    THREAD_PRIORITY_CAN_TO_AVTP, 0, K_NO_WAIT);
+                           K_THREAD_STACK_SIZEOF(can_to_avtp_stack), can_to_avtp_runnable, NULL,
+                           NULL, NULL, THREAD_PRIORITY_CAN_TO_AVTP, 0, K_NO_WAIT);
     k_thread_name_set(t_id, "can_to_avtp_thread");
 
     printf("Main thread going to sleep\n");
     k_sleep(K_FOREVER);
     return 1;
 }
-


### PR DESCRIPTION
We now have multiple formats for a CAN message in IEEE 1722.
- CAN
- CAN_BRIEF
- CANV2
- CAN_BRIEFV2

And of course the talker/listener applications have to use the same format.
This results in multiple combinations. Instead of handling them in code, we choose the API to be used at compile time by setting the macro _AVTP_CAN_API_.

These can take values: 
- _AVTP_CAN_API_CAN_
- _AVTP_CAN_API_CANV2_
- _AVTP_CAN_API_CANBRIEF_
- _AVTP_CAN_API_CANBRIEFV2_