### PR TITLE
Fix VSS out-of-bounds read

### DIFF
--- a/docs/api-design.md
+++ b/docs/api-design.md
@@ -36,7 +36,7 @@ reading either half of this document.
 Function, type and field names are taken directly from the IEEE 1722
 specification. The guiding idea is: **if you have read and understood the spec,
 you can use Open1722 directly** - the mapping from a spec field to the
-corresponding API call is mechanical. 
+corresponding API call is mechanical.
 
 For example, the ACF CAN header contains the fields `pad`, `mtv`, `rtr`, `eff`,
 `brs`, `fdf`, `esi`, `can_bus_id`, `message_timestamp` and `can_identifier`.
@@ -221,8 +221,10 @@ if (Avtp_Can_IsValid(pdu, buffer_size)) {
 
 > **General rule, with exceptions.** This assume-valid model is the norm. Where
 > it does not hold - because a format's validity check would be expensive or
-> complex - the accessors perform their own bounds checking instead. See
-> [Exceptions to the rules](#exceptions-to-the-rules).
+> complex - the accessors perform their own bounds checking instead. VSS is
+> such an exception: its `IsValid` covers buffer containment but deliberately
+> not semantic validity, so its accessors stay self-checking even after
+> validation. See [Exceptions to the rules](#exceptions-to-the-rules).
 
 ## Convenience functions
 
@@ -489,6 +491,9 @@ A format provides an `IsValid` function as an inline accessor in its header. It
 checks (1) that the length field is contained within the actual buffer, and (2)
 any format-specific invariants. See
 [Accessor semantics & the safety contract](#accessor-semantics--the-safety-contract).
+The one exception is the custom VSS format, whose non-inline `IsValid` checks
+containment only (not the variable-length path/payload structure) - see
+[Exceptions to the rules](#exceptions-to-the-rules).
 
 ```c
 bool Avtp_Can_IsValid(const Avtp_Can_t *const pdu, size_t bufferSize);
@@ -610,10 +615,20 @@ IEEE 1722 standard and which carries variable-length, length-prefixed data.
 
 For VSS:
 
-- A cheap `IsValid` is not practical - verifying a VSS frame would require
-  walking variable-length paths and payloads. So VSS accessors instead perform
-  their own bounds checking, clamping reads against the *declared* message
-  length so a malformed frame cannot cause an overread.
+- VSS offers an `IsValid` function, but deliberately as a *shallow* check.
+  `Avtp_Vss_IsValid(pdu, bufferSize)` verifies the frame envelope only -
+  correct ACF message type, a buffer that covers the fixed header, and a
+  declared message length of at least the fixed header that also fits the
+  actual `bufferSize`. That makes the buffer-containment half of the safety
+  contract hold: after `IsValid` returns true, no VSS accessor can overread
+  the buffer. `IsValid` does **not** walk the variable-length path and
+  payload structure, so `true` does not mean the frame is semantically
+  well-formed.
+- VSS accessors therefore remain self-checking: reads are clamped against the
+  *declared* message length, and truncated or internally inconsistent fields
+  (e.g. a path or data length prefix that exceeds the declared message)
+  no-op or return conservative values instead of trusting the wire data. The
+  remaining validation lives in the getters, not in `IsValid`.
 - Because of that complexity, VSS accessors are implemented in the `.c` file
   (non-inline) rather than as inline header functions.
 

--- a/examples/acf-vss/acf-vss-listener.c
+++ b/examples/acf-vss/acf-vss-listener.c
@@ -45,8 +45,8 @@
 #include "avtp/acf/custom/Vss.h"
 #include "avtp/CommonHeader.h"
 
-#define MAX_PDU_SIZE                1500
-#define MAX_MSG_SIZE                100
+#define MAX_PDU_SIZE 1500
+#define MAX_MSG_SIZE 100
 
 static char ifname[IFNAMSIZ];
 static uint8_t macaddr[ETH_ALEN];
@@ -57,9 +57,8 @@ static struct argp_option options[] = {
     {"port", 'p', "UDP_PORT", 0, "UDP Port to listen on if UDP enabled"},
     {"udp", 'u', 0, 0, "Use UDP"},
     {"dst-mac-address", 0, 0, OPTION_DOC, "Stream destination MAC address (If Ethernet)"},
-    {"ifname", 0, 0, OPTION_DOC, "Network interface (If Ethernet)" },
-    { 0 }
-};
+    {"ifname", 0, 0, OPTION_DOC, "Network interface (If Ethernet)"},
+    {0}};
 
 static error_t parser(int key, char *arg, struct argp_state *state)
 {
@@ -78,19 +77,17 @@ static error_t parser(int key, char *arg, struct argp_state *state)
 
     case ARGP_KEY_ARG:
 
-        if(state->argc < 2){
+        if (state->argc < 2) {
             argp_usage(state);
         }
 
-        if(!use_udp){
+        if (!use_udp) {
 
             strncpy(ifname, arg, sizeof(ifname) - 1);
 
-            if(state->next < state->argc)
-            {
-                res = sscanf(state->argv[state->next], "%hhx:%hhx:%hhx:%hhx:%hhx:%hhx",
-                        &macaddr[0], &macaddr[1], &macaddr[2],
-                        &macaddr[3], &macaddr[4], &macaddr[5]);
+            if (state->next < state->argc) {
+                res = sscanf(state->argv[state->next], "%hhx:%hhx:%hhx:%hhx:%hhx:%hhx", &macaddr[0],
+                             &macaddr[1], &macaddr[2], &macaddr[3], &macaddr[4], &macaddr[5]);
                 if (res != 6) {
                     fprintf(stderr, "Invalid MAC address\n\n");
                     argp_usage(state);
@@ -107,15 +104,14 @@ static error_t parser(int key, char *arg, struct argp_state *state)
 
 static char args_doc[] = "[ifname] dst-mac-address";
 
-static struct argp argp = { options, parser, args_doc, 0};
+static struct argp argp = {options, parser, args_doc, 0};
 
 int main(int argc, char *argv[])
 {
     int sk_fd, res;
     uint64_t proc_bytes = 0, msg_proc_bytes = 0;
     uint32_t udp_seq_num;
-    uint16_t msg_length, acf_msg_length;
-    uint8_t subtype, acf_type;
+    uint8_t subtype;
     uint64_t flag;
     uint8_t pdu[MAX_PDU_SIZE];
     uint8_t *cf_pdu, *acf_pdu, *udp_pdu;
@@ -152,19 +148,23 @@ int main(int argc, char *argv[])
         }
 
         // Check if the packet is a control format packet (i.e. NTSCF or TSCF)
-        subtype = Avtp_CommonHeader_GetSubtype((Avtp_CommonHeader_t*)cf_pdu);
-        if (subtype == AVTP_SUBTYPE_TSCF){
+        subtype = Avtp_CommonHeader_GetSubtype((Avtp_CommonHeader_t *)cf_pdu);
+        if (subtype == AVTP_SUBTYPE_TSCF) {
             proc_bytes += AVTP_TSCF_HEADER_LEN;
-            msg_length = Avtp_Tscf_GetStreamDataLength((Avtp_Tscf_t*)cf_pdu);
         } else {
             proc_bytes += AVTP_NTSCF_HEADER_LEN;
-            msg_length = Avtp_Ntscf_GetNtscfDataLength((Avtp_Ntscf_t*)cf_pdu);
         }
 
-        // Check if the control packet payload is a ACF GPC.
+        // Ignore frames that do not even contain the parsed headers
+        if ((uint64_t)res < proc_bytes) {
+            continue;
+        }
+
+        // Check if the control packet payload is an ACF VSS GPC. The declared
+        // ACF message length is untrusted, so only accept the message when it
+        // actually fits the number of bytes received (recv() return value).
         acf_pdu = &pdu[proc_bytes];
-        acf_type = Avtp_AcfCommon_GetAcfMsgType((Avtp_AcfCommon_t*)acf_pdu);
-        if (acf_type != AVTP_ACF_TYPE_VSS) {
+        if (!Avtp_Vss_IsValid((Avtp_Vss_t *)acf_pdu, (size_t)((uint64_t)res - proc_bytes))) {
             // Ignore further processing.
             continue;
         }
@@ -172,26 +172,29 @@ int main(int argc, char *argv[])
         // Parse the VSS Packet and print contents on the STDOUT
         Vss_AddrMode_t addrMode;
         VssPath_t path;
-        addrMode = Avtp_Vss_GetAddrMode((Avtp_Vss_t*)acf_pdu);
-        Avtp_Vss_GetVssPath((Avtp_Vss_t*)acf_pdu, &path);
+        // A received frame is at most MAX_PDU_SIZE bytes (bounded by recv()
+        // above), and IsValid() guarantees the declared message length fits
+        // that, so this buffer is always large enough for the clamped path.
+        char interop_path_storage[MAX_PDU_SIZE];
+        addrMode = Avtp_Vss_GetAddrMode((Avtp_Vss_t *)acf_pdu);
+        path.vss_interop_path.path = interop_path_storage;
+        Avtp_Vss_GetVssPath((Avtp_Vss_t *)acf_pdu, &path);
 
         if (addrMode == VSS_INTEROP_MODE) {
-            char path_string[path.vss_interop_path.path_length+1];
-            memset(path_string, '\0', path.vss_interop_path.path_length+1);
+            char path_string[path.vss_interop_path.path_length + 1];
+            memset(path_string, '\0', path.vss_interop_path.path_length + 1);
             memcpy(path_string, path.vss_interop_path.path, path.vss_interop_path.path_length);
             printf("VSS Path: %s, ", path_string);
         } else if (addrMode == VSS_STATIC_ID_MODE) {
             printf("VSS Path: %d, ", path.vss_static_id_path);
         }
 
-        VssData_t data;
-        Vss_Datatype_t dt = Avtp_Vss_GetDatatype((Avtp_Vss_t*)acf_pdu);
-        Avtp_Vss_GetVssData((Avtp_Vss_t*)acf_pdu, &data);
-
+        Vss_Datatype_t dt = Avtp_Vss_GetDatatype((Avtp_Vss_t *)acf_pdu);
         if (dt == VSS_FLOAT) {
+            VssData_t data;
+            Avtp_Vss_GetVssData((Avtp_Vss_t *)acf_pdu, &data);
             printf("VSS Value: %f\n", data.data_float);
         }
-
     }
 
     return 0;
@@ -199,5 +202,4 @@ int main(int argc, char *argv[])
 err:
     close(sk_fd);
     return 1;
-
 }

--- a/include/avtp/acf/custom/Vss.h
+++ b/include/avtp/acf/custom/Vss.h
@@ -37,6 +37,7 @@
 
 #include <stdint.h>
 #include <stdbool.h>
+#include <stddef.h>
 
 #include "avtp/Defines.h"
 #include "avtp/acf/AcfCommon.h"
@@ -248,7 +249,65 @@ Vss_AddrMode_t Avtp_Vss_GetAddrMode(const Avtp_Vss_t *const pdu);
 Vss_OpCode_t Avtp_Vss_GetOpCode(const Avtp_Vss_t *const pdu);
 Vss_Datatype_t Avtp_Vss_GetDatatype(const Avtp_Vss_t *const pdu);
 uint64_t Avtp_Vss_GetMessageTimestamp(const Avtp_Vss_t *const pdu);
+
+/**
+ * Checks the envelope of an ACF VSS PDU against the actual buffer that
+ * contains it. This is a deliberately shallow check: it verifies the ACF
+ * message type, that the buffer can hold the fixed header, and that the
+ * declared ACF message length (an attacker-influenced field) fits within
+ * the actual buffer.
+ *
+ * `IsValid` does NOT walk the variable-length path and payload structure.
+ * A frame that passes it may still be semantically inconsistent (e.g. a
+ * path or data length prefix that exceeds the declared message length);
+ * the accessors clamp such values rather than trusting them.
+ *
+ * @param pdu Pointer to the first bit of an 1722 ACF VSS PDU.
+ * @param bufferSize Size of the buffer containing the ACF VSS frame.
+ * @return true if the frame envelope is valid and every accessor can be
+ *         called without overreading the buffer, false otherwise.
+ */
+bool Avtp_Vss_IsValid(const Avtp_Vss_t *const pdu, size_t bufferSize);
+
+/**
+ * Parses the VSS path out of an ACF VSS PDU.
+ *
+ * Preconditions:
+ *  - When the PDU holds untrusted (e.g. network-received) data, validate it
+ *    first with Avtp_Vss_IsValid() so no accessor can overread the buffer.
+ *  - In VSS_INTEROP_MODE, val->vss_interop_path.path must point to writable
+ *    memory. The maximum number of bytes written is
+ *    (declared ACF message length - AVTP_VSS_FIXED_HEADER_LEN - 2), and
+ *    val->vss_interop_path.path_length is set to that clamped copy length.
+ *  - In VSS_STATIC_ID_MODE, val->vss_static_id_path receives the static ID.
+ *
+ * A truncated or internally inconsistent path is clamped: path_length
+ * reflects only the bytes actually copied.
+ *
+ * @param pdu Pointer to the first bit of an 1722 ACF VSS PDU.
+ * @param val Pointer to the VSS path struct to fill.
+ */
 void Avtp_Vss_GetVssPath(const Avtp_Vss_t *const pdu, VssPath_t *val);
+
+/**
+ * Parses the VSS data out of an ACF VSS PDU.
+ *
+ * Preconditions:
+ *  - When the PDU holds untrusted (e.g. network-received) data, validate it
+ *    first with Avtp_Vss_IsValid() so no accessor can overread the buffer.
+ *  - For string and array datatypes, the matching pointer member of the
+ *    val union (e.g. val->data_string) must point to a writable
+ *    VssDataString_t / VssData*Array_t struct whose `data` member is either
+ *    NULL (copy skipped, only the length is reported) or points to writable
+ *    memory large enough for the clamped data length.
+ *  - For scalar datatypes the corresponding scalar member receives the value.
+ *
+ * Missing data leaves the target member unchanged; truncated data is
+ * clamped to the bytes actually present. Getters never overread.
+ *
+ * @param pdu Pointer to the first bit of an 1722 ACF VSS PDU.
+ * @param val Pointer to the VSS data union to fill.
+ */
 void Avtp_Vss_GetVssData(const Avtp_Vss_t *const pdu, VssData_t *val);
 uint16_t Avtp_Vss_GetVSSDataStringArrayLength(const VssDataStringArray_t *str_array);
 uint16_t Avtp_Vss_CalcVssPathLength(const Avtp_Vss_t *const pdu);

--- a/src/avtp/acf/custom/Vss.c
+++ b/src/avtp/acf/custom/Vss.c
@@ -123,6 +123,36 @@ static bool vss_has_bytes(const Avtp_Vss_t *pdu, const uint8_t *ptr, uint16_t nu
     return (uint32_t)(ptr - (const uint8_t *)pdu) + num_bytes <= declared;
 }
 
+/* Deliberately shallow envelope check.  All getters clamp their reads to the
+ * declared ACF message length, so once that declared length is known to fit
+ * within the actual buffer (`bufferSize`) no getter can overread it.  The
+ * variable-length path/payload structure is not walked here; a frame that
+ * passes this check may still be internally inconsistent and the getters
+ * clamp such inconsistencies. */
+bool Avtp_Vss_IsValid(const Avtp_Vss_t *const pdu, size_t bufferSize)
+{
+    if (pdu == NULL) {
+        return false;
+    }
+
+    /* Nothing may be read from the PDU before the buffer size is known to
+     * cover the fixed header, which all field reads stay within. */
+    if (bufferSize < AVTP_VSS_FIXED_HEADER_LEN) {
+        return false;
+    }
+
+    if (Avtp_AcfCommon_GetAcfMsgType((const Avtp_AcfCommon_t *)pdu) != AVTP_ACF_TYPE_VSS) {
+        return false;
+    }
+
+    uint16_t msg_length_bytes =
+        Avtp_AcfCommon_GetAcfMsgLengthInBytes((const Avtp_AcfCommon_t *)pdu);
+    if (msg_length_bytes < AVTP_VSS_FIXED_HEADER_LEN || msg_length_bytes > bufferSize) {
+        return false;
+    }
+    return true;
+}
+
 void Avtp_Vss_Init(Avtp_Vss_t *vss_pdu)
 {
 

--- a/unit/test-vss.c
+++ b/unit/test-vss.c
@@ -1644,11 +1644,144 @@ static void vss_data_string_zero_msg_length_oob(void **state)
     assert_int_equal((uint8_t)out[0], 0x5A);
 }
 
+/* ──────────────────────────────────────────────────────────────────────────
+ * Avtp_Vss_IsValid tests
+ *
+ * IsValid is a deliberately shallow envelope check: it guarantees that the
+ * declared ACF message length fits the actual buffer, so no getter can
+ * overread.  It does NOT verify that the variable-length path/payload is
+ * semantically well-formed.  The regression scenario is a frame declaring
+ * 511 quadlets (2044 bytes) that is physically much shorter.
+ * ────────────────────────────────────────────────────────────────────────── */
+
+static void vss_is_valid_null(void **state)
+{
+    assert_false(Avtp_Vss_IsValid(NULL, 2044));
+}
+
+static void vss_is_valid_buffer_too_small(void **state)
+{
+    uint8_t buf[AVTP_VSS_FIXED_HEADER_LEN];
+    Avtp_Vss_t *pdu = (Avtp_Vss_t *)buf;
+    memset(buf, 0, sizeof(buf));
+    Avtp_Vss_Init(pdu);
+
+    /* The fixed header must be fully covered before any field is read. */
+    assert_false(Avtp_Vss_IsValid(pdu, 0));
+    assert_false(Avtp_Vss_IsValid(pdu, AVTP_VSS_FIXED_HEADER_LEN - 1));
+}
+
+static void vss_is_valid_wrong_acf_type(void **state)
+{
+    uint8_t buf[2044];
+    Avtp_Vss_t *pdu = (Avtp_Vss_t *)buf;
+    memset(buf, 0, sizeof(buf));
+    Avtp_Vss_Init(pdu);
+    Avtp_AcfCommon_SetAcfMsgType((Avtp_AcfCommon_t *)pdu, AVTP_ACF_TYPE_CAN);
+    Avtp_AcfCommon_SetAcfMsgLength((Avtp_AcfCommon_t *)pdu, 3);
+
+    assert_false(Avtp_Vss_IsValid(pdu, sizeof(buf)));
+}
+
+static void vss_is_valid_declared_larger_than_buffer(void **state)
+{
+    /* Regression scenario from the listener report: declared length is the
+     * 9-bit maximum (511 quadlets = 2044 bytes) but the actual buffer is
+     * far smaller.  Clamping inside the getters alone cannot know the real
+     * size, so IsValid must reject the frame up front. */
+    uint8_t buf[2044];
+    Avtp_Vss_t *pdu = (Avtp_Vss_t *)buf;
+    memset(buf, 0, sizeof(buf));
+    Avtp_Vss_Init(pdu);
+    Avtp_AcfCommon_SetAcfMsgLength((Avtp_AcfCommon_t *)pdu, 511);
+
+    assert_false(Avtp_Vss_IsValid(pdu, 100));
+    assert_false(Avtp_Vss_IsValid(pdu, AVTP_VSS_FIXED_HEADER_LEN));
+    assert_false(Avtp_Vss_IsValid(pdu, 2043));
+    /* With a buffer that really is 2044 bytes the same frame is fine. */
+    assert_true(Avtp_Vss_IsValid(pdu, 2044));
+}
+
+static void vss_is_valid_declared_smaller_than_header(void **state)
+{
+    uint8_t buf[2044];
+    Avtp_Vss_t *pdu = (Avtp_Vss_t *)buf;
+    memset(buf, 0, sizeof(buf));
+    Avtp_Vss_Init(pdu);
+
+    /* 0, 1 and 2 quadlets all declare fewer than the fixed header bytes. */
+    for (uint16_t quadlets = 0; quadlets <= 2; quadlets++) {
+        Avtp_AcfCommon_SetAcfMsgLength((Avtp_AcfCommon_t *)pdu, quadlets);
+        assert_false(Avtp_Vss_IsValid(pdu, sizeof(buf)));
+    }
+}
+
+static void vss_is_valid_header_only_frame(void **state)
+{
+    uint8_t buf[AVTP_VSS_FIXED_HEADER_LEN];
+    Avtp_Vss_t *pdu = (Avtp_Vss_t *)buf;
+    memset(buf, 0, sizeof(buf));
+    Avtp_Vss_Init(pdu);
+    Avtp_AcfCommon_SetAcfMsgLength((Avtp_AcfCommon_t *)pdu,
+                                   AVTP_VSS_FIXED_HEADER_LEN / AVTP_QUADLET_SIZE);
+
+    /* Smallest frame that still passes: declared == buffer == header. */
+    assert_true(Avtp_Vss_IsValid(pdu, sizeof(buf)));
+    assert_false(Avtp_Vss_IsValid(pdu, sizeof(buf) - 1));
+}
+
+/* A valid full frame (talker-built, interop path + float data) must pass
+ * IsValid exactly when the buffer covers the declared length, and the
+ * getters must then decode it without any further surprises. */
+static void vss_is_valid_roundtrip(void **state)
+{
+    uint8_t buf[MAX_PDU_SIZE];
+    Avtp_Vss_t *pdu = (Avtp_Vss_t *)buf;
+    memset(buf, 0, sizeof(buf));
+    Avtp_Vss_Init(pdu);
+    Avtp_Vss_SetAddrMode(pdu, VSS_INTEROP_MODE);
+
+    char path[] = "Vehicle.Speed";
+    VssPath_t path_id = {0};
+    path_id.vss_interop_path.path = path;
+    path_id.vss_interop_path.path_length = (uint16_t)strlen(path);
+    Avtp_Vss_SetVssPath(pdu, &path_id);
+
+    VssData_t data = {.data_float = 12.5f};
+    Avtp_Vss_SetDatatype(pdu, VSS_FLOAT);
+    Avtp_Vss_SetVssData(pdu, &data);
+    Avtp_Vss_SetPayloadLength(pdu, (uint16_t)(2 + strlen(path) + sizeof(float)));
+
+    uint16_t declared = Avtp_AcfCommon_GetAcfMsgLengthInBytes((Avtp_AcfCommon_t *)pdu);
+    assert_true(Avtp_Vss_IsValid(pdu, declared));
+    assert_true(Avtp_Vss_IsValid(pdu, 2044));
+    /* One byte short of the declared length must fail. */
+    assert_false(Avtp_Vss_IsValid(pdu, declared - 1));
+
+    char path_out[32];
+    VssPath_t get_path = {0};
+    get_path.vss_interop_path.path = path_out;
+    Avtp_Vss_GetVssPath(pdu, &get_path);
+    assert_int_equal(get_path.vss_interop_path.path_length, strlen(path));
+    assert_memory_equal(path_out, path, strlen(path));
+
+    VssData_t get_data;
+    Avtp_Vss_GetVssData(pdu, &get_data);
+    assert_float_equal(get_data.data_float, 12.5, 0.001);
+}
+
 int main(void)
 {
     const struct CMUnitTest tests[] = {
         cmocka_unit_test(vss_init),
         cmocka_unit_test(vss_pad),
+        cmocka_unit_test(vss_is_valid_null),
+        cmocka_unit_test(vss_is_valid_buffer_too_small),
+        cmocka_unit_test(vss_is_valid_wrong_acf_type),
+        cmocka_unit_test(vss_is_valid_declared_larger_than_buffer),
+        cmocka_unit_test(vss_is_valid_declared_smaller_than_header),
+        cmocka_unit_test(vss_is_valid_header_only_frame),
+        cmocka_unit_test(vss_is_valid_roundtrip),
         cmocka_unit_test(vss_static_path),
         cmocka_unit_test(vss_interop_path),
         cmocka_unit_test(vss_data_uint8),


### PR DESCRIPTION
Found this when scanning with scrutineer. The report said

> examples/acf-vss/acf-vss-listener.c:138 recv() fills pdu[1500] (MAX_PDU_SIZE). The listener decodes the CF subtype (Tscf.h/Ntscf.h), then at line 166 reads the ACF message type and at 175/176/189 calls Avtp_Vss_GetVssPath / Avtp_Vss_GetVssData on acf_pdu = &pdu[proc_bytes]. In Vss.c, vss_get_clamped_path_length (line 96) and vss_read_clamped_length (line 68) compute declared = Avtp_AcfCommon_GetAcfMsgLengthInBytes(pdu) from the 9-bit ACF message-length field (max 511 quadlets = 2044 bytes) that the attacker controls, and clamp every read against that declared length rather than against the actual received byte count. For a message that declares 2044 bytes, Avtp_Vss_GetVssPath memcpy's ~2030 bytes at Vss.c:215 out of the 1500-byte stack buffer. The listener never passes the recv() return value into any getter, and the threat model's documented precondition (properties_provided[2]: buffer at least the declared ACF message length) is violated by the shipped listener's fixed 1500-byte buffer.

I verified, this is true. Fixed by the following measures

 - ACF-VSS now also gets an isValid() that does structural checks only: Is it ACF-VSS does the frame FIT in the buffer when believing ACFMessageLength (the root cause)
   - Updating api-design.doc explaining that VSS exception: It has a _basic_ isValid, but that most of the heavy lifting is done in the accessors itself
 - use isValid in listener. (also formatted it - did not touch it since clang-format)
 -  generated new unit test for VSS isValid, because.. why not....