### PR TITLE
Align all CAN CreateAcfMessage signatures

### DIFF
--- a/docs/api-design.md
+++ b/docs/api-design.md
@@ -501,7 +501,7 @@ message, reading/writing the payload, and computing the length/padding fields.
 See [Convenience functions](#convenience-functions).
 
 ```c
-void Avtp_Can_CreateAcfMessage(Avtp_Can_t *can_pdu, uint32_t frame_id,
+void Avtp_Can_CreateAcfMessage(Avtp_Can_t *pdu, uint32_t frame_id,
                                uint8_t *payload, uint16_t payload_length,
                                Avtp_CanVariant_t can_variant);
 ```

--- a/include/avtp/acf/Can.h
+++ b/include/avtp/acf/Can.h
@@ -423,8 +423,8 @@ OPEN1722_INLINE void Avtp_Can_Init(Avtp_Can_t *pdu)
  * @param payload_length Length of the payload.
  * @param can_variant Classic CAN or CAN-FD
  */
-OPEN1722_INLINE void Avtp_Can_CreateAcfMessage(Avtp_Can_t *pdu, uint32_t frame_id,
-                                               uint8_t *payload, uint16_t payload_length,
+OPEN1722_INLINE void Avtp_Can_CreateAcfMessage(Avtp_Can_t *pdu, uint32_t frame_id, uint8_t *payload,
+                                               uint16_t payload_length,
                                                Avtp_CanVariant_t can_variant)
 {
     // Initialize the ACF CAN header

--- a/include/avtp/acf/Can.h
+++ b/include/avtp/acf/Can.h
@@ -417,34 +417,34 @@ OPEN1722_INLINE void Avtp_Can_Init(Avtp_Can_t *pdu)
  * Copies the payload data and CAN frame ID into the ACF CAN frame. This function will
  * also set the length and pad fields while inserting the padded bytes.
  *
- * @param can_pdu Pointer to the first bit of an 1722 ACF CAN PDU.
+ * @param pdu Pointer to the first bit of an 1722 ACF CAN PDU.
  * @param frame_id ID of the CAN frame
  * @param payload Pointer to the payload byte array
  * @param payload_length Length of the payload.
  * @param can_variant Classic CAN or CAN-FD
  */
-OPEN1722_INLINE void Avtp_Can_CreateAcfMessage(Avtp_Can_t *can_pdu, uint32_t frame_id,
+OPEN1722_INLINE void Avtp_Can_CreateAcfMessage(Avtp_Can_t *pdu, uint32_t frame_id,
                                                uint8_t *payload, uint16_t payload_length,
                                                Avtp_CanVariant_t can_variant)
 {
     // Initialize the ACF CAN header
-    Avtp_Can_Init(can_pdu);
+    Avtp_Can_Init(pdu);
 
     // Copy the payload into the CAN PDU
-    Avtp_Can_SetPayload(can_pdu, payload, payload_length);
+    Avtp_Can_SetPayload(pdu, payload, payload_length);
 
     // Set the Frame ID and CAN variant
     if (frame_id > 0x7ff) {
-        Avtp_Can_SetEff(can_pdu, true);
+        Avtp_Can_SetEff(pdu, true);
     }
 
-    Avtp_Can_SetCanIdentifier(can_pdu, frame_id);
+    Avtp_Can_SetCanIdentifier(pdu, frame_id);
     if (can_variant == AVTP_CAN_FD) {
-        Avtp_Can_SetFdf(can_pdu, true);
+        Avtp_Can_SetFdf(pdu, true);
     }
 
     // Finalize the AVTP CAN Frame
-    Avtp_Can_SetPayloadLength(can_pdu, payload_length);
+    Avtp_Can_SetPayloadLength(pdu, payload_length);
 }
 
 /**

--- a/include/avtp/acf/CanBrief.h
+++ b/include/avtp/acf/CanBrief.h
@@ -399,34 +399,34 @@ OPEN1722_INLINE void Avtp_CanBrief_Init(Avtp_CanBrief_t *pdu)
  * Copies the payload data and CAN frame ID into the ACF CAN Brief frame. This function will
  * also set the length and pad fields while inserting the padded bytes.
  *
- * @param can_pdu Pointer to the first bit of an 1722 ACF CAN Brief PDU.
+ * @param pdu Pointer to the first bit of an 1722 ACF CAN Brief PDU.
  * @param frame_id ID of the CAN frame
  * @param payload Pointer to the payload byte array
  * @param payload_length Length of the payload.
  * @param can_variant Classic CAN or CAN-FD
  */
-OPEN1722_INLINE void Avtp_CanBrief_CreateAcfMessage(Avtp_CanBrief_t *can_pdu, uint32_t frame_id,
+OPEN1722_INLINE void Avtp_CanBrief_CreateAcfMessage(Avtp_CanBrief_t *pdu, uint32_t frame_id,
                                                     uint8_t *payload, uint16_t payload_length,
                                                     Avtp_CanVariant_t can_variant)
 {
     // Initialize the ACF CAN Brief header
-    Avtp_CanBrief_Init(can_pdu);
+    Avtp_CanBrief_Init(pdu);
 
     // Copy the payload into the CAN PDU
-    Avtp_CanBrief_SetPayload(can_pdu, payload, payload_length);
+    Avtp_CanBrief_SetPayload(pdu, payload, payload_length);
 
     // Set the Frame ID and CAN variant
     if (frame_id > 0x7ff) {
-        Avtp_CanBrief_SetEff(can_pdu, true);
+        Avtp_CanBrief_SetEff(pdu, true);
     }
 
-    Avtp_CanBrief_SetCanIdentifier(can_pdu, frame_id);
+    Avtp_CanBrief_SetCanIdentifier(pdu, frame_id);
     if (can_variant == AVTP_CAN_FD) {
-        Avtp_CanBrief_SetFdf(can_pdu, true);
+        Avtp_CanBrief_SetFdf(pdu, true);
     }
 
     // Finalize the AVTP CAN Frame
-    Avtp_CanBrief_SetPayloadLength(can_pdu, payload_length);
+    Avtp_CanBrief_SetPayloadLength(pdu, payload_length);
 }
 
 /**

--- a/include/avtp/acf/CanBriefV2.h
+++ b/include/avtp/acf/CanBriefV2.h
@@ -388,19 +388,17 @@ OPEN1722_INLINE void Avtp_CanBriefV2_Init(Avtp_CanBriefV2_t *pdu)
 }
 
 /**
- * Copies the payload data, CAN frame ID and CAN bus ID into the ACF CAN Brief V2 frame. This
- * function will also set the length and pad fields while inserting the padded bytes.
+ * Copies the payload data and CAN frame ID into the ACF CAN Brief V2 frame. This function will
+ * also set the length and pad fields while inserting the padded bytes.
  *
  * @param pdu Pointer to the first bit of a 1722 ACF CAN Brief V2 PDU.
  * @param frame_id ID of the CAN frame
- * @param can_bus_id CAN bus ID
  * @param payload Pointer to the payload byte array
  * @param payload_length Length of the payload.
  * @param can_variant Classic CAN or CAN-FD
  */
 OPEN1722_INLINE void Avtp_CanBriefV2_CreateAcfMessage(Avtp_CanBriefV2_t *pdu, uint32_t frame_id,
-                                                      uint16_t can_bus_id, uint8_t *payload,
-                                                      uint16_t payload_length,
+                                                      uint8_t *payload, uint16_t payload_length,
                                                       Avtp_CanVariant_t can_variant)
 {
     // Initialize the ACF CAN Brief V2 header
@@ -409,13 +407,12 @@ OPEN1722_INLINE void Avtp_CanBriefV2_CreateAcfMessage(Avtp_CanBriefV2_t *pdu, ui
     // Copy the payload into the CAN PDU
     Avtp_CanBriefV2_SetPayload(pdu, payload, payload_length);
 
-    // Set the Frame ID, bus ID and CAN variant
+    // Set the Frame ID and CAN variant
     if (frame_id > 0x7ff) {
         Avtp_CanBriefV2_SetEff(pdu, true);
     }
 
     Avtp_CanBriefV2_SetCanIdentifier(pdu, frame_id);
-    Avtp_CanBriefV2_SetCanBusId(pdu, can_bus_id);
     if (can_variant == AVTP_CAN_FD) {
         Avtp_CanBriefV2_SetFdf(pdu, true);
     }

--- a/unit/test-can-brief-v2.c
+++ b/unit/test-can-brief-v2.c
@@ -287,8 +287,7 @@ static void Test_CanBriefV2_CreateAcfMessage(void **state)
     uint8_t payload[8] = {0, 1, 2, 3, 4, 5, 6, 7};
 
     Avtp_CanBriefV2_Init(canV2);
-    Avtp_CanBriefV2_CreateAcfMessage(canV2, 0x7ff, payload, sizeof(payload),
-                                     AVTP_CAN_CLASSIC);
+    Avtp_CanBriefV2_CreateAcfMessage(canV2, 0x7ff, payload, sizeof(payload), AVTP_CAN_CLASSIC);
 
     assert_int_equal(Avtp_CanBriefV2_GetCanIdentifier(canV2), 0x7ff);
     assert_int_equal(Avtp_CanBriefV2_GetCanBusId(canV2), 0x0);
@@ -297,8 +296,7 @@ static void Test_CanBriefV2_CreateAcfMessage(void **state)
     assert_int_equal(Avtp_CanBriefV2_GetPayloadLength(canV2), 8);
 
     // Extended Frame IDs set the EFF flag
-    Avtp_CanBriefV2_CreateAcfMessage(canV2, 0x800, payload, sizeof(payload),
-                                     AVTP_CAN_CLASSIC);
+    Avtp_CanBriefV2_CreateAcfMessage(canV2, 0x800, payload, sizeof(payload), AVTP_CAN_CLASSIC);
     assert_int_equal(Avtp_CanBriefV2_GetCanIdentifier(canV2), 0x800);
     assert_int_equal(Avtp_CanBriefV2_IsEff(canV2), true);
 }

--- a/unit/test-can-brief-v2.c
+++ b/unit/test-can-brief-v2.c
@@ -287,17 +287,17 @@ static void Test_CanBriefV2_CreateAcfMessage(void **state)
     uint8_t payload[8] = {0, 1, 2, 3, 4, 5, 6, 7};
 
     Avtp_CanBriefV2_Init(canV2);
-    Avtp_CanBriefV2_CreateAcfMessage(canV2, 0x7ff, 0x5FF, payload, sizeof(payload),
+    Avtp_CanBriefV2_CreateAcfMessage(canV2, 0x7ff, payload, sizeof(payload),
                                      AVTP_CAN_CLASSIC);
 
     assert_int_equal(Avtp_CanBriefV2_GetCanIdentifier(canV2), 0x7ff);
-    assert_int_equal(Avtp_CanBriefV2_GetCanBusId(canV2), 0x5FF);
+    assert_int_equal(Avtp_CanBriefV2_GetCanBusId(canV2), 0x0);
     assert_int_equal(Avtp_CanBriefV2_IsEff(canV2), false);
     assert_memory_equal(payload, msg + AVTP_CAN_BRIEF_V2_HEADER_LEN, sizeof(payload));
     assert_int_equal(Avtp_CanBriefV2_GetPayloadLength(canV2), 8);
 
     // Extended Frame IDs set the EFF flag
-    Avtp_CanBriefV2_CreateAcfMessage(canV2, 0x800, 0x5FF, payload, sizeof(payload),
+    Avtp_CanBriefV2_CreateAcfMessage(canV2, 0x800, payload, sizeof(payload),
                                      AVTP_CAN_CLASSIC);
     assert_int_equal(Avtp_CanBriefV2_GetCanIdentifier(canV2), 0x800);
     assert_int_equal(Avtp_CanBriefV2_IsEff(canV2), true);
@@ -318,7 +318,7 @@ static void Test_CanBriefV2_IsValid(void **state)
     {
         uint8_t payload[8] = {0, 1, 2, 3, 4, 5, 6, 7};
         Avtp_CanBriefV2_Init(canV2);
-        Avtp_CanBriefV2_CreateAcfMessage(canV2, frame_id, 0x0, payload, sizeof(payload),
+        Avtp_CanBriefV2_CreateAcfMessage(canV2, frame_id, payload, sizeof(payload),
                                          AVTP_CAN_CLASSIC);
         assert_int_equal(Avtp_CanBriefV2_IsValid(canV2, msg_len), 1);
     }
@@ -331,7 +331,7 @@ static void Test_CanBriefV2_IsValid(void **state)
     {
         uint8_t too_big[12] = {0};
         Avtp_CanBriefV2_Init(canV2);
-        Avtp_CanBriefV2_CreateAcfMessage(canV2, frame_id, 0x0, too_big, sizeof(too_big),
+        Avtp_CanBriefV2_CreateAcfMessage(canV2, frame_id, too_big, sizeof(too_big),
                                          AVTP_CAN_CLASSIC);
         assert_int_equal(Avtp_CanBriefV2_IsValid(canV2, msg_len), 0);
     }
@@ -340,13 +340,13 @@ static void Test_CanBriefV2_IsValid(void **state)
     {
         uint8_t fd_max[64] = {0};
         Avtp_CanBriefV2_Init(canV2);
-        Avtp_CanBriefV2_CreateAcfMessage(canV2, frame_id, 0x0, fd_max, sizeof(fd_max), AVTP_CAN_FD);
+        Avtp_CanBriefV2_CreateAcfMessage(canV2, frame_id, fd_max, sizeof(fd_max), AVTP_CAN_FD);
         assert_int_equal(Avtp_CanBriefV2_IsValid(canV2, msg_len), 1);
     }
     {
         uint8_t fd_too_big[68] = {0};
         Avtp_CanBriefV2_Init(canV2);
-        Avtp_CanBriefV2_CreateAcfMessage(canV2, frame_id, 0x0, fd_too_big, sizeof(fd_too_big),
+        Avtp_CanBriefV2_CreateAcfMessage(canV2, frame_id, fd_too_big, sizeof(fd_too_big),
                                          AVTP_CAN_FD);
         assert_int_equal(Avtp_CanBriefV2_IsValid(canV2, msg_len), 0);
     }
@@ -361,7 +361,7 @@ static void Test_CanBriefV2_CreateFromGarbage(void **state)
 
     // CreateAcfMessage must fully initialize the header even on garbage input.
     memset(msg, 0xAA, msg_len);
-    Avtp_CanBriefV2_CreateAcfMessage(canV2, 0x123, 0x0, payload, sizeof(payload), AVTP_CAN_CLASSIC);
+    Avtp_CanBriefV2_CreateAcfMessage(canV2, 0x123, payload, sizeof(payload), AVTP_CAN_CLASSIC);
 
     assert_int_equal(Avtp_AcfCommon_GetAcfMsgType((Avtp_AcfCommon_t *)canV2),
                      AVTP_ACF_TYPE_CAN_BRIEF_V2);


### PR DESCRIPTION
This fixes #188 by removing `can_bus_id` parameter from CanBriefV2 (that was the only exception, and for a minimally valid & useful ACF CAN message setting it is not required).

While at times, I also aligned parameter names, but that is purely cosemetic.