### PR TITLE
Remove public get/setPad functions

### DIFF
--- a/.github/workflows/style.yml
+++ b/.github/workflows/style.yml
@@ -38,14 +38,17 @@ jobs:
       with:
         fetch-depth: 0
     - name: Install clang-format
-      run: sudo apt update && sudo apt install -y clang-format
+      run: |
+        sudo apt update && sudo apt install -y python3-venv
+        python3 -m venv /tmp/cfenv
+        /tmp/cfenv/bin/pip install -q clang-format==18.1.8
     - name: Check formatting of changed C/H files
       run: |
         changed=$(git diff --name-only --diff-filter=d origin/${{ github.base_ref }}...HEAD \
                   | grep -E '\.(c|h)$' || true)
         if [ -n "$changed" ]; then
           echo "Checking format for: $changed"
-          clang-format --dry-run --Werror $changed
+          /tmp/cfenv/bin/clang-format --dry-run --Werror $changed
         else
           echo "No C/H files changed — skipping format check"
         fi

--- a/docs/api-design.md
+++ b/docs/api-design.md
@@ -43,11 +43,16 @@ For example, the ACF CAN header contains the fields `pad`, `mtv`, `rtr`, `eff`,
 Those exact names reappear in the API:
 
 ```c
-Avtp_Can_GetPad(pdu);
+Avtp_Can_GetCanBusId(pdu);
 Avtp_Can_IsMtv(pdu);
 Avtp_Can_GetCanIdentifier(pdu);
 Avtp_Can_SetMessageTimestamp(pdu, value);
 ```
+
+The one systematic exception is the `pad` field: it is *derived* (fully determined
+by the payload length), so it has no `Avtp_Can_GetPad`/`Avtp_Can_SetPad`
+accessors. It is written for you by `SetPayloadLength` (see
+[Convenience functions](#convenience-functions)).
 
 There is no "rename for taste" step. If the spec calls a field `eff`, the
 function is `Avtp_Can_IsEff`, not `Avtp_Can_GetExtendedFrameFormat`.
@@ -141,7 +146,7 @@ Getters return the natural C type for the field width - `uint8_t`,
 `uint16_t`, `uint32_t` or `uint64_t`:
 
 ```c
-OPEN1722_INLINE uint8_t  Avtp_Can_GetPad(const Avtp_Can_t *const pdu);
+OPEN1722_INLINE uint8_t  Avtp_Can_GetCanBusId(const Avtp_Can_t *const pdu);
 OPEN1722_INLINE uint16_t Avtp_AcfCommon_GetAcfMsgLengthInBytes(const Avtp_AcfCommon_t *const pdu);
 OPEN1722_INLINE uint64_t Avtp_Can_GetMessageTimestamp(const Avtp_Can_t *const pdu);
 ```
@@ -246,7 +251,7 @@ The canonical set (CAN as reference):
       if (pad > 0)
           memset(can_pdu->payload + payload_length, 0, pad);
       uint16_t msgLenQuadlets = (uint16_t)((msgLenBytes + pad) / 4);
-      Avtp_Can_SetPad(can_pdu, pad);
+      SET_CAN_FIELD(AVTP_CAN_FIELD_PAD, pad);
       Avtp_AcfCommon_SetAcfMsgLength((Avtp_AcfCommon_t *)can_pdu, msgLenQuadlets);
   }
   ```
@@ -419,6 +424,23 @@ can reach them through the generic engine:
 ```c
 uint64_t rsv = Avtp_GetField(Avtp_CanFieldDesc, AVTP_CAN_FIELD_MAX,
                              (uint8_t *)pdu, AVTP_CAN_FIELD_RSV1);
+```
+
+### The derived `pad` field
+
+Like reserved fields, the `pad` field gets **no** `Get`/`Set` accessors - but for
+a different reason. `pad` is *derived*: its value is fully determined by the
+payload length (how many zero bytes are needed to reach a whole quadlet), so
+writing it by hand can only desynchronise the header. It is written by the
+convenience function `Avtp_<Format>_SetPayloadLength` (and therefore by
+`Avtp_<Format>_CreateAcfMessage`), and read back by `GetPayloadLength` and
+`IsValid`, all through the `SET_<FORMAT>_FIELD`/`GET_<FORMAT>_FIELD` macros. Code
+that needs raw access anyway (test vectors, fuzzing) can reach it through the
+generic engine, exactly like a reserved field:
+
+```c
+uint64_t pad = Avtp_GetField(Avtp_CanFieldDesc, AVTP_CAN_FIELD_MAX,
+                             (uint8_t *)pdu, AVTP_CAN_FIELD_PAD);
 ```
 
 ### The GET/SET macros

--- a/examples/acf-can/linux-kernel-mod/1722ethernet.c
+++ b/examples/acf-can/linux-kernel-mod/1722ethernet.c
@@ -92,7 +92,8 @@ void prepare_can_header(Avtp_Can_t *can_header, struct acfcan_cfg *cfg, const st
                       AVTP_QUADLET_SIZE;
     Avtp_AcfCommon_SetAcfMsgLength((Avtp_AcfCommon_t *)can_header,
                                    (AVTP_CAN_HEADER_LEN + cfd->len + padSize) / AVTP_QUADLET_SIZE);
-    Avtp_Can_SetPad(can_header, padSize);
+    Avtp_SetField(Avtp_CanFieldDesc, AVTP_CAN_FIELD_MAX, (uint8_t *)can_header, AVTP_CAN_FIELD_PAD,
+                  padSize);
 
     pr_debug("Prepared AVTP ACFCAN msg for can id 0x%08x, len %i\n",
              Avtp_Can_GetCanIdentifier(can_header), cfd->len);
@@ -132,10 +133,11 @@ int forward_can_frame(struct net_device *can_dev, const struct sk_buff *skb_can)
     // Prepare ethernet
     struct sk_buff *skb_eth;
     struct canfd_frame *cfd = (struct canfd_frame *)skb_can->data;
+    uint8_t pad = (uint8_t)Avtp_GetField(Avtp_CanFieldDesc, AVTP_CAN_FIELD_MAX,
+                                         (const uint8_t *)&pdu.can, AVTP_CAN_FIELD_PAD);
 
     // Allocate a socket buffer
-    skb_eth = alloc_skb(ETH_HLEN + sizeof(ACFCANPdu_t) + cfd->len + Avtp_Can_GetPad(&pdu.can),
-                        GFP_KERNEL);
+    skb_eth = alloc_skb(ETH_HLEN + sizeof(ACFCANPdu_t) + cfd->len + pad, GFP_KERNEL);
     pr_debug("ACFCAN: Allocating skb for ethernet frame: 0x%p\n", (void *)skb_eth->data);
     if (!skb_eth) {
         printk(KERN_ERR "Failed to allocate skb\n");
@@ -148,8 +150,8 @@ int forward_can_frame(struct net_device *can_dev, const struct sk_buff *skb_can)
     data = skb_put(skb_eth, cfd->len);                   // Add payload data
     memcpy(data, (uint8_t *)cfd->data, cfd->len);        // Fill payload with avtp +  acf-can header
 
-    data = skb_put(skb_eth, Avtp_Can_GetPad(&pdu.can)); // Add payload data
-    memset(data, 0, Avtp_Can_GetPad(&pdu.can));
+    data = skb_put(skb_eth, pad); // Add padding data
+    memset(data, 0, pad);
 
     // Set up the Ethernet header
     struct ethhdr *eth = (struct ethhdr *)skb_push(skb_eth, sizeof(struct ethhdr));
@@ -266,6 +268,8 @@ int ieee1722_packet_handdler(struct sk_buff *skb, struct net_device *dev, struct
     }
 
     bool is_fd = Avtp_Can_IsFdf(can);
+    uint8_t pad = (uint8_t)Avtp_GetField(Avtp_CanFieldDesc, AVTP_CAN_FIELD_MAX,
+                                         (const uint8_t *)can, AVTP_CAN_FIELD_PAD);
     struct sk_buff *can_skb;
     struct can_frame *cf;
     struct canfd_frame *cfd;
@@ -307,9 +311,9 @@ int ieee1722_packet_handdler(struct sk_buff *skb, struct net_device *dev, struct
         if (Avtp_Can_IsEsi(can)) {
             cfd->flags |= CANFD_ESI;
         }
-        cfd->len = msg_length - AVTP_CAN_HEADER_LEN - Avtp_Can_GetPad(can);
+        cfd->len = msg_length - AVTP_CAN_HEADER_LEN - pad;
     } else {
-        cf->len = msg_length - AVTP_CAN_HEADER_LEN - Avtp_Can_GetPad(can);
+        cf->len = msg_length - AVTP_CAN_HEADER_LEN - pad;
     }
 
     if (is_fd && cfd->len > CANFD_MAX_DLEN) {

--- a/include/avtp/acf/Abb.h
+++ b/include/avtp/acf/Abb.h
@@ -118,28 +118,6 @@ static const Avtp_FieldDescriptor_t Avtp_AbbFieldDesc[AVTP_ABB_FIELD_MAX] = {
 };
 
 /**
- * Returns the pad field from an ACF_ABB message header.
- *
- * @param pdu Pointer to an ACF_ABB message.
- * @returns The value of the pad field.
- */
-OPEN1722_INLINE uint8_t Avtp_Abb_GetPad(const Avtp_Abb_t *const pdu)
-{
-    return (uint8_t)GET_ABB_FIELD(AVTP_ABB_FIELD_PAD);
-}
-
-/**
- * Sets the pad field in an ACF_ABB message header.
- *
- * @param pdu Pointer to an ACF_ABB message.
- * @param pad The value to set.
- */
-OPEN1722_INLINE void Avtp_Abb_SetPad(Avtp_Abb_t *pdu, uint8_t pad)
-{
-    SET_ABB_FIELD(AVTP_ABB_FIELD_PAD, pad);
-}
-
-/**
  * Returns the message timestamp valid flag (mtv) from an ACF_ABB message header.
  *
  * @param pdu Pointer to an ACF_ABB message.
@@ -443,7 +421,7 @@ OPEN1722_INLINE void Avtp_Abb_SetPayloadLength(Avtp_Abb_t *pdu, uint16_t payload
         memset(pdu->payload + payload_length, 0, pad);
     }
     uint16_t msgLenQuadlets = (uint16_t)((msgLenBytes + pad) / 4);
-    Avtp_Abb_SetPad(pdu, pad);
+    SET_ABB_FIELD(AVTP_ABB_FIELD_PAD, pad);
     Avtp_AcfCommon_SetAcfMsgLength((Avtp_AcfCommon_t *)pdu, msgLenQuadlets);
 }
 
@@ -460,7 +438,7 @@ OPEN1722_INLINE void Avtp_Abb_SetPayloadLength(Avtp_Abb_t *pdu, uint16_t payload
  */
 OPEN1722_INLINE uint8_t Avtp_Abb_GetPayloadLength(const Avtp_Abb_t *const pdu)
 {
-    uint8_t pad_length = Avtp_Abb_GetPad(pdu);
+    uint8_t pad_length = (uint8_t)GET_ABB_FIELD(AVTP_ABB_FIELD_PAD);
     uint16_t acf_length_bytes =
         Avtp_AcfCommon_GetAcfMsgLengthInBytes((const Avtp_AcfCommon_t *)pdu);
     return (uint8_t)(acf_length_bytes - AVTP_ABB_HEADER_LEN - pad_length);
@@ -541,7 +519,7 @@ OPEN1722_INLINE bool Avtp_Abb_IsValid(const Avtp_Abb_t *const pdu, size_t buffer
     /* The encoded message length must accommodate header + declared padding
      * so the payload computation in Avtp_Abb_GetPayloadLength() doesn't
      * underflow. */
-    uint8_t pad_length = Avtp_Abb_GetPad(pdu);
+    uint8_t pad_length = (uint8_t)GET_ABB_FIELD(AVTP_ABB_FIELD_PAD);
     uint16_t header_and_pad = (uint16_t)AVTP_ABB_HEADER_LEN + pad_length;
     if (msg_length_bytes < header_and_pad) {
         return false;

--- a/include/avtp/acf/Can.h
+++ b/include/avtp/acf/Can.h
@@ -110,17 +110,6 @@ static const Avtp_FieldDescriptor_t Avtp_CanFieldDesc[AVTP_CAN_FIELD_MAX] = {
 };
 
 /**
- * Return the value of an an ACF padding field as specified in the IEEE 1722 Specification.
- *
- * @param pdu Pointer to the first bit of an 1722 ACF CAN PDU.
- * @returns Value of the ACF padding field.
- */
-OPEN1722_INLINE uint8_t Avtp_Can_GetPad(const Avtp_Can_t *const pdu)
-{
-    return (uint8_t)GET_CAN_FIELD(AVTP_CAN_FIELD_PAD);
-}
-
-/**
  * Return the value of an an ACF CAN PDU MTV field as specified in the IEEE 1722 Specification.
  *
  * @param pdu Pointer to the first bit of an 1722 ACF CAN PDU.
@@ -220,17 +209,6 @@ OPEN1722_INLINE uint64_t Avtp_Can_GetMessageTimestamp(const Avtp_Can_t *const pd
 OPEN1722_INLINE uint32_t Avtp_Can_GetCanIdentifier(const Avtp_Can_t *const pdu)
 {
     return (uint32_t)GET_CAN_FIELD(AVTP_CAN_FIELD_CAN_IDENTIFIER);
-}
-
-/**
- * Set the value of an an ACF padding field as specified in the IEEE 1722 Specification.
- *
- * @param pdu Pointer to the first bit of an 1722 ACF CAN PDU.
- * @param value Value to set the ACF padding field to.
- */
-OPEN1722_INLINE void Avtp_Can_SetPad(Avtp_Can_t *pdu, uint8_t value)
-{
-    SET_CAN_FIELD(AVTP_CAN_FIELD_PAD, value);
 }
 
 /**
@@ -375,7 +353,8 @@ OPEN1722_INLINE void Avtp_Can_SetPayloadLength(Avtp_Can_t *can_pdu, uint16_t pay
         memset(can_pdu->payload + payload_length, 0, pad);
     }
     uint16_t msgLenQuadlets = (uint16_t)((msgLenBytes + pad) / 4);
-    Avtp_Can_SetPad(can_pdu, pad);
+    Avtp_SetField(Avtp_CanFieldDesc, AVTP_CAN_FIELD_MAX, (uint8_t *)can_pdu, AVTP_CAN_FIELD_PAD,
+                  pad);
     Avtp_AcfCommon_SetAcfMsgLength((Avtp_AcfCommon_t *)can_pdu, msgLenQuadlets);
 }
 
@@ -394,7 +373,7 @@ OPEN1722_INLINE void Avtp_Can_SetPayloadLength(Avtp_Can_t *can_pdu, uint16_t pay
  */
 OPEN1722_INLINE uint8_t Avtp_Can_GetPayloadLength(const Avtp_Can_t *const pdu)
 {
-    uint8_t pad_length = Avtp_Can_GetPad(pdu);
+    uint8_t pad_length = (uint8_t)GET_CAN_FIELD(AVTP_CAN_FIELD_PAD);
     uint16_t acf_length_bytes =
         Avtp_AcfCommon_GetAcfMsgLengthInBytes((const Avtp_AcfCommon_t *)pdu);
     return (uint8_t)(acf_length_bytes - AVTP_CAN_HEADER_LEN - pad_length);
@@ -479,7 +458,7 @@ OPEN1722_INLINE bool Avtp_Can_IsValid(const Avtp_Can_t *const pdu, size_t buffer
      * bytes (selected by the FDF bit). The encoded message length must
      * also accommodate header + declared padding so the payload
      * computation in Avtp_Can_GetPayloadLength() doesn't underflow. */
-    uint8_t pad_length = Avtp_Can_GetPad(pdu);
+    uint8_t pad_length = (uint8_t)GET_CAN_FIELD(AVTP_CAN_FIELD_PAD);
     uint16_t header_and_pad = (uint16_t)AVTP_CAN_HEADER_LEN + pad_length;
     if (msg_length_bytes < header_and_pad) {
         return false;

--- a/include/avtp/acf/CanBrief.h
+++ b/include/avtp/acf/CanBrief.h
@@ -108,17 +108,6 @@ static const Avtp_FieldDescriptor_t Avtp_CanBriefFieldDesc[AVTP_CAN_BRIEF_FIELD_
 };
 
 /**
- * Return the value of an an ACF padding field as specified in the IEEE 1722 Specification.
- *
- * @param pdu Pointer to the first bit of an 1722 ACF CAN Brief PDU.
- * @returns Value of the ACF padding field.
- */
-OPEN1722_INLINE uint8_t Avtp_CanBrief_GetPad(const Avtp_CanBrief_t *const pdu)
-{
-    return (uint8_t)GET_CAN_BRIEF_FIELD(AVTP_CAN_BRIEF_FIELD_PAD);
-}
-
-/**
  * Return the value of an an ACF CAN Brief PDU MTV field as specified in the IEEE 1722
  * Specification.
  *
@@ -212,17 +201,6 @@ OPEN1722_INLINE uint8_t Avtp_CanBrief_GetCanBusId(const Avtp_CanBrief_t *const p
 OPEN1722_INLINE uint32_t Avtp_CanBrief_GetCanIdentifier(const Avtp_CanBrief_t *const pdu)
 {
     return (uint32_t)GET_CAN_BRIEF_FIELD(AVTP_CAN_BRIEF_FIELD_CAN_IDENTIFIER);
-}
-
-/**
- * Set the value of an an ACF padding field as specified in the IEEE 1722 Specification.
- *
- * @param pdu Pointer to the first bit of an 1722 ACF CAN Brief PDU.
- * @param value Value to set the ACF padding field to.
- */
-OPEN1722_INLINE void Avtp_CanBrief_SetPad(Avtp_CanBrief_t *pdu, uint8_t value)
-{
-    SET_CAN_BRIEF_FIELD(AVTP_CAN_BRIEF_FIELD_PAD, value);
 }
 
 /**
@@ -357,7 +335,8 @@ OPEN1722_INLINE void Avtp_CanBrief_SetPayloadLength(Avtp_CanBrief_t *can_pdu,
         memset(can_pdu->payload + payload_length, 0, pad);
     }
     uint16_t msgLenQuadlets = (uint16_t)((msgLenBytes + pad) / 4);
-    Avtp_CanBrief_SetPad(can_pdu, pad);
+    Avtp_SetField(Avtp_CanBriefFieldDesc, AVTP_CAN_BRIEF_FIELD_MAX, (uint8_t *)can_pdu,
+                  AVTP_CAN_BRIEF_FIELD_PAD, pad);
     Avtp_AcfCommon_SetAcfMsgLength((Avtp_AcfCommon_t *)can_pdu, msgLenQuadlets);
 }
 
@@ -376,7 +355,7 @@ OPEN1722_INLINE void Avtp_CanBrief_SetPayloadLength(Avtp_CanBrief_t *can_pdu,
  */
 OPEN1722_INLINE uint8_t Avtp_CanBrief_GetPayloadLength(const Avtp_CanBrief_t *const pdu)
 {
-    uint8_t pad_length = Avtp_CanBrief_GetPad(pdu);
+    uint8_t pad_length = (uint8_t)GET_CAN_BRIEF_FIELD(AVTP_CAN_BRIEF_FIELD_PAD);
     uint16_t acf_length_bytes =
         Avtp_AcfCommon_GetAcfMsgLengthInBytes((const Avtp_AcfCommon_t *)pdu);
     return (uint8_t)(acf_length_bytes - AVTP_CAN_BRIEF_HEADER_LEN - pad_length);
@@ -461,7 +440,7 @@ OPEN1722_INLINE bool Avtp_CanBrief_IsValid(const Avtp_CanBrief_t *const pdu, siz
      * bytes (selected by the FDF bit). The encoded message length must
      * also accommodate header + declared padding so the payload
      * computation in Avtp_CanBrief_GetPayloadLength() doesn't underflow. */
-    uint8_t pad_length = Avtp_CanBrief_GetPad(pdu);
+    uint8_t pad_length = (uint8_t)GET_CAN_BRIEF_FIELD(AVTP_CAN_BRIEF_FIELD_PAD);
     uint16_t header_and_pad = (uint16_t)AVTP_CAN_BRIEF_HEADER_LEN + pad_length;
     if (msg_length_bytes < header_and_pad) {
         return false;

--- a/include/avtp/acf/CanBriefV2.h
+++ b/include/avtp/acf/CanBriefV2.h
@@ -109,28 +109,6 @@ static const Avtp_FieldDescriptor_t Avtp_CanBriefV2FieldDesc[AVTP_CAN_BRIEF_V2_F
 };
 
 /**
- * Returns the pad field from an ACF_CAN_BRIEF_V2 message header.
- *
- * @param pdu Pointer to an ACF_CAN_BRIEF_V2 message.
- * @returns The value of the pad field.
- */
-OPEN1722_INLINE uint8_t Avtp_CanBriefV2_GetPad(const Avtp_CanBriefV2_t *const pdu)
-{
-    return (uint8_t)GET_CAN_BRIEF_V2_FIELD(AVTP_CAN_BRIEF_V2_FIELD_PAD);
-}
-
-/**
- * Sets the pad field in an ACF_CAN_BRIEF_V2 message header.
- *
- * @param pdu Pointer to an ACF_CAN_BRIEF_V2 message.
- * @param pad The value to set.
- */
-OPEN1722_INLINE void Avtp_CanBriefV2_SetPad(Avtp_CanBriefV2_t *pdu, uint8_t pad)
-{
-    SET_CAN_BRIEF_V2_FIELD(AVTP_CAN_BRIEF_V2_FIELD_PAD, pad);
-}
-
-/**
  * Returns the message timestamp valid flag (mtv) from an ACF_CAN_BRIEF_V2 message header.
  *
  * @param pdu Pointer to an ACF_CAN_BRIEF_V2 message.
@@ -349,7 +327,7 @@ OPEN1722_INLINE void Avtp_CanBriefV2_SetPayloadLength(Avtp_CanBriefV2_t *pdu,
         memset(pdu->payload + payload_length, 0, pad);
     }
     uint16_t msgLenQuadlets = (uint16_t)((msgLenBytes + pad) / 4);
-    Avtp_CanBriefV2_SetPad(pdu, pad);
+    SET_CAN_BRIEF_V2_FIELD(AVTP_CAN_BRIEF_V2_FIELD_PAD, pad);
     Avtp_AcfCommon_SetAcfMsgLength((Avtp_AcfCommon_t *)pdu, msgLenQuadlets);
 }
 
@@ -368,7 +346,7 @@ OPEN1722_INLINE void Avtp_CanBriefV2_SetPayloadLength(Avtp_CanBriefV2_t *pdu,
  */
 OPEN1722_INLINE uint8_t Avtp_CanBriefV2_GetPayloadLength(const Avtp_CanBriefV2_t *const pdu)
 {
-    uint8_t pad_length = Avtp_CanBriefV2_GetPad(pdu);
+    uint8_t pad_length = (uint8_t)GET_CAN_BRIEF_V2_FIELD(AVTP_CAN_BRIEF_V2_FIELD_PAD);
     uint16_t acf_length_bytes =
         Avtp_AcfCommon_GetAcfMsgLengthInBytes((const Avtp_AcfCommon_t *)pdu);
     return (uint8_t)(acf_length_bytes - AVTP_CAN_BRIEF_V2_HEADER_LEN - pad_length);
@@ -453,7 +431,7 @@ OPEN1722_INLINE bool Avtp_CanBriefV2_IsValid(const Avtp_CanBriefV2_t *const pdu,
      * bytes (selected by the FDF bit). The encoded message length must
      * also accommodate header + declared padding so the payload
      * computation in Avtp_CanBriefV2_GetPayloadLength() doesn't underflow. */
-    uint8_t pad_length = Avtp_CanBriefV2_GetPad(pdu);
+    uint8_t pad_length = (uint8_t)GET_CAN_BRIEF_V2_FIELD(AVTP_CAN_BRIEF_V2_FIELD_PAD);
     uint16_t header_and_pad = (uint16_t)AVTP_CAN_BRIEF_V2_HEADER_LEN + pad_length;
     if (msg_length_bytes < header_and_pad) {
         return false;

--- a/include/avtp/acf/CanV2.h
+++ b/include/avtp/acf/CanV2.h
@@ -110,28 +110,6 @@ static const Avtp_FieldDescriptor_t Avtp_CanV2FieldDesc[AVTP_CAN_V2_FIELD_MAX] =
 };
 
 /**
- * Returns the pad field from an ACF_CAN_V2 message header.
- *
- * @param pdu Pointer to an ACF_CAN_V2 message.
- * @returns The value of the pad field.
- */
-OPEN1722_INLINE uint8_t Avtp_CanV2_GetPad(const Avtp_CanV2_t *const pdu)
-{
-    return (uint8_t)GET_CAN_V2_FIELD(AVTP_CAN_V2_FIELD_PAD);
-}
-
-/**
- * Sets the pad field in an ACF_CAN_V2 message header.
- *
- * @param pdu Pointer to an ACF_CAN_V2 message.
- * @param pad The value to set.
- */
-OPEN1722_INLINE void Avtp_CanV2_SetPad(Avtp_CanV2_t *pdu, uint8_t pad)
-{
-    SET_CAN_V2_FIELD(AVTP_CAN_V2_FIELD_PAD, pad);
-}
-
-/**
  * Returns the message timestamp valid flag (mtv) from an ACF_CAN_V2 message header.
  *
  * @param pdu Pointer to an ACF_CAN_V2 message.
@@ -370,7 +348,7 @@ OPEN1722_INLINE void Avtp_CanV2_SetPayloadLength(Avtp_CanV2_t *pdu, uint16_t pay
         memset(pdu->payload + payload_length, 0, pad);
     }
     uint16_t msgLenQuadlets = (uint16_t)((msgLenBytes + pad) / 4);
-    Avtp_CanV2_SetPad(pdu, pad);
+    SET_CAN_V2_FIELD(AVTP_CAN_V2_FIELD_PAD, pad);
     Avtp_AcfCommon_SetAcfMsgLength((Avtp_AcfCommon_t *)pdu, msgLenQuadlets);
 }
 
@@ -389,7 +367,7 @@ OPEN1722_INLINE void Avtp_CanV2_SetPayloadLength(Avtp_CanV2_t *pdu, uint16_t pay
  */
 OPEN1722_INLINE uint8_t Avtp_CanV2_GetPayloadLength(const Avtp_CanV2_t *const pdu)
 {
-    uint8_t pad_length = Avtp_CanV2_GetPad(pdu);
+    uint8_t pad_length = (uint8_t)GET_CAN_V2_FIELD(AVTP_CAN_V2_FIELD_PAD);
     uint16_t acf_length_bytes =
         Avtp_AcfCommon_GetAcfMsgLengthInBytes((const Avtp_AcfCommon_t *)pdu);
     return (uint8_t)(acf_length_bytes - AVTP_CAN_V2_HEADER_LEN - pad_length);
@@ -474,7 +452,7 @@ OPEN1722_INLINE bool Avtp_CanV2_IsValid(const Avtp_CanV2_t *const pdu, size_t bu
      * bytes (selected by the FDF bit). The encoded message length must
      * also accommodate header + declared padding so the payload
      * computation in Avtp_CanV2_GetPayloadLength() doesn't underflow. */
-    uint8_t pad_length = Avtp_CanV2_GetPad(pdu);
+    uint8_t pad_length = (uint8_t)GET_CAN_V2_FIELD(AVTP_CAN_V2_FIELD_PAD);
     uint16_t header_and_pad = (uint16_t)AVTP_CAN_V2_HEADER_LEN + pad_length;
     if (msg_length_bytes < header_and_pad) {
         return false;

--- a/include/avtp/acf/CanXl.h
+++ b/include/avtp/acf/CanXl.h
@@ -124,28 +124,6 @@ static const Avtp_FieldDescriptor_t Avtp_CanXlFieldDesc[AVTP_CANXL_FIELD_MAX] = 
 };
 
 /**
- * Returns the pad field from an ACF_CANXL message header.
- *
- * @param pdu Pointer to an ACF_CANXL message.
- * @returns The value of the pad field.
- */
-OPEN1722_INLINE uint8_t Avtp_CanXl_GetPad(const Avtp_CanXl_t *const pdu)
-{
-    return (uint8_t)GET_CANXL_FIELD(AVTP_CANXL_FIELD_PAD);
-}
-
-/**
- * Sets the pad field in an ACF_CANXL message header.
- *
- * @param pdu Pointer to an ACF_CANXL message.
- * @param pad The value to set.
- */
-OPEN1722_INLINE void Avtp_CanXl_SetPad(Avtp_CanXl_t *pdu, uint8_t pad)
-{
-    SET_CANXL_FIELD(AVTP_CANXL_FIELD_PAD, pad);
-}
-
-/**
  * Returns the message timestamp valid flag (mtv) from an ACF_CANXL message header.
  *
  * @param pdu Pointer to an ACF_CANXL message.
@@ -450,7 +428,7 @@ OPEN1722_INLINE void Avtp_CanXl_SetPayloadLength(Avtp_CanXl_t *pdu, uint16_t pay
         memset(pdu->payload + payload_length, 0, pad);
     }
     uint16_t msgLenQuadlets = (uint16_t)((msgLenBytes + pad) / 4);
-    Avtp_CanXl_SetPad(pdu, pad);
+    SET_CANXL_FIELD(AVTP_CANXL_FIELD_PAD, pad);
     Avtp_AcfCommon_SetAcfMsgLength((Avtp_AcfCommon_t *)pdu, msgLenQuadlets);
 }
 
@@ -467,7 +445,7 @@ OPEN1722_INLINE void Avtp_CanXl_SetPayloadLength(Avtp_CanXl_t *pdu, uint16_t pay
  */
 OPEN1722_INLINE uint8_t Avtp_CanXl_GetPayloadLength(const Avtp_CanXl_t *const pdu)
 {
-    uint8_t pad_length = Avtp_CanXl_GetPad(pdu);
+    uint8_t pad_length = (uint8_t)GET_CANXL_FIELD(AVTP_CANXL_FIELD_PAD);
     uint16_t acf_length_bytes =
         Avtp_AcfCommon_GetAcfMsgLengthInBytes((const Avtp_AcfCommon_t *)pdu);
     return (uint8_t)(acf_length_bytes - AVTP_CANXL_HEADER_LEN - pad_length);
@@ -547,7 +525,7 @@ OPEN1722_INLINE bool Avtp_CanXl_IsValid(const Avtp_CanXl_t *const pdu, size_t bu
     /* The encoded message length must accommodate header + declared padding
      * so the payload computation in Avtp_CanXl_GetPayloadLength() doesn't
      * underflow. */
-    uint8_t pad_length = Avtp_CanXl_GetPad(pdu);
+    uint8_t pad_length = (uint8_t)GET_CANXL_FIELD(AVTP_CANXL_FIELD_PAD);
     uint16_t header_and_pad = (uint16_t)AVTP_CANXL_HEADER_LEN + pad_length;
     if (msg_length_bytes < header_and_pad) {
         return false;

--- a/include/avtp/acf/CanXlBrief.h
+++ b/include/avtp/acf/CanXlBrief.h
@@ -124,28 +124,6 @@ static const Avtp_FieldDescriptor_t Avtp_CanXlBriefFieldDesc[AVTP_CANXL_BRIEF_FI
 };
 
 /**
- * Returns the pad field from an ACF_CAN_XL_BRIEF message header.
- *
- * @param pdu Pointer to an ACF_CAN_XL_BRIEF message.
- * @returns The value of the pad field.
- */
-OPEN1722_INLINE uint8_t Avtp_CanXlBrief_GetPad(const Avtp_CanXlBrief_t *const pdu)
-{
-    return (uint8_t)GET_CANXL_BRIEF_FIELD(AVTP_CANXL_BRIEF_FIELD_PAD);
-}
-
-/**
- * Sets the pad field in an ACF_CAN_XL_BRIEF message header.
- *
- * @param pdu Pointer to an ACF_CAN_XL_BRIEF message.
- * @param pad The value to set.
- */
-OPEN1722_INLINE void Avtp_CanXlBrief_SetPad(Avtp_CanXlBrief_t *pdu, uint8_t pad)
-{
-    SET_CANXL_BRIEF_FIELD(AVTP_CANXL_BRIEF_FIELD_PAD, pad);
-}
-
-/**
  * Returns the message timestamp valid flag (mtv) from an ACF_CAN_XL_BRIEF message header.
  *
  * @param pdu Pointer to an ACF_CAN_XL_BRIEF message.
@@ -431,7 +409,7 @@ OPEN1722_INLINE void Avtp_CanXlBrief_SetPayloadLength(Avtp_CanXlBrief_t *pdu,
         memset(pdu->payload + payload_length, 0, pad);
     }
     uint16_t msgLenQuadlets = (uint16_t)((msgLenBytes + pad) / 4);
-    Avtp_CanXlBrief_SetPad(pdu, pad);
+    SET_CANXL_BRIEF_FIELD(AVTP_CANXL_BRIEF_FIELD_PAD, pad);
     Avtp_AcfCommon_SetAcfMsgLength((Avtp_AcfCommon_t *)pdu, msgLenQuadlets);
 }
 
@@ -448,7 +426,7 @@ OPEN1722_INLINE void Avtp_CanXlBrief_SetPayloadLength(Avtp_CanXlBrief_t *pdu,
  */
 OPEN1722_INLINE uint8_t Avtp_CanXlBrief_GetPayloadLength(const Avtp_CanXlBrief_t *const pdu)
 {
-    uint8_t pad_length = Avtp_CanXlBrief_GetPad(pdu);
+    uint8_t pad_length = (uint8_t)GET_CANXL_BRIEF_FIELD(AVTP_CANXL_BRIEF_FIELD_PAD);
     uint16_t acf_length_bytes =
         Avtp_AcfCommon_GetAcfMsgLengthInBytes((const Avtp_AcfCommon_t *)pdu);
     return (uint8_t)(acf_length_bytes - AVTP_CANXL_BRIEF_HEADER_LEN - pad_length);
@@ -528,7 +506,7 @@ OPEN1722_INLINE bool Avtp_CanXlBrief_IsValid(const Avtp_CanXlBrief_t *const pdu,
     /* The encoded message length must accommodate header + declared padding
      * so the payload computation in Avtp_CanXlBrief_GetPayloadLength()
      * doesn't underflow. */
-    uint8_t pad_length = Avtp_CanXlBrief_GetPad(pdu);
+    uint8_t pad_length = (uint8_t)GET_CANXL_BRIEF_FIELD(AVTP_CANXL_BRIEF_FIELD_PAD);
     uint16_t header_and_pad = (uint16_t)AVTP_CANXL_BRIEF_HEADER_LEN + pad_length;
     if (msg_length_bytes < header_and_pad) {
         return false;

--- a/include/avtp/acf/FlexRay.h
+++ b/include/avtp/acf/FlexRay.h
@@ -111,18 +111,6 @@ static const Avtp_FieldDescriptor_t Avtp_FlexRayFieldDesc[AVTP_FLEXRAY_FIELD_MAX
 };
 
 /**
- * Return the value of an an ACF FlexRay PDU padding field as specified in the IEEE 1722
- * Specification.
- *
- * @param pdu Pointer to the first bit of an 1722 ACF FlexRay PDU.
- * @returns Value of the ACF FlexRay PDU padding field.
- */
-OPEN1722_INLINE uint8_t Avtp_FlexRay_GetPad(const Avtp_FlexRay_t *const pdu)
-{
-    return (uint8_t)GET_FLEXRAY_FIELD(AVTP_FLEXRAY_FIELD_PAD);
-}
-
-/**
  * Return the value of an an ACF FlexRay PDU MTV field as specified in the IEEE 1722 Specification.
  *
  * @param pdu Pointer to the first bit of an 1722 ACF FlexRay PDU.
@@ -235,17 +223,6 @@ OPEN1722_INLINE uint16_t Avtp_FlexRay_GetFrFrameId(const Avtp_FlexRay_t *const p
 OPEN1722_INLINE uint8_t Avtp_FlexRay_GetCycle(const Avtp_FlexRay_t *const pdu)
 {
     return (uint8_t)GET_FLEXRAY_FIELD(AVTP_FLEXRAY_FIELD_CYCLE);
-}
-
-/**
- * Set the value of an an ACF FlexRay PDU padding field as specified in the IEEE 1722 Specification.
- *
- * @param pdu Pointer to the first bit of an 1722 ACF FlexRay PDU.
- * @param value Value to set the ACF FlexRay PDU padding field to.
- */
-OPEN1722_INLINE void Avtp_FlexRay_SetPad(Avtp_FlexRay_t *pdu, uint8_t value)
-{
-    SET_FLEXRAY_FIELD(AVTP_FLEXRAY_FIELD_PAD, value);
 }
 
 /**
@@ -401,7 +378,7 @@ OPEN1722_INLINE void Avtp_FlexRay_SetPayloadLength(Avtp_FlexRay_t *pdu, uint16_t
         memset(pdu->payload + payload_length, 0, pad);
     }
     uint16_t msgLenQuadlets = (uint16_t)((msgLenBytes + pad) / 4);
-    Avtp_FlexRay_SetPad(pdu, pad);
+    SET_FLEXRAY_FIELD(AVTP_FLEXRAY_FIELD_PAD, pad);
     Avtp_AcfCommon_SetAcfMsgLength((Avtp_AcfCommon_t *)pdu, msgLenQuadlets);
 }
 
@@ -418,7 +395,7 @@ OPEN1722_INLINE void Avtp_FlexRay_SetPayloadLength(Avtp_FlexRay_t *pdu, uint16_t
  */
 OPEN1722_INLINE uint8_t Avtp_FlexRay_GetPayloadLength(const Avtp_FlexRay_t *const pdu)
 {
-    uint8_t pad_length = Avtp_FlexRay_GetPad(pdu);
+    uint8_t pad_length = (uint8_t)GET_FLEXRAY_FIELD(AVTP_FLEXRAY_FIELD_PAD);
     uint16_t acf_length_bytes =
         Avtp_AcfCommon_GetAcfMsgLengthInBytes((const Avtp_AcfCommon_t *)pdu);
     return (uint8_t)(acf_length_bytes - AVTP_FLEXRAY_HEADER_LEN - pad_length);
@@ -497,7 +474,7 @@ OPEN1722_INLINE bool Avtp_FlexRay_IsValid(const Avtp_FlexRay_t *const pdu, size_
     /* FlexRay payload-length invariant: the encoded message length must also
      * accommodate header + declared padding so the payload computation in
      * Avtp_FlexRay_GetPayloadLength() doesn't underflow. */
-    uint8_t pad_length = Avtp_FlexRay_GetPad(pdu);
+    uint8_t pad_length = (uint8_t)GET_FLEXRAY_FIELD(AVTP_FLEXRAY_FIELD_PAD);
     uint16_t header_and_pad = (uint16_t)AVTP_FLEXRAY_HEADER_LEN + pad_length;
     if (msg_length_bytes < header_and_pad) {
         return false;

--- a/include/avtp/acf/Gbb.h
+++ b/include/avtp/acf/Gbb.h
@@ -120,28 +120,6 @@ static const Avtp_FieldDescriptor_t Avtp_GbbFieldDesc[AVTP_GBB_FIELD_MAX] = {
 };
 
 /**
- * Returns the pad field from an ACF_GBB message header.
- *
- * @param pdu Pointer to an ACF_GBB message.
- * @returns The value of the pad field.
- */
-OPEN1722_INLINE uint8_t Avtp_Gbb_GetPad(const Avtp_Gbb_t *const pdu)
-{
-    return (uint8_t)GET_GBB_FIELD(AVTP_GBB_FIELD_PAD);
-}
-
-/**
- * Sets the pad field in an ACF_GBB message header.
- *
- * @param pdu Pointer to an ACF_GBB message.
- * @param pad The value to set.
- */
-OPEN1722_INLINE void Avtp_Gbb_SetPad(Avtp_Gbb_t *pdu, uint8_t pad)
-{
-    SET_GBB_FIELD(AVTP_GBB_FIELD_PAD, pad);
-}
-
-/**
  * Returns the message timestamp valid flag (mtv) from an ACF_GBB message header.
  *
  * @param pdu Pointer to an ACF_GBB message.
@@ -467,7 +445,7 @@ OPEN1722_INLINE void Avtp_Gbb_SetPayloadLength(Avtp_Gbb_t *pdu, uint16_t payload
         memset(pdu->payload + payload_length, 0, pad);
     }
     uint16_t msgLenQuadlets = (uint16_t)((msgLenBytes + pad) / 4);
-    Avtp_Gbb_SetPad(pdu, pad);
+    SET_GBB_FIELD(AVTP_GBB_FIELD_PAD, pad);
     Avtp_AcfCommon_SetAcfMsgLength((Avtp_AcfCommon_t *)pdu, msgLenQuadlets);
 }
 
@@ -484,7 +462,7 @@ OPEN1722_INLINE void Avtp_Gbb_SetPayloadLength(Avtp_Gbb_t *pdu, uint16_t payload
  */
 OPEN1722_INLINE uint8_t Avtp_Gbb_GetPayloadLength(const Avtp_Gbb_t *const pdu)
 {
-    uint8_t pad_length = Avtp_Gbb_GetPad(pdu);
+    uint8_t pad_length = (uint8_t)GET_GBB_FIELD(AVTP_GBB_FIELD_PAD);
     uint16_t acf_length_bytes =
         Avtp_AcfCommon_GetAcfMsgLengthInBytes((const Avtp_AcfCommon_t *)pdu);
     return (uint8_t)(acf_length_bytes - AVTP_GBB_HEADER_LEN - pad_length);
@@ -564,7 +542,7 @@ OPEN1722_INLINE bool Avtp_Gbb_IsValid(const Avtp_Gbb_t *const pdu, size_t buffer
     /* The encoded message length must accommodate header + declared padding
      * so the payload computation in Avtp_Gbb_GetPayloadLength() doesn't
      * underflow. */
-    uint8_t pad_length = Avtp_Gbb_GetPad(pdu);
+    uint8_t pad_length = (uint8_t)GET_GBB_FIELD(AVTP_GBB_FIELD_PAD);
     uint16_t header_and_pad = (uint16_t)AVTP_GBB_HEADER_LEN + pad_length;
     if (msg_length_bytes < header_and_pad) {
         return false;

--- a/include/avtp/acf/Gisf.h
+++ b/include/avtp/acf/Gisf.h
@@ -124,28 +124,6 @@ static const Avtp_FieldDescriptor_t Avtp_GisfFieldDesc[AVTP_GISF_FIELD_MAX] = {
 };
 
 /**
- * Returns the pad field from an ACF_GISF message header.
- *
- * @param pdu Pointer to an ACF_GISF message.
- * @returns The value of the pad field.
- */
-OPEN1722_INLINE uint8_t Avtp_Gisf_GetPad(const Avtp_Gisf_t *const pdu)
-{
-    return (uint8_t)GET_GISF_FIELD(AVTP_GISF_FIELD_PAD);
-}
-
-/**
- * Sets the pad field in an ACF_GISF message header.
- *
- * @param pdu Pointer to an ACF_GISF message.
- * @param pad The value to set.
- */
-OPEN1722_INLINE void Avtp_Gisf_SetPad(Avtp_Gisf_t *pdu, uint8_t pad)
-{
-    SET_GISF_FIELD(AVTP_GISF_FIELD_PAD, pad);
-}
-
-/**
  * Returns the message timestamp valid flag (mtv) from an ACF_GISF message header.
  *
  * @param pdu Pointer to an ACF_GISF message.
@@ -451,7 +429,7 @@ OPEN1722_INLINE void Avtp_Gisf_SetPayloadLength(Avtp_Gisf_t *pdu, uint16_t paylo
         memset(pdu->payload + payload_length, 0, pad);
     }
     uint16_t msgLenQuadlets = (uint16_t)((msgLenBytes + pad) / 4);
-    Avtp_Gisf_SetPad(pdu, pad);
+    SET_GISF_FIELD(AVTP_GISF_FIELD_PAD, pad);
     Avtp_AcfCommon_SetAcfMsgLength((Avtp_AcfCommon_t *)pdu, msgLenQuadlets);
 }
 
@@ -468,7 +446,7 @@ OPEN1722_INLINE void Avtp_Gisf_SetPayloadLength(Avtp_Gisf_t *pdu, uint16_t paylo
  */
 OPEN1722_INLINE uint16_t Avtp_Gisf_GetPayloadLength(const Avtp_Gisf_t *const pdu)
 {
-    uint8_t pad_length = Avtp_Gisf_GetPad(pdu);
+    uint8_t pad_length = (uint8_t)GET_GISF_FIELD(AVTP_GISF_FIELD_PAD);
     uint16_t acf_length_bytes =
         Avtp_AcfCommon_GetAcfMsgLengthInBytes((const Avtp_AcfCommon_t *)pdu);
     return (uint16_t)(acf_length_bytes - AVTP_GISF_HEADER_LEN - pad_length);
@@ -544,7 +522,7 @@ OPEN1722_INLINE bool Avtp_Gisf_IsValid(const Avtp_Gisf_t *const pdu, size_t buff
     /* The encoded message length must accommodate header + declared padding
      * so the payload computation in Avtp_Gisf_GetPayloadLength() doesn't
      * underflow. */
-    uint8_t pad_length = Avtp_Gisf_GetPad(pdu);
+    uint8_t pad_length = (uint8_t)GET_GISF_FIELD(AVTP_GISF_FIELD_PAD);
     uint16_t header_and_pad = (uint16_t)AVTP_GISF_HEADER_LEN + pad_length;
     if (msg_length_bytes < header_and_pad) {
         return false;

--- a/include/avtp/acf/Lin.h
+++ b/include/avtp/acf/Lin.h
@@ -95,17 +95,6 @@ static const Avtp_FieldDescriptor_t Avtp_LinFieldDesc[AVTP_LIN_FIELD_MAX] = {
 };
 
 /**
- * Returns the value of an an ACF Lin PDU Pad field as specified in the IEEE 1722 Specification.
- *
- * @param pdu Pointer to the first bit of an 1722 ACF Lin PDU.
- * @returns The value of the ACF Lin PDU Pad field.
- */
-OPEN1722_INLINE uint8_t Avtp_Lin_GetPad(const Avtp_Lin_t *const pdu)
-{
-    return (uint8_t)GET_LIN_FIELD(AVTP_LIN_FIELD_PAD);
-}
-
-/**
  * Returns the value of an an ACF Lin PDU MTV field as specified in the IEEE 1722 Specification.
  *
  * @param pdu Pointer to the first bit of an 1722 ACF Lin PDU.
@@ -150,17 +139,6 @@ OPEN1722_INLINE uint8_t Avtp_Lin_GetLinIdentifier(const Avtp_Lin_t *const pdu)
 OPEN1722_INLINE uint64_t Avtp_Lin_GetMessageTimestamp(const Avtp_Lin_t *const pdu)
 {
     return (uint64_t)GET_LIN_FIELD(AVTP_LIN_FIELD_MESSAGE_TIMESTAMP);
-}
-
-/**
- * Sets the value of an an ACF Lin PDU Pad field as specified in the IEEE 1722 Specification.
- *
- * @param pdu Pointer to the first bit of an 1722 ACF Lin PDU.
- * @param value Value to set the ACF Lin PDU Pad field to.
- */
-OPEN1722_INLINE void Avtp_Lin_SetPad(Avtp_Lin_t *pdu, uint8_t value)
-{
-    SET_LIN_FIELD(AVTP_LIN_FIELD_PAD, value);
 }
 
 /**
@@ -249,7 +227,8 @@ OPEN1722_INLINE void Avtp_Lin_SetPayloadLength(Avtp_Lin_t *lin_pdu, uint16_t pay
         memset(lin_pdu->payload + payload_length, 0, pad);
     }
     uint16_t msgLenQuadlets = (uint16_t)((msgLenBytes + pad) / 4);
-    Avtp_Lin_SetPad(lin_pdu, pad);
+    Avtp_SetField(Avtp_LinFieldDesc, AVTP_LIN_FIELD_MAX, (uint8_t *)lin_pdu, AVTP_LIN_FIELD_PAD,
+                  pad);
     Avtp_AcfCommon_SetAcfMsgLength((Avtp_AcfCommon_t *)lin_pdu, msgLenQuadlets);
 }
 
@@ -267,7 +246,7 @@ OPEN1722_INLINE void Avtp_Lin_SetPayloadLength(Avtp_Lin_t *lin_pdu, uint16_t pay
  */
 OPEN1722_INLINE uint8_t Avtp_Lin_GetPayloadLength(const Avtp_Lin_t *const pdu)
 {
-    uint8_t pad_length = Avtp_Lin_GetPad(pdu);
+    uint8_t pad_length = (uint8_t)GET_LIN_FIELD(AVTP_LIN_FIELD_PAD);
     uint16_t acf_length_bytes =
         Avtp_AcfCommon_GetAcfMsgLengthInBytes((const Avtp_AcfCommon_t *)pdu);
     return (uint8_t)(acf_length_bytes - AVTP_LIN_HEADER_LEN - pad_length);
@@ -348,7 +327,7 @@ OPEN1722_INLINE bool Avtp_Lin_IsValid(const Avtp_Lin_t *const pdu, size_t buffer
     /* LIN payload-length invariant: the encoded message length must also
      * accommodate header + declared padding so the payload computation in
      * Avtp_Lin_GetPayloadLength() doesn't underflow. */
-    uint8_t pad_length = Avtp_Lin_GetPad(pdu);
+    uint8_t pad_length = (uint8_t)GET_LIN_FIELD(AVTP_LIN_FIELD_PAD);
     uint16_t header_and_pad = (uint16_t)AVTP_LIN_HEADER_LEN + pad_length;
     if (msg_length_bytes < header_and_pad) {
         return false;

--- a/include/avtp/acf/Most.h
+++ b/include/avtp/acf/Most.h
@@ -107,17 +107,6 @@ static const Avtp_FieldDescriptor_t Avtp_MostFieldDesc[AVTP_MOST_FIELD_MAX] = {
 };
 
 /**
- * Return the value of an an ACF Most PDU padding field as specified in the IEEE 1722 Specification.
- *
- * @param pdu Pointer to the first bit of an 1722 ACF Most PDU.
- * @returns Value of the ACF Most PDU padding field.
- */
-OPEN1722_INLINE uint8_t Avtp_Most_GetPad(const Avtp_Most_t *const pdu)
-{
-    return (uint8_t)GET_MOST_FIELD(AVTP_MOST_FIELD_PAD);
-}
-
-/**
  * Return the value of an an ACF Most PDU MTV field as specified in the IEEE 1722 Specification.
  *
  * @param pdu Pointer to the first bit of an 1722 ACF Most PDU.
@@ -207,17 +196,6 @@ OPEN1722_INLINE uint16_t Avtp_Most_GetFuncId(const Avtp_Most_t *const pdu)
 OPEN1722_INLINE uint8_t Avtp_Most_GetOpType(const Avtp_Most_t *const pdu)
 {
     return (uint8_t)GET_MOST_FIELD(AVTP_MOST_FIELD_OP_TYPE);
-}
-
-/**
- * Set the value of an an ACF Most PDU padding field as specified in the IEEE 1722 Specification.
- *
- * @param pdu Pointer to the first bit of an 1722 ACF Most PDU.
- * @param value Value to set the ACF Most PDU padding field to.
- */
-OPEN1722_INLINE void Avtp_Most_SetPad(Avtp_Most_t *pdu, uint8_t value)
-{
-    SET_MOST_FIELD(AVTP_MOST_FIELD_PAD, value);
 }
 
 /**
@@ -350,7 +328,7 @@ OPEN1722_INLINE void Avtp_Most_SetPayloadLength(Avtp_Most_t *pdu, uint16_t paylo
         memset(pdu->payload + payload_length, 0, pad);
     }
     uint16_t msgLenQuadlets = (uint16_t)((msgLenBytes + pad) / 4);
-    Avtp_Most_SetPad(pdu, pad);
+    SET_MOST_FIELD(AVTP_MOST_FIELD_PAD, pad);
     Avtp_AcfCommon_SetAcfMsgLength((Avtp_AcfCommon_t *)pdu, msgLenQuadlets);
 }
 
@@ -367,7 +345,7 @@ OPEN1722_INLINE void Avtp_Most_SetPayloadLength(Avtp_Most_t *pdu, uint16_t paylo
  */
 OPEN1722_INLINE uint8_t Avtp_Most_GetPayloadLength(const Avtp_Most_t *const pdu)
 {
-    uint8_t pad_length = Avtp_Most_GetPad(pdu);
+    uint8_t pad_length = (uint8_t)GET_MOST_FIELD(AVTP_MOST_FIELD_PAD);
     uint16_t acf_length_bytes =
         Avtp_AcfCommon_GetAcfMsgLengthInBytes((const Avtp_AcfCommon_t *)pdu);
     return (uint8_t)(acf_length_bytes - AVTP_MOST_HEADER_LEN - pad_length);
@@ -453,7 +431,7 @@ OPEN1722_INLINE bool Avtp_Most_IsValid(const Avtp_Most_t *const pdu, size_t buff
     /* The encoded message length must accommodate header + declared padding
      * so the payload computation in Avtp_Most_GetPayloadLength() doesn't
      * underflow. */
-    uint8_t pad_length = Avtp_Most_GetPad(pdu);
+    uint8_t pad_length = (uint8_t)GET_MOST_FIELD(AVTP_MOST_FIELD_PAD);
     uint16_t header_and_pad = (uint16_t)AVTP_MOST_HEADER_LEN + pad_length;
     if (msg_length_bytes < header_and_pad) {
         return false;

--- a/include/avtp/acf/custom/Vss.h
+++ b/include/avtp/acf/custom/Vss.h
@@ -242,7 +242,6 @@ void Avtp_Vss_SetField(Avtp_Vss_t *pdu, Avtp_VssFields_t field, uint64_t value);
 void Avtp_Vss_SetPayloadLength(Avtp_Vss_t *pdu, uint16_t payload_length);
 
 /* Getter and Setter Functions*/
-uint8_t Avtp_Vss_GetPad(const Avtp_Vss_t *const pdu);
 bool Avtp_Vss_IsMtv(const Avtp_Vss_t *const pdu);
 Vss_AddrMode_t Avtp_Vss_GetAddrMode(const Avtp_Vss_t *const pdu);
 Vss_OpCode_t Avtp_Vss_GetOpCode(const Avtp_Vss_t *const pdu);
@@ -254,7 +253,6 @@ uint16_t Avtp_Vss_GetVSSDataStringArrayLength(const VssDataStringArray_t *str_ar
 uint16_t Avtp_Vss_CalcVssPathLength(const Avtp_Vss_t *const pdu);
 void Avtp_Vss_DeserializeStringArray(const VssDataStringArray_t *const vss_data_string_array,
                                      VssDataString_t *strings[], uint16_t num_strings);
-void Avtp_Vss_SetPad(Avtp_Vss_t *pdu, uint8_t val);
 void Avtp_Vss_SetMtv(Avtp_Vss_t *pdu, bool mtv);
 void Avtp_Vss_SetAddrMode(Avtp_Vss_t *pdu, Vss_AddrMode_t val);
 void Avtp_Vss_SetOpCode(Avtp_Vss_t *pdu, Vss_OpCode_t val);

--- a/src/avtp/acf/custom/Vss.c
+++ b/src/avtp/acf/custom/Vss.c
@@ -166,11 +166,6 @@ void Avtp_Vss_SetPayloadLength(Avtp_Vss_t *vss_pdu, uint16_t payload_length)
     Avtp_Vss_SetField(vss_pdu, AVTP_VSS_FIELD_PAD, padSize);
 }
 
-uint8_t Avtp_Vss_GetPad(const Avtp_Vss_t *const pdu)
-{
-    return (uint8_t)GET_FIELD(AVTP_VSS_FIELD_PAD);
-}
-
 bool Avtp_Vss_IsMtv(const Avtp_Vss_t *const pdu)
 {
     return (bool)GET_FIELD(AVTP_VSS_FIELD_MTV);
@@ -503,11 +498,6 @@ void Avtp_Vss_GetVssData(const Avtp_Vss_t *const pdu, VssData_t *val)
     default:
         break;
     }
-}
-
-void Avtp_Vss_SetPad(Avtp_Vss_t *pdu, uint8_t val)
-{
-    SET_FIELD(AVTP_VSS_FIELD_PAD, val);
 }
 
 void Avtp_Vss_SetMtv(Avtp_Vss_t *pdu, bool mtv)

--- a/unit/test-abb.c
+++ b/unit/test-abb.c
@@ -55,14 +55,6 @@ static void Test_Abb_Init(void **state)
     assert_memory_equal(msg, expected_msg, msg_len);
 }
 
-static void Test_Abb_GetPad(void **state)
-{
-    const size_t msg_len = AVTP_ABB_HEADER_LEN + 4;
-    uint8_t msg[msg_len] = {0x1C, 0x02, 0xC0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0};
-    Avtp_Abb_t *abb = (Avtp_Abb_t *)msg;
-    assert_int_equal(Avtp_Abb_GetPad(abb), 3);
-}
-
 static void Test_Abb_IsMtv(void **state)
 {
     const size_t msg_len = AVTP_ABB_HEADER_LEN + 4;
@@ -425,7 +417,6 @@ static void Test_Abb_IsValid(void **state)
 int main(void)
 {
     const struct CMUnitTest tests[] = {cmocka_unit_test(Test_Abb_Init),
-                                       cmocka_unit_test(Test_Abb_GetPad),
                                        cmocka_unit_test(Test_Abb_IsMtv),
                                        cmocka_unit_test(Test_Abb_GetByteBusId),
                                        cmocka_unit_test(Test_Abb_GetEvt),

--- a/unit/test-can-brief-v2.c
+++ b/unit/test-can-brief-v2.c
@@ -55,14 +55,6 @@ static void Test_CanBriefV2_Init(void **state)
     assert_memory_equal(msg, expected_msg, msg_len);
 }
 
-static void Test_CanBriefV2_GetPad(void **state)
-{
-    const size_t msg_len = AVTP_CAN_BRIEF_V2_HEADER_LEN + 4;
-    uint8_t msg[msg_len] = {0x44, 0x02, 0xC0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0};
-    Avtp_CanBriefV2_t *canV2 = (Avtp_CanBriefV2_t *)msg;
-    assert_int_equal(Avtp_CanBriefV2_GetPad(canV2), 3);
-}
-
 static void Test_CanBriefV2_IsMtv(void **state)
 {
     const size_t msg_len = AVTP_CAN_BRIEF_V2_HEADER_LEN + 4;
@@ -376,7 +368,6 @@ static void Test_CanBriefV2_CreateFromGarbage(void **state)
 int main(void)
 {
     const struct CMUnitTest tests[] = {cmocka_unit_test(Test_CanBriefV2_Init),
-                                       cmocka_unit_test(Test_CanBriefV2_GetPad),
                                        cmocka_unit_test(Test_CanBriefV2_IsMtv),
                                        cmocka_unit_test(Test_CanBriefV2_IsRtr),
                                        cmocka_unit_test(Test_CanBriefV2_IsEff),

--- a/unit/test-can-v2.c
+++ b/unit/test-can-v2.c
@@ -56,15 +56,6 @@ static void Test_CanV2_Init(void **state)
     assert_memory_equal(msg, expected_msg, msg_len);
 }
 
-static void Test_CanV2_GetPad(void **state)
-{
-    const size_t msg_len = AVTP_CAN_V2_HEADER_LEN + 4;
-    uint8_t msg[msg_len] = {0x42, 0x04, 0xC0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0,
-                            0x0,  0x0,  0x0,  0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0};
-    Avtp_CanV2_t *canV2 = (Avtp_CanV2_t *)msg;
-    assert_int_equal(Avtp_CanV2_GetPad(canV2), 3);
-}
-
 static void Test_CanV2_IsMtv(void **state)
 {
     const size_t msg_len = AVTP_CAN_V2_HEADER_LEN + 4;
@@ -422,7 +413,6 @@ static void Test_CanV2_IsValid(void **state)
 int main(void)
 {
     const struct CMUnitTest tests[] = {cmocka_unit_test(Test_CanV2_Init),
-                                       cmocka_unit_test(Test_CanV2_GetPad),
                                        cmocka_unit_test(Test_CanV2_IsMtv),
                                        cmocka_unit_test(Test_CanV2_IsRtr),
                                        cmocka_unit_test(Test_CanV2_IsEff),

--- a/unit/test-can.c
+++ b/unit/test-can.c
@@ -94,7 +94,7 @@ static void can_set_payload(void **state)
     // Set payload and check for EFF
     Avtp_Can_CreateAcfMessage((Avtp_Can_t *)pdu, set_frame_id, set_payload, CAN_PAYLOAD_SIZE,
                               AVTP_CAN_CLASSIC);
-    assert_int_equal(htonl(set_frame_id), (uint32_t)*((int *)pdu + 3));
+    assert_int_equal(htonl(set_frame_id), *((uint32_t *)pdu + 3));
     assert_memory_equal(set_payload, pdu + 16, CAN_PAYLOAD_SIZE);
     assert_int_equal(0x0, *(pdu + 2) & 0x08); // Check EFF
 
@@ -102,7 +102,7 @@ static void can_set_payload(void **state)
     set_frame_id = 0x800;
     Avtp_Can_CreateAcfMessage((Avtp_Can_t *)pdu, set_frame_id, set_payload, CAN_PAYLOAD_SIZE,
                               AVTP_CAN_CLASSIC);
-    assert_int_equal(htonl(set_frame_id), (uint32_t)*((int *)pdu + 3));
+    assert_int_equal(htonl(set_frame_id), *((uint32_t *)pdu + 3));
     assert_int_equal(0x8, *(pdu + 2) & 0x08); // Check EFF
 
     // Check padding bytes and length field

--- a/unit/test-can.c
+++ b/unit/test-can.c
@@ -94,7 +94,7 @@ static void can_set_payload(void **state)
     // Set payload and check for EFF
     Avtp_Can_CreateAcfMessage((Avtp_Can_t *)pdu, set_frame_id, set_payload, CAN_PAYLOAD_SIZE,
                               AVTP_CAN_CLASSIC);
-    assert_int_equal(htonl(set_frame_id), (uint32_t) * ((int *)pdu + 3));
+    assert_int_equal(htonl(set_frame_id), (uint32_t)*((int *)pdu + 3));
     assert_memory_equal(set_payload, pdu + 16, CAN_PAYLOAD_SIZE);
     assert_int_equal(0x0, *(pdu + 2) & 0x08); // Check EFF
 
@@ -102,7 +102,7 @@ static void can_set_payload(void **state)
     set_frame_id = 0x800;
     Avtp_Can_CreateAcfMessage((Avtp_Can_t *)pdu, set_frame_id, set_payload, CAN_PAYLOAD_SIZE,
                               AVTP_CAN_CLASSIC);
-    assert_int_equal(htonl(set_frame_id), (uint32_t) * ((int *)pdu + 3));
+    assert_int_equal(htonl(set_frame_id), (uint32_t)*((int *)pdu + 3));
     assert_int_equal(0x8, *(pdu + 2) & 0x08); // Check EFF
 
     // Check padding bytes and length field
@@ -228,7 +228,9 @@ static void can_brief_set_payload(void **state)
 
         uint16_t msgLenBytes = AVTP_CAN_BRIEF_HEADER_LEN + i;
         uint8_t pad = (uint8_t)(4 - (msgLenBytes % 4)) % 4;
-        assert_int_equal(Avtp_CanBrief_GetPad((Avtp_CanBrief_t *)pdu), pad);
+        assert_int_equal(Avtp_GetField(Avtp_CanBriefFieldDesc, AVTP_CAN_BRIEF_FIELD_MAX,
+                                       (const uint8_t *)pdu, AVTP_CAN_BRIEF_FIELD_PAD),
+                         pad);
         assert_int_equal(Avtp_AcfCommon_GetAcfMsgLength((Avtp_AcfCommon_t *)pdu),
                          (msgLenBytes + pad) / 4);
     }

--- a/unit/test-canxl-brief.c
+++ b/unit/test-canxl-brief.c
@@ -56,15 +56,6 @@ static void Test_CanXlBrief_Init(void **state)
     assert_memory_equal(msg, expected_msg, msg_len);
 }
 
-static void Test_CanXlBrief_GetPad(void **state)
-{
-    const size_t msg_len = AVTP_CANXL_BRIEF_HEADER_LEN + 4;
-    uint8_t msg[msg_len] = {0x24, 0x04, 0xC0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0,
-                            0x0,  0x0,  0x0,  0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0};
-    Avtp_CanXlBrief_t *canxl = (Avtp_CanXlBrief_t *)msg;
-    assert_int_equal(Avtp_CanXlBrief_GetPad(canxl), 3);
-}
-
 static void Test_CanXlBrief_IsMtv(void **state)
 {
     const size_t msg_len = AVTP_CANXL_BRIEF_HEADER_LEN + 4;
@@ -438,7 +429,6 @@ static void Test_CanXlBrief_IsValid(void **state)
 int main(void)
 {
     const struct CMUnitTest tests[] = {cmocka_unit_test(Test_CanXlBrief_Init),
-                                       cmocka_unit_test(Test_CanXlBrief_GetPad),
                                        cmocka_unit_test(Test_CanXlBrief_IsMtv),
                                        cmocka_unit_test(Test_CanXlBrief_GetCanBusId),
                                        cmocka_unit_test(Test_CanXlBrief_GetVcid),

--- a/unit/test-canxl.c
+++ b/unit/test-canxl.c
@@ -57,16 +57,6 @@ static void Test_CanXl_Init(void **state)
     assert_memory_equal(msg, expected_msg, msg_len);
 }
 
-static void Test_CanXl_GetPad(void **state)
-{
-    const size_t msg_len = AVTP_CANXL_HEADER_LEN + 4;
-    uint8_t msg[msg_len] = {0x22, 0x06, 0xC0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0,
-                            0x0,  0x0,  0x0,  0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0,
-                            0x0,  0x0,  0x0,  0x0, 0x0, 0x0, 0x0, 0x0};
-    Avtp_CanXl_t *canxl = (Avtp_CanXl_t *)msg;
-    assert_int_equal(Avtp_CanXl_GetPad(canxl), 3);
-}
-
 static void Test_CanXl_IsMtv(void **state)
 {
     const size_t msg_len = AVTP_CANXL_HEADER_LEN + 4;
@@ -486,7 +476,6 @@ static void Test_CanXl_IsValid(void **state)
 int main(void)
 {
     const struct CMUnitTest tests[] = {cmocka_unit_test(Test_CanXl_Init),
-                                       cmocka_unit_test(Test_CanXl_GetPad),
                                        cmocka_unit_test(Test_CanXl_IsMtv),
                                        cmocka_unit_test(Test_CanXl_GetCanBusId),
                                        cmocka_unit_test(Test_CanXl_GetMessageTimestamp),

--- a/unit/test-flexray.c
+++ b/unit/test-flexray.c
@@ -68,9 +68,6 @@ static void flexray_get_set_fields(void **state)
     Avtp_AcfCommon_SetAcfMsgLength((Avtp_AcfCommon_t *)pdu, 100);
     assert_int_equal(Avtp_AcfCommon_GetAcfMsgLength((Avtp_AcfCommon_t *)pdu), 100);
 
-    Avtp_FlexRay_SetPad((Avtp_FlexRay_t *)pdu, 2);
-    assert_int_equal(Avtp_FlexRay_GetPad((Avtp_FlexRay_t *)pdu), 2);
-
     Avtp_FlexRay_SetMtv((Avtp_FlexRay_t *)pdu, true);
     assert_int_equal(Avtp_FlexRay_IsMtv((Avtp_FlexRay_t *)pdu), 1);
 

--- a/unit/test-gbb.c
+++ b/unit/test-gbb.c
@@ -56,15 +56,6 @@ static void Test_Gbb_Init(void **state)
     assert_memory_equal(msg, expected_msg, msg_len);
 }
 
-static void Test_Gbb_GetPad(void **state)
-{
-    const size_t msg_len = AVTP_GBB_HEADER_LEN + 4;
-    uint8_t msg[msg_len] = {0x1A, 0x04, 0xC0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0,
-                            0x0,  0x0,  0x0,  0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0};
-    Avtp_Gbb_t *gbb = (Avtp_Gbb_t *)msg;
-    assert_int_equal(Avtp_Gbb_GetPad(gbb), 3);
-}
-
 static void Test_Gbb_IsMtv(void **state)
 {
     const size_t msg_len = AVTP_GBB_HEADER_LEN + 4;
@@ -480,7 +471,6 @@ static void Test_Gbb_IsValid(void **state)
 int main(void)
 {
     const struct CMUnitTest tests[] = {cmocka_unit_test(Test_Gbb_Init),
-                                       cmocka_unit_test(Test_Gbb_GetPad),
                                        cmocka_unit_test(Test_Gbb_IsMtv),
                                        cmocka_unit_test(Test_Gbb_GetByteBusId),
                                        cmocka_unit_test(Test_Gbb_GetMessageTimestamp),

--- a/unit/test-gisf.c
+++ b/unit/test-gisf.c
@@ -55,17 +55,6 @@ static void Test_Gisf_Init(void **state)
     assert_memory_equal(msg, expected_msg, msg_len);
 }
 
-static void Test_Gisf_GetPad(void **state)
-{
-    const size_t msg_len = AVTP_GISF_HEADER_LEN + 4;
-    uint8_t msg[msg_len] = {
-        0x18, 0x06, 0xC0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0,
-        0x0,  0x0,  0x0,  0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0,
-    };
-    Avtp_Gisf_t *gisf = (Avtp_Gisf_t *)msg;
-    assert_int_equal(Avtp_Gisf_GetPad(gisf), 3);
-}
-
 static void Test_Gisf_IsMtv(void **state)
 {
     const size_t msg_len = AVTP_GISF_HEADER_LEN + 4;
@@ -488,7 +477,6 @@ static void Test_Gisf_IsValid(void **state)
 int main(void)
 {
     const struct CMUnitTest tests[] = {cmocka_unit_test(Test_Gisf_Init),
-                                       cmocka_unit_test(Test_Gisf_GetPad),
                                        cmocka_unit_test(Test_Gisf_IsMtv),
                                        cmocka_unit_test(Test_Gisf_GetImageSensorId),
                                        cmocka_unit_test(Test_Gisf_GetMessageTimestamp),

--- a/unit/test-lin.c
+++ b/unit/test-lin.c
@@ -68,9 +68,6 @@ static void lin_get_set_fields(void **state)
     Avtp_AcfCommon_SetAcfMsgLength((Avtp_AcfCommon_t *)pdu, 50);
     assert_int_equal(Avtp_AcfCommon_GetAcfMsgLength((Avtp_AcfCommon_t *)pdu), 50);
 
-    Avtp_Lin_SetPad((Avtp_Lin_t *)pdu, 3);
-    assert_int_equal(Avtp_Lin_GetPad((Avtp_Lin_t *)pdu), 3);
-
     Avtp_Lin_SetMtv((Avtp_Lin_t *)pdu, true);
     assert_int_equal(Avtp_Lin_IsMtv((Avtp_Lin_t *)pdu), 1);
 

--- a/unit/test-most.c
+++ b/unit/test-most.c
@@ -68,9 +68,6 @@ static void most_get_set_fields(void **state)
     Avtp_AcfCommon_SetAcfMsgLength((Avtp_AcfCommon_t *)pdu, 120);
     assert_int_equal(Avtp_AcfCommon_GetAcfMsgLength((Avtp_AcfCommon_t *)pdu), 120);
 
-    Avtp_Most_SetPad((Avtp_Most_t *)pdu, 1);
-    assert_int_equal(Avtp_Most_GetPad((Avtp_Most_t *)pdu), 1);
-
     Avtp_Most_SetMtv((Avtp_Most_t *)pdu, true);
     assert_int_equal(Avtp_Most_IsMtv((Avtp_Most_t *)pdu), 1);
 

--- a/unit/test-vss.c
+++ b/unit/test-vss.c
@@ -81,7 +81,7 @@ static void vss_pad(void **state)
         uint8_t vss_quadlets = Avtp_AcfCommon_GetAcfMsgLength((Avtp_AcfCommon_t *)vss_pdu);
         assert_int_equal(vss_quadlets, AVTP_VSS_FIXED_HEADER_LEN / 4 + 1);
 
-        uint8_t vss_pad = Avtp_Vss_GetPad(vss_pdu);
+        uint8_t vss_pad = (uint8_t)Avtp_Vss_GetField(vss_pdu, AVTP_VSS_FIELD_PAD);
         assert_int_equal(vss_pad, 4 - i);
     }
 }


### PR DESCRIPTION
This will fix #191 

Also updated documentation, so the non existing Pad functions do not pop up in the examples anymore. Also added some lines why pad has no direct accessors anymore.


There is a minor change in CI script: I noticed clang-format 18 and 21 treat some rules differently, so there could be a mismatch between checking locally and in CI. I did pin 18 now in CI and formatted for that, so at least it is defined now. 