### PR TITLE
Common functions for common AVTP fields subtype and version

### DIFF
--- a/README.md
+++ b/README.md
@@ -171,7 +171,7 @@ int main()
 
     // Init TSCF header
     Avtp_Tscf_Init(&pdu.tscf);
-    Avtp_Tscf_SetVersion(&pdu.tscf, 0);
+    Avtp_CommonHeader_SetVersion((Avtp_CommonHeader_t *)&pdu.tscf, 0);
     Avtp_Tscf_SetSequenceNum(&pdu.tscf, 123);
     Avtp_Tscf_SetStreamId(&pdu.tscf, 0xAABBCCDDEEFF);
     Avtp_Tscf_SetTv(&pdu.tscf, true);

--- a/docs/api-design.md
+++ b/docs/api-design.md
@@ -508,18 +508,19 @@ void Avtp_Can_CreateAcfMessage(Avtp_Can_t *pdu, uint32_t frame_id,
                                Avtp_CanVariant_t can_variant);
 ```
 
-## The AVTP common header: subtype & version
+## The AVTP common header
 
 Every AVTP PDU starts with the common header described in
 [`CommonHeader.h`](../include/avtp/CommonHeader.h) - `subtype`, `h` and
-`version`. `Avtp_CommonHeader_Get/SetSubtype` and
-`Avtp_CommonHeader_Get/SetVersion` are its accessors. Because every format
-struct begins with that header, a format PDU pointer can be cast to
-`Avtp_CommonHeader_t *` to read or write these fields.
+`version`. Because every format struct begins with that header, a format PDU
+pointer can be cast to `Avtp_CommonHeader_t *` to read or write these fields.
+
+### subtype and version
 
 As with the ACF message type, `subtype` and `version` each have exactly one
 correct value, so there are **no per-format `Get/SetSubtype` or `Get/SetVersion`
-functions**:
+functions**. They are accessed through `Avtp_CommonHeader_Get/SetSubtype` and
+`Avtp_CommonHeader_Get/SetVersion`:
 
 - `Init` stamps the subtype with
   `Avtp_CommonHeader_SetSubtype((Avtp_CommonHeader_t *)pdu, AVTP_SUBTYPE_<NAME>)`.
@@ -529,9 +530,21 @@ functions**:
 Each format still declares `AVTP_<FORMAT>_FIELD_SUBTYPE` and
 `AVTP_<FORMAT>_FIELD_VERSION` in its field enum and descriptor table, so the
 generic `Avtp_<Format>_Get/SetField` path and the "every bit described exactly
-once" rule continue to hold; only the convenience accessors are omitted. The
-remaining common-header bit, `h` (spelled `sv` in the stream formats), still
-uses per-format accessors.
+once" rule continue to hold; only the convenience accessors are omitted.
+
+### h (header specific)
+
+Unlike `subtype` and `version`, `h` is explicitly header-specific: its meaning
+is defined by the header/format (IEEE 1722-2025, 4.7.3.3). The common stream
+header (4.7.4) and common control header (4.7.5) define it as `sv`
+(stream_id valid), but formats using the alternative header (4.7.6) define it
+themselves or leave it reserved.
+
+Format modules therefore keep their own semantic accessors wherever the format
+defines the bit - e.g. AAF/CVF/TSCF/RVF (`GetSv`/`EnableSv`/`DisableSv`) and
+CRF/NTSCF (`IsSv`/`SetSv`), even though the latter two use the alternative
+header. `Avtp_CommonHeader_GetH`/`SetH` remains the generic accessor for the raw
+bit, for formats that redefine it or reserve it.
 
 ## ACF layering & the common header
 
@@ -669,7 +682,7 @@ this order and the template in
    flags use `Is<Flag>` (returns `bool`) and `Set<Flag>(bool)`. Reserved fields
    get no accessors (see [Reserved fields](#reserved-fields)), and neither do
    the shared common-header fields (see
-   [The AVTP common header](#the-avtp-common-header-subtype--version) and
+   [The AVTP common header](#the-avtp-common-header) and
    [ACF layering & the common header](#acf-layering--the-common-header)).
 7. Add `Avtp_<Format>_Init` (zero + set the ACF message type).
 8. Add the convenience functions (`Get/SetPayload`, `SetPayloadLength`,

--- a/docs/api-design.md
+++ b/docs/api-design.md
@@ -36,7 +36,7 @@ reading either half of this document.
 Function, type and field names are taken directly from the IEEE 1722
 specification. The guiding idea is: **if you have read and understood the spec,
 you can use Open1722 directly** - the mapping from a spec field to the
-corresponding API call is mechanical. 
+corresponding API call is mechanical.
 
 For example, the ACF CAN header contains the fields `pad`, `mtv`, `rtr`, `eff`,
 `brs`, `fdf`, `esi`, `can_bus_id`, `message_timestamp` and `can_identifier`.
@@ -439,7 +439,9 @@ enclosing function scope (the accessors below use exactly that name).
 ### Accessors
 
 One getter and one setter per field, implemented as thin inline wrappers around
-the macros:
+the macros, except for fields shared by every format - the ACF common fields
+and the AVTP common header's `subtype` - which are accessed through the shared
+`Avtp_AcfCommon_*` / `Avtp_CommonHeader_*` functions instead:
 
 ```c
 OPEN1722_INLINE uint8_t Avtp_Can_GetCanBusId(const Avtp_Can_t *const pdu)
@@ -505,6 +507,27 @@ void Avtp_Can_CreateAcfMessage(Avtp_Can_t *pdu, uint32_t frame_id,
                                uint8_t *payload, uint16_t payload_length,
                                Avtp_CanVariant_t can_variant);
 ```
+
+## The AVTP common header & subtype
+
+Every AVTP PDU starts with the common header described in
+[`CommonHeader.h`](../include/avtp/CommonHeader.h) - `subtype`, `h` and
+`version` - and `Avtp_CommonHeader_Get/SetSubtype` are its accessors. Because
+every format struct begins with that header, a format PDU pointer can be cast to
+`Avtp_CommonHeader_t *` to read or write the subtype.
+
+As with the ACF message type, the subtype has exactly one correct value per
+format, so there are **no per-format `Get/SetSubtype` functions**:
+
+- `Init` stamps the subtype with
+  `Avtp_CommonHeader_SetSubtype((Avtp_CommonHeader_t *)pdu, AVTP_SUBTYPE_<NAME>)`.
+- `IsValid` checks it with
+  `Avtp_CommonHeader_GetSubtype((const Avtp_CommonHeader_t *)pdu)`.
+
+Each format still declares `AVTP_<FORMAT>_FIELD_SUBTYPE` in its field enum and
+descriptor table, so the generic `Avtp_<Format>_Get/SetField` path and the
+"every bit described exactly once" rule continue to hold; only the convenience
+accessors are omitted.
 
 ## ACF layering & the common header
 
@@ -640,7 +663,10 @@ this order and the template in
 5. Add the `GET_/SET_<FORMAT>_FIELD` macros.
 6. Add one `Get`/`Set` accessor per field (using `OPEN1722_INLINE`); single-bit
    flags use `Is<Flag>` (returns `bool`) and `Set<Flag>(bool)`. Reserved fields
-   get no accessors (see [Reserved fields](#reserved-fields)).
+   get no accessors (see [Reserved fields](#reserved-fields)), and neither do
+   the shared common-header fields (see
+   [The AVTP common header & subtype](#the-avtp-common-header--subtype) and
+   [ACF layering & the common header](#acf-layering--the-common-header)).
 7. Add `Avtp_<Format>_Init` (zero + set the ACF message type).
 8. Add the convenience functions (`Get/SetPayload`, `SetPayloadLength`,
    `GetPayloadLength`, and `Create…` if a full-message builder makes sense).

--- a/docs/api-design.md
+++ b/docs/api-design.md
@@ -440,8 +440,8 @@ enclosing function scope (the accessors below use exactly that name).
 
 One getter and one setter per field, implemented as thin inline wrappers around
 the macros, except for fields shared by every format - the ACF common fields
-and the AVTP common header's `subtype` - which are accessed through the shared
-`Avtp_AcfCommon_*` / `Avtp_CommonHeader_*` functions instead:
+and the AVTP common header's `subtype` and `version` - which are accessed
+through the shared `Avtp_AcfCommon_*` / `Avtp_CommonHeader_*` functions instead:
 
 ```c
 OPEN1722_INLINE uint8_t Avtp_Can_GetCanBusId(const Avtp_Can_t *const pdu)
@@ -508,26 +508,30 @@ void Avtp_Can_CreateAcfMessage(Avtp_Can_t *pdu, uint32_t frame_id,
                                Avtp_CanVariant_t can_variant);
 ```
 
-## The AVTP common header & subtype
+## The AVTP common header: subtype & version
 
 Every AVTP PDU starts with the common header described in
 [`CommonHeader.h`](../include/avtp/CommonHeader.h) - `subtype`, `h` and
-`version` - and `Avtp_CommonHeader_Get/SetSubtype` are its accessors. Because
-every format struct begins with that header, a format PDU pointer can be cast to
-`Avtp_CommonHeader_t *` to read or write the subtype.
+`version`. `Avtp_CommonHeader_Get/SetSubtype` and
+`Avtp_CommonHeader_Get/SetVersion` are its accessors. Because every format
+struct begins with that header, a format PDU pointer can be cast to
+`Avtp_CommonHeader_t *` to read or write these fields.
 
-As with the ACF message type, the subtype has exactly one correct value per
-format, so there are **no per-format `Get/SetSubtype` functions**:
+As with the ACF message type, `subtype` and `version` each have exactly one
+correct value, so there are **no per-format `Get/SetSubtype` or `Get/SetVersion`
+functions**:
 
 - `Init` stamps the subtype with
   `Avtp_CommonHeader_SetSubtype((Avtp_CommonHeader_t *)pdu, AVTP_SUBTYPE_<NAME>)`.
 - `IsValid` checks it with
   `Avtp_CommonHeader_GetSubtype((const Avtp_CommonHeader_t *)pdu)`.
 
-Each format still declares `AVTP_<FORMAT>_FIELD_SUBTYPE` in its field enum and
-descriptor table, so the generic `Avtp_<Format>_Get/SetField` path and the
-"every bit described exactly once" rule continue to hold; only the convenience
-accessors are omitted.
+Each format still declares `AVTP_<FORMAT>_FIELD_SUBTYPE` and
+`AVTP_<FORMAT>_FIELD_VERSION` in its field enum and descriptor table, so the
+generic `Avtp_<Format>_Get/SetField` path and the "every bit described exactly
+once" rule continue to hold; only the convenience accessors are omitted. The
+remaining common-header bit, `h` (spelled `sv` in the stream formats), still
+uses per-format accessors.
 
 ## ACF layering & the common header
 
@@ -665,7 +669,7 @@ this order and the template in
    flags use `Is<Flag>` (returns `bool`) and `Set<Flag>(bool)`. Reserved fields
    get no accessors (see [Reserved fields](#reserved-fields)), and neither do
    the shared common-header fields (see
-   [The AVTP common header & subtype](#the-avtp-common-header--subtype) and
+   [The AVTP common header](#the-avtp-common-header-subtype--version) and
    [ACF layering & the common header](#acf-layering--the-common-header)).
 7. Add `Avtp_<Format>_Init` (zero + set the ACF message type).
 8. Add the convenience functions (`Get/SetPayload`, `SetPayloadLength`,

--- a/examples/acf-can/linux-kernel-mod/1722ethernet.c
+++ b/examples/acf-can/linux-kernel-mod/1722ethernet.c
@@ -49,7 +49,7 @@
 void prepare_ntscf_header(Avtp_Ntscf_t *ntscf_header, struct acfcan_cfg *cfg)
 {
     Avtp_Ntscf_Init(ntscf_header);
-    Avtp_Ntscf_SetVersion(ntscf_header, 0);
+    Avtp_CommonHeader_SetVersion((Avtp_CommonHeader_t *)ntscf_header, 0);
     Avtp_Ntscf_SetSequenceNum(ntscf_header, cfg->sequenceNum++); // This can't be right. Increase?
     Avtp_Ntscf_SetStreamId(ntscf_header, cfg->tx_streamid);
 }

--- a/examples/cvf/cvf-listener.c
+++ b/examples/cvf/cvf-listener.c
@@ -77,11 +77,11 @@
 #include "avtp/CommonHeader.h"
 #include "common/common.h"
 
-#define STREAM_ID				0xAABBCCDDEEFF0001
-#define DATA_LEN				1400
-#define AVTP_H264_HEADER_LEN	(sizeof(Avtp_H264_t))
-#define AVTP_FULL_HEADER_LEN	(sizeof(Avtp_Cvf_t) + sizeof(Avtp_H264_t))
-#define MAX_PDU_SIZE			(AVTP_FULL_HEADER_LEN + DATA_LEN)
+#define STREAM_ID 0xAABBCCDDEEFF0001
+#define DATA_LEN 1400
+#define AVTP_H264_HEADER_LEN (sizeof(Avtp_H264_t))
+#define AVTP_FULL_HEADER_LEN (sizeof(Avtp_Cvf_t) + sizeof(Avtp_H264_t))
+#define MAX_PDU_SIZE (AVTP_FULL_HEADER_LEN + DATA_LEN)
 
 struct nal_entry {
     STAILQ_ENTRY(nal_entry) entries;
@@ -97,10 +97,9 @@ static uint8_t macaddr[ETH_ALEN];
 static uint8_t expected_seq;
 
 static struct argp_option options[] = {
-    {"dst-addr", 'd', "MACADDR", 0, "Stream Destination MAC address" },
-    {"ifname", 'i', "IFNAME", 0, "Network Interface" },
-    { 0 }
-};
+    {"dst-addr", 'd', "MACADDR", 0, "Stream Destination MAC address"},
+    {"ifname", 'i', "IFNAME", 0, "Network Interface"},
+    {0}};
 
 static error_t parser(int key, char *arg, struct argp_state *state)
 {
@@ -108,9 +107,8 @@ static error_t parser(int key, char *arg, struct argp_state *state)
 
     switch (key) {
     case 'd':
-        res = sscanf(arg, "%hhx:%hhx:%hhx:%hhx:%hhx:%hhx",
-                    &macaddr[0], &macaddr[1], &macaddr[2],
-                    &macaddr[3], &macaddr[4], &macaddr[5]);
+        res = sscanf(arg, "%hhx:%hhx:%hhx:%hhx:%hhx:%hhx", &macaddr[0], &macaddr[1], &macaddr[2],
+                     &macaddr[3], &macaddr[4], &macaddr[5]);
         if (res != 6) {
             fprintf(stderr, "Invalid address\n");
             exit(EXIT_FAILURE);
@@ -125,10 +123,9 @@ static error_t parser(int key, char *arg, struct argp_state *state)
     return 0;
 }
 
-static struct argp argp = { options, parser };
+static struct argp argp = {options, parser};
 
-static int schedule_nal(int fd, struct timespec *tspec, uint8_t *nal,
-                                ssize_t len)
+static int schedule_nal(int fd, struct timespec *tspec, uint8_t *nal, ssize_t len)
 {
     struct nal_entry *entry;
 
@@ -162,61 +159,61 @@ static int schedule_nal(int fd, struct timespec *tspec, uint8_t *nal,
     return 0;
 }
 
-static bool is_valid_packet(Avtp_Cvf_t* cvf)
+static bool is_valid_packet(Avtp_Cvf_t *cvf)
 {
-    uint8_t subtype = Avtp_Cvf_GetSubtype(cvf);
+    uint8_t subtype = Avtp_CommonHeader_GetSubtype((Avtp_CommonHeader_t *)cvf);
     if (subtype != AVTP_SUBTYPE_CVF) {
-        fprintf(stderr, "Subtype mismatch: expected %u, got %"PRIu8"\n",
-                AVTP_SUBTYPE_CVF, subtype);
+        fprintf(stderr, "Subtype mismatch: expected %u, got %" PRIu8 "\n", AVTP_SUBTYPE_CVF,
+                subtype);
         return false;
     }
 
     uint8_t version = Avtp_Cvf_GetVersion(cvf);
     if (version != 0) {
-        fprintf(stderr, "Version mismatch: expected %u, got %"PRIu8"\n", 0,
-                version);
+        fprintf(stderr, "Version mismatch: expected %u, got %" PRIu8 "\n", 0, version);
         return false;
     }
 
     uint8_t tv = Avtp_Cvf_GetTv(cvf);
     if (tv != 1) {
-        fprintf(stderr, "tv mismatch: expected %u, got %"PRIu8"\n", 1, tv);
+        fprintf(stderr, "tv mismatch: expected %u, got %" PRIu8 "\n", 1, tv);
         return false;
     }
 
     uint64_t stream_id = Avtp_Cvf_GetStreamId(cvf);
     if (stream_id != STREAM_ID) {
-        fprintf(stderr, "Stream ID mismatch: expected %lu, got %lu\n",
-                STREAM_ID, stream_id);
+        fprintf(stderr, "Stream ID mismatch: expected %lu, got %lu\n", STREAM_ID, stream_id);
         return false;
     }
 
     uint8_t sequence_num = Avtp_Cvf_GetSequenceNum(cvf);
     if (sequence_num != expected_seq) {
-        fprintf(stderr, "Sequence number mismatch: expected %"PRIu8", "
-                "got %"PRIu8"\n", expected_seq, sequence_num);
+        fprintf(stderr,
+                "Sequence number mismatch: expected %" PRIu8 ", "
+                "got %" PRIu8 "\n",
+                expected_seq, sequence_num);
         expected_seq = sequence_num;
     }
     expected_seq++;
 
     uint8_t format = Avtp_Cvf_GetFormat(cvf);
     if (format != AVTP_CVF_FORMAT_RFC) {
-        fprintf(stderr, "Format mismatch: expected %"PRIu8", got %"PRIu8"\n",
-                    AVTP_CVF_FORMAT_RFC, format);
+        fprintf(stderr, "Format mismatch: expected %" PRIu8 ", got %" PRIu8 "\n",
+                AVTP_CVF_FORMAT_RFC, format);
         return false;
     }
 
     uint8_t format_subtype = Avtp_Cvf_GetFormatSubtype(cvf);
     if (format_subtype != AVTP_CVF_FORMAT_SUBTYPE_H264) {
-        fprintf(stderr, "Format mismatch: expected %"PRIu8", got %"PRIu8"\n",
-                    AVTP_CVF_FORMAT_SUBTYPE_H264, format_subtype);
+        fprintf(stderr, "Format mismatch: expected %" PRIu8 ", got %" PRIu8 "\n",
+                AVTP_CVF_FORMAT_SUBTYPE_H264, format_subtype);
         return false;
     }
 
     return true;
 }
 
-static uint16_t get_h264_data_len(Avtp_Cvf_t* cvf)
+static uint16_t get_h264_data_len(Avtp_Cvf_t *cvf)
 {
     uint16_t stream_data_len = Avtp_Cvf_GetStreamDataLength(cvf);
     return stream_data_len - AVTP_H264_HEADER_LEN;
@@ -229,9 +226,9 @@ static int new_packet(int sk_fd, int timer_fd)
     uint16_t h264_data_len;
     uint32_t avtp_time;
     struct timespec tspec;
-    Avtp_Cvf_t* cvf = alloca(MAX_PDU_SIZE);
-    Avtp_H264_t* h264Header = (Avtp_H264_t*)(&cvf->payload);
-    uint8_t* h264Payload = (uint8_t*)(&h264Header->payload);
+    Avtp_Cvf_t *cvf = alloca(MAX_PDU_SIZE);
+    Avtp_H264_t *h264Header = (Avtp_H264_t *)(&cvf->payload);
+    uint8_t *h264Payload = (uint8_t *)(&h264Header->payload);
 
     memset(cvf, 1, MAX_PDU_SIZE);
 

--- a/examples/cvf/cvf-listener.c
+++ b/examples/cvf/cvf-listener.c
@@ -168,7 +168,7 @@ static bool is_valid_packet(Avtp_Cvf_t *cvf)
         return false;
     }
 
-    uint8_t version = Avtp_Cvf_GetVersion(cvf);
+    uint8_t version = Avtp_CommonHeader_GetVersion((Avtp_CommonHeader_t *)cvf);
     if (version != 0) {
         fprintf(stderr, "Version mismatch: expected %u, got %" PRIu8 "\n", 0, version);
         return false;

--- a/include/avtp/CommonHeader.h
+++ b/include/avtp/CommonHeader.h
@@ -9,7 +9,7 @@
  *    * Redistributions in binary form must reproduce the above copyright
  *      notice, this list of conditions and the following disclaimer in the
  *      documentation and/or other materials provided with the distribution.
- *    * Neither the name of COVESA nor the names of its contributors may be 
+ *    * Neither the name of COVESA nor the names of its contributors may be
  *      used to endorse or promote products derived from this software without
  *      specific prior written permission.
  *
@@ -42,7 +42,7 @@
 extern "C" {
 #endif
 
-#define AVTP_COMMON_HEADER_LEN             (1 * AVTP_QUADLET_SIZE)
+#define AVTP_COMMON_HEADER_LEN (1 * AVTP_QUADLET_SIZE)
 
 typedef struct {
     uint8_t header[AVTP_COMMON_HEADER_LEN];
@@ -53,7 +53,7 @@ typedef struct {
  * Enumeration over all IEEE 1722 header fields. The naming convention used is
  * AVTP_<MSG_TYPE>_FIELD_<FIELD_NAME>.
  */
-typedef enum Avtp_CommonHeaderField{
+typedef enum Avtp_CommonHeaderField {
     /* Common AVTP header fields */
     AVTP_COMMON_HEADER_FIELD_SUBTYPE = 0,
     AVTP_COMMON_HEADER_FIELD_H,
@@ -64,26 +64,26 @@ typedef enum Avtp_CommonHeaderField{
 } Avtp_CommonHeaderField_t;
 
 typedef enum {
-    AVTP_SUBTYPE_61883_IIDC        = 0x0,
-    AVTP_SUBTYPE_MMA_STREAM        = 0x1,
-    AVTP_SUBTYPE_AAF               = 0x2,
-    AVTP_SUBTYPE_CVF               = 0x3,
-    AVTP_SUBTYPE_CRF               = 0x4,
-    AVTP_SUBTYPE_TSCF              = 0x5,
-    AVTP_SUBTYPE_SVF               = 0x6,
-    AVTP_SUBTYPE_RVF               = 0x7,
-    AVTP_SUBTYPE_AEF_CONTINUOUS    = 0x6E,
-    AVTP_SUBTYPE_VSF_STREAM        = 0x6F,
-    AVTP_SUBTYPE_EF_STREAM         = 0x7F,
-    AVTP_SUBTYPE_NTSCF             = 0x82,
-    AVTP_SUBTYPE_ESCF              = 0xEC,
-    AVTP_SUBTYPE_EECF              = 0xED,
-    AVTP_SUBTYPE_AEF_DISCRETE      = 0xEE,
-    AVTP_SUBTYPE_ADP               = 0xFA,
-    AVTP_SUBTYPE_AECP              = 0xFB,
-    AVTP_SUBTYPE_ACMP              = 0xFC,
-    AVTP_SUBTYPE_MAAP              = 0xFE,
-    AVTP_SUBTYPE_EF_CONTROL        = 0xFF,
+    AVTP_SUBTYPE_61883_IIDC = 0x0,
+    AVTP_SUBTYPE_MMA_STREAM = 0x1,
+    AVTP_SUBTYPE_AAF = 0x2,
+    AVTP_SUBTYPE_CVF = 0x3,
+    AVTP_SUBTYPE_CRF = 0x4,
+    AVTP_SUBTYPE_TSCF = 0x5,
+    AVTP_SUBTYPE_SVF = 0x6,
+    AVTP_SUBTYPE_RVF = 0x7,
+    AVTP_SUBTYPE_AEF_CONTINUOUS = 0x6E,
+    AVTP_SUBTYPE_VSF_STREAM = 0x6F,
+    AVTP_SUBTYPE_EF_STREAM = 0x7F,
+    AVTP_SUBTYPE_NTSCF = 0x82,
+    AVTP_SUBTYPE_ESCF = 0xEC,
+    AVTP_SUBTYPE_EECF = 0xED,
+    AVTP_SUBTYPE_AEF_DISCRETE = 0xEE,
+    AVTP_SUBTYPE_ADP = 0xFA,
+    AVTP_SUBTYPE_AECP = 0xFB,
+    AVTP_SUBTYPE_ACMP = 0xFC,
+    AVTP_SUBTYPE_MAAP = 0xFE,
+    AVTP_SUBTYPE_EF_CONTROL = 0xFF,
 } Avtp_AvtpSubtype_t;
 
 /**
@@ -93,22 +93,26 @@ typedef enum {
  * @param field Specifies the position of the data field to be read
  * @returns This function the value of the specified PDU field
  */
-uint64_t Avtp_CommonHeader_GetField(const Avtp_CommonHeader_t* const pdu, Avtp_CommonHeaderField_t field);
+uint64_t Avtp_CommonHeader_GetField(const Avtp_CommonHeader_t *const pdu,
+                                    Avtp_CommonHeaderField_t field);
 
 /**
  * Returns the subtype field of the AVTP common header.
  */
-uint8_t Avtp_CommonHeader_GetSubtype(const Avtp_CommonHeader_t* const pdu);
+uint8_t Avtp_CommonHeader_GetSubtype(const Avtp_CommonHeader_t *const pdu);
 
 /**
- * Returns the header specific field of the AVTP common header.
+ * Returns the h (header specific) bit of the AVTP common header. The meaning of this bit is defined
+ * by the header/format: the common stream header (4.7.4) and common control header (4.7.5) define
+ * it as sv (stream_id valid), while formats using the alternative header (4.7.6) define it
+ * themselves or leave it reserved.
  */
-uint8_t Avtp_CommonHeader_GetH(const Avtp_CommonHeader_t* const pdu);
+uint8_t Avtp_CommonHeader_GetH(const Avtp_CommonHeader_t *const pdu);
 
 /**
  * Returns the version field of the AVTP common header.
  */
-uint8_t Avtp_CommonHeader_GetVersion(const Avtp_CommonHeader_t* const pdu);
+uint8_t Avtp_CommonHeader_GetVersion(const Avtp_CommonHeader_t *const pdu);
 
 /**
  * Sets the value of an an AVTP common header field as specified in the IEEE 1722 Specification.
@@ -117,22 +121,24 @@ uint8_t Avtp_CommonHeader_GetVersion(const Avtp_CommonHeader_t* const pdu);
  * @param field Specifies the position of the data field to be read
  * @param value Pointer to location to store the value.
  */
-void Avtp_CommonHeader_SetField(Avtp_CommonHeader_t* pdu, Avtp_CommonHeaderField_t field, uint64_t value);
+void Avtp_CommonHeader_SetField(Avtp_CommonHeader_t *pdu, Avtp_CommonHeaderField_t field,
+                                uint64_t value);
 
 /**
  * Set the subtype field of the AVTP common header.
  */
-void Avtp_CommonHeader_SetSubtype(Avtp_CommonHeader_t* pdu, uint8_t value);
+void Avtp_CommonHeader_SetSubtype(Avtp_CommonHeader_t *pdu, uint8_t value);
 
 /**
- * Set the header specific field of the AVTP common header.
+ * Sets the h (header specific) bit of the AVTP common header. See Avtp_CommonHeader_GetH for the
+ * definition of this bit.
  */
-void Avtp_CommonHeader_SetH(Avtp_CommonHeader_t* pdu, uint8_t value);
+void Avtp_CommonHeader_SetH(Avtp_CommonHeader_t *pdu, uint8_t value);
 
 /**
  * Set the version field of the AVTP common header.
  */
-void Avtp_CommonHeader_SetVersion(Avtp_CommonHeader_t* pdu, uint8_t value);
+void Avtp_CommonHeader_SetVersion(Avtp_CommonHeader_t *pdu, uint8_t value);
 
 /******************************************************************************
  * Legacy API (deprecated)
@@ -141,7 +147,7 @@ void Avtp_CommonHeader_SetVersion(Avtp_CommonHeader_t* pdu, uint8_t value);
 struct avtp_common_pdu {
     uint32_t subtype_data;
     uint8_t pdu_specific[0];
-} __attribute__ ((__packed__));
+} __attribute__((__packed__));
 
 struct avtp_stream_pdu {
     uint32_t subtype_data;
@@ -150,11 +156,11 @@ struct avtp_stream_pdu {
     uint32_t format_specific;
     uint32_t packet_info;
     uint8_t avtp_payload[0];
-} __attribute__ ((__packed__));
+} __attribute__((__packed__));
 
-#define AVTP_FIELD_SUBTYPE      (AVTP_COMMON_HEADER_FIELD_SUBTYPE)
-#define AVTP_FIELD_VERSION      (AVTP_COMMON_HEADER_FIELD_VERSION)
-#define AVTP_FIELD_MAX          (AVTP_COMMON_HEADER_FIELD_MAX)
+#define AVTP_FIELD_SUBTYPE (AVTP_COMMON_HEADER_FIELD_SUBTYPE)
+#define AVTP_FIELD_VERSION (AVTP_COMMON_HEADER_FIELD_VERSION)
+#define AVTP_FIELD_MAX (AVTP_COMMON_HEADER_FIELD_MAX)
 
 /* Get value from Common AVTPDU field.
  * @pdu: Pointer to PDU struct.
@@ -165,8 +171,8 @@ struct avtp_stream_pdu {
  *    0: Success.
  *    -EINVAL: If any argument is invalid.
  */
-int avtp_pdu_get(const struct avtp_common_pdu * const pdu, Avtp_CommonHeaderField_t field,
-                                uint32_t *val);
+int avtp_pdu_get(const struct avtp_common_pdu *const pdu, Avtp_CommonHeaderField_t field,
+                 uint32_t *val);
 
 /* Set value from Common AVTPDU field.
  * @pdu: Pointer to PDU struct.
@@ -177,8 +183,7 @@ int avtp_pdu_get(const struct avtp_common_pdu * const pdu, Avtp_CommonHeaderFiel
  *    0: Success.
  *    -EINVAL: If any argument is invalid.
  */
-int avtp_pdu_set(struct avtp_common_pdu *pdu, Avtp_CommonHeaderField_t field,
-                                uint32_t val);
+int avtp_pdu_set(struct avtp_common_pdu *pdu, Avtp_CommonHeaderField_t field, uint32_t val);
 
 #ifdef __cplusplus
 }

--- a/include/avtp/Crf.h
+++ b/include/avtp/Crf.h
@@ -38,7 +38,7 @@
 extern "C" {
 #endif
 
-#define AVTP_CRF_HEADER_LEN     (5 * AVTP_QUADLET_SIZE)
+#define AVTP_CRF_HEADER_LEN (5 * AVTP_QUADLET_SIZE)
 
 typedef struct Avtp_Cvf {
     uint8_t header[AVTP_CRF_HEADER_LEN];
@@ -46,19 +46,19 @@ typedef struct Avtp_Cvf {
 } Avtp_Crf_t;
 
 /* CRF 'type' field values. */
-#define AVTP_CRF_TYPE_USER			0x00
-#define AVTP_CRF_TYPE_AUDIO_SAMPLE		0x01
-#define AVTP_CRF_TYPE_VIDEO_FRAME		0x02
-#define AVTP_CRF_TYPE_VIDEO_LINE		0x03
-#define AVTP_CRF_TYPE_MACHINE_CYCLE		0x04
+#define AVTP_CRF_TYPE_USER 0x00
+#define AVTP_CRF_TYPE_AUDIO_SAMPLE 0x01
+#define AVTP_CRF_TYPE_VIDEO_FRAME 0x02
+#define AVTP_CRF_TYPE_VIDEO_LINE 0x03
+#define AVTP_CRF_TYPE_MACHINE_CYCLE 0x04
 
 /* CRF 'pull' field values. */
-#define AVTP_CRF_PULL_MULT_BY_1			0x00
-#define AVTP_CRF_PULL_MULT_BY_1_OVER_1_001	0x01
-#define AVTP_CRF_PULL_MULT_BY_1_001		0x02
-#define AVTP_CRF_PULL_MULT_BY_24_OVER_25	0x03
-#define AVTP_CRF_PULL_MULT_BY_25_OVER_24	0x04
-#define AVTP_CRF_PULL_MULT_BY_1_OVER_8		0x05
+#define AVTP_CRF_PULL_MULT_BY_1 0x00
+#define AVTP_CRF_PULL_MULT_BY_1_OVER_1_001 0x01
+#define AVTP_CRF_PULL_MULT_BY_1_001 0x02
+#define AVTP_CRF_PULL_MULT_BY_24_OVER_25 0x03
+#define AVTP_CRF_PULL_MULT_BY_25_OVER_24 0x04
+#define AVTP_CRF_PULL_MULT_BY_1_OVER_8 0x05
 
 typedef enum Avtp_CrfField {
     /* CRF header fields */
@@ -78,60 +78,58 @@ typedef enum Avtp_CrfField {
     AVTP_CRF_FIELD_TIMESTAMP_INTERVAL,
     /* Count number of fields for bound checks */
     AVTP_CRF_FIELD_MAX,
-}Avtp_CrfField_t;
+} Avtp_CrfField_t;
 
-void Avtp_Crf_Init(Avtp_Crf_t* pdu);
+void Avtp_Crf_Init(Avtp_Crf_t *pdu);
 
-uint64_t Avtp_Crf_GetField(const Avtp_Crf_t* const pdu, Avtp_CrfField_t field);
+uint64_t Avtp_Crf_GetField(const Avtp_Crf_t *const pdu, Avtp_CrfField_t field);
 
-uint8_t Avtp_Crf_GetSubtype(const Avtp_Crf_t* const pdu);
-uint8_t Avtp_Crf_GetSv(const Avtp_Crf_t* const pdu);
-uint8_t Avtp_Crf_GetVersion(const Avtp_Crf_t* const pdu);
-uint8_t Avtp_Crf_GetMr(const Avtp_Crf_t* const pdu);
-uint8_t Avtp_Crf_GetFs(const Avtp_Crf_t* const pdu);
-uint8_t Avtp_Crf_GetTu(const Avtp_Crf_t* const pdu);
-uint8_t Avtp_Crf_GetSequenceNum(const Avtp_Crf_t* const pdu);
-uint8_t Avtp_Crf_GetType(const Avtp_Crf_t* const pdu);
-uint64_t Avtp_Crf_GetStreamId(const Avtp_Crf_t* const pdu);
-uint8_t Avtp_Crf_GetPull(const Avtp_Crf_t* const pdu);
-uint32_t Avtp_Crf_GetBaseFrequency(const Avtp_Crf_t* const pdu);
-uint16_t Avtp_Crf_GetCrfDataLength(const Avtp_Crf_t* const pdu);
-uint16_t Avtp_Crf_GetTimestampInterval(const Avtp_Crf_t* const pdu);
+uint8_t Avtp_Crf_GetSv(const Avtp_Crf_t *const pdu);
+uint8_t Avtp_Crf_GetVersion(const Avtp_Crf_t *const pdu);
+uint8_t Avtp_Crf_GetMr(const Avtp_Crf_t *const pdu);
+uint8_t Avtp_Crf_GetFs(const Avtp_Crf_t *const pdu);
+uint8_t Avtp_Crf_GetTu(const Avtp_Crf_t *const pdu);
+uint8_t Avtp_Crf_GetSequenceNum(const Avtp_Crf_t *const pdu);
+uint8_t Avtp_Crf_GetType(const Avtp_Crf_t *const pdu);
+uint64_t Avtp_Crf_GetStreamId(const Avtp_Crf_t *const pdu);
+uint8_t Avtp_Crf_GetPull(const Avtp_Crf_t *const pdu);
+uint32_t Avtp_Crf_GetBaseFrequency(const Avtp_Crf_t *const pdu);
+uint16_t Avtp_Crf_GetCrfDataLength(const Avtp_Crf_t *const pdu);
+uint16_t Avtp_Crf_GetTimestampInterval(const Avtp_Crf_t *const pdu);
 
-void Avtp_Crf_SetField(Avtp_Crf_t* pdu, Avtp_CrfField_t field, uint64_t value);
+void Avtp_Crf_SetField(Avtp_Crf_t *pdu, Avtp_CrfField_t field, uint64_t value);
 
-void Avtp_Crf_SetSubtype(Avtp_Crf_t* pdu, uint8_t value);
-void Avtp_Crf_EnableSv(Avtp_Crf_t* pdu);
-void Avtp_Crf_DisableSv(Avtp_Crf_t* pdu);
-void Avtp_Crf_SetVersion(Avtp_Crf_t* pdu, uint8_t value);
-void Avtp_Crf_EnableMr(Avtp_Crf_t* pdu);
-void Avtp_Crf_DisableMr(Avtp_Crf_t* pdu);
-void Avtp_Crf_EnableFs(Avtp_Crf_t* pdu);
-void Avtp_Crf_DisableFs(Avtp_Crf_t* pdu);
-void Avtp_Crf_EnableTu(Avtp_Crf_t* pdu);
-void Avtp_Crf_DisableTu(Avtp_Crf_t* pdu);
-void Avtp_Crf_SetSequenceNum(Avtp_Crf_t* pdu, uint8_t value);
-void Avtp_Crf_SetType(Avtp_Crf_t* pdu, uint8_t value);
-void Avtp_Crf_SetStreamId(Avtp_Crf_t* pdu, uint64_t value);
-void Avtp_Crf_SetPull(Avtp_Crf_t* pdu, uint8_t value);
-void Avtp_Crf_SetBaseFrequency(Avtp_Crf_t* pdu, uint32_t value);
-void Avtp_Crf_SetCrfDataLength(Avtp_Crf_t* pdu, uint16_t value);
-void Avtp_Crf_SetTimestampInterval(Avtp_Crf_t* pdu, uint16_t value);
+void Avtp_Crf_EnableSv(Avtp_Crf_t *pdu);
+void Avtp_Crf_DisableSv(Avtp_Crf_t *pdu);
+void Avtp_Crf_SetVersion(Avtp_Crf_t *pdu, uint8_t value);
+void Avtp_Crf_EnableMr(Avtp_Crf_t *pdu);
+void Avtp_Crf_DisableMr(Avtp_Crf_t *pdu);
+void Avtp_Crf_EnableFs(Avtp_Crf_t *pdu);
+void Avtp_Crf_DisableFs(Avtp_Crf_t *pdu);
+void Avtp_Crf_EnableTu(Avtp_Crf_t *pdu);
+void Avtp_Crf_DisableTu(Avtp_Crf_t *pdu);
+void Avtp_Crf_SetSequenceNum(Avtp_Crf_t *pdu, uint8_t value);
+void Avtp_Crf_SetType(Avtp_Crf_t *pdu, uint8_t value);
+void Avtp_Crf_SetStreamId(Avtp_Crf_t *pdu, uint64_t value);
+void Avtp_Crf_SetPull(Avtp_Crf_t *pdu, uint8_t value);
+void Avtp_Crf_SetBaseFrequency(Avtp_Crf_t *pdu, uint32_t value);
+void Avtp_Crf_SetCrfDataLength(Avtp_Crf_t *pdu, uint16_t value);
+void Avtp_Crf_SetTimestampInterval(Avtp_Crf_t *pdu, uint16_t value);
 
 /******************************************************************************
  * Legacy API (deprecated)
  *****************************************************************************/
 
-#define AVTP_CRF_FIELD_SEQ_NUM          AVTP_CRF_FIELD_SEQUENCE_NUM
-#define AVTP_CRF_FIELD_BASE_FREQ        AVTP_CRF_FIELD_BASE_FREQUENCY
-#define AVTP_CRF_FIELD_CRF_DATA_LEN     AVTP_CRF_FIELD_CRF_DATA_LENGTH
+#define AVTP_CRF_FIELD_SEQ_NUM AVTP_CRF_FIELD_SEQUENCE_NUM
+#define AVTP_CRF_FIELD_BASE_FREQ AVTP_CRF_FIELD_BASE_FREQUENCY
+#define AVTP_CRF_FIELD_CRF_DATA_LEN AVTP_CRF_FIELD_CRF_DATA_LENGTH
 
 struct avtp_crf_pdu {
     uint32_t subtype_data;
     uint64_t stream_id;
     uint64_t packet_info;
     uint64_t crf_data[0];
-} __attribute__ ((__packed__));
+} __attribute__((__packed__));
 
 /**
  * @deprecated
@@ -144,7 +142,7 @@ struct avtp_crf_pdu {
  *    0: Success.
  *    -EINVAL: If any argument is invalid.
  */
-int avtp_crf_pdu_get(const void * const pdu, Avtp_CrfField_t field, uint64_t *val);
+int avtp_crf_pdu_get(const void *const pdu, Avtp_CrfField_t field, uint64_t *val);
 
 /**
  * @deprecated

--- a/include/avtp/Crf.h
+++ b/include/avtp/Crf.h
@@ -85,7 +85,6 @@ void Avtp_Crf_Init(Avtp_Crf_t *pdu);
 uint64_t Avtp_Crf_GetField(const Avtp_Crf_t *const pdu, Avtp_CrfField_t field);
 
 uint8_t Avtp_Crf_GetSv(const Avtp_Crf_t *const pdu);
-uint8_t Avtp_Crf_GetVersion(const Avtp_Crf_t *const pdu);
 uint8_t Avtp_Crf_GetMr(const Avtp_Crf_t *const pdu);
 uint8_t Avtp_Crf_GetFs(const Avtp_Crf_t *const pdu);
 uint8_t Avtp_Crf_GetTu(const Avtp_Crf_t *const pdu);
@@ -101,7 +100,6 @@ void Avtp_Crf_SetField(Avtp_Crf_t *pdu, Avtp_CrfField_t field, uint64_t value);
 
 void Avtp_Crf_EnableSv(Avtp_Crf_t *pdu);
 void Avtp_Crf_DisableSv(Avtp_Crf_t *pdu);
-void Avtp_Crf_SetVersion(Avtp_Crf_t *pdu, uint8_t value);
 void Avtp_Crf_EnableMr(Avtp_Crf_t *pdu);
 void Avtp_Crf_DisableMr(Avtp_Crf_t *pdu);
 void Avtp_Crf_EnableFs(Avtp_Crf_t *pdu);

--- a/include/avtp/Rvf.h
+++ b/include/avtp/Rvf.h
@@ -62,13 +62,13 @@ typedef enum Avtp_RvfField {
     AVTP_RVF_FIELD_ACTIVE_PIXELS,
     AVTP_RVF_FIELD_TOTAL_LINES,
     AVTP_RVF_FIELD_STREAM_DATA_LENGTH,
-    AVTP_RVF_FIELD_AP,                     // Active pixels
+    AVTP_RVF_FIELD_AP, // Active pixels
     AVTP_RVF_FIELD_RESERVED_3,
-    AVTP_RVF_FIELD_F,                      // Field
-    AVTP_RVF_FIELD_EF,                     // End frame
+    AVTP_RVF_FIELD_F,  // Field
+    AVTP_RVF_FIELD_EF, // End frame
     AVTP_RVF_FIELD_EVT,
-    AVTP_RVF_FIELD_PD,                     // Pull-down
-    AVTP_RVF_FIELD_I,                      // Interlaced
+    AVTP_RVF_FIELD_PD, // Pull-down
+    AVTP_RVF_FIELD_I,  // Interlaced
     AVTP_RVF_FIELD_RESERVED_4,
     AVTP_RVF_FIELD_RESERVED_5,
     AVTP_RVF_FIELD_PIXEL_DEPTH,
@@ -77,154 +77,152 @@ typedef enum Avtp_RvfField {
     AVTP_RVF_FIELD_COLORSPACE,
     AVTP_RVF_FIELD_NUM_LINES,
     AVTP_RVF_FIELD_RESERVED_6,
-    AVTP_RVF_FIELD_I_SEQ_NUM,              // Intra-line sequence number
+    AVTP_RVF_FIELD_I_SEQ_NUM, // Intra-line sequence number
     AVTP_RVF_FIELD_LINE_NUMBER,
     /* Count number of fields for bound checks */
     AVTP_RVF_FIELD_MAX
 } Avtp_RvfField_t;
 
 typedef enum Avtp_RvfPixelDepth {
-    AVTP_RVF_PIXEL_DEPTH_8              = 0x01,
-    AVTP_RVF_PIXEL_DEPTH_10             = 0x02,
-    AVTP_RVF_PIXEL_DEPTH_12             = 0x03,
-    AVTP_RVF_PIXEL_DEPTH_16             = 0x04,
-    AVTP_RVF_PIXEL_DEPTH_USER           = 0x0F
+    AVTP_RVF_PIXEL_DEPTH_8 = 0x01,
+    AVTP_RVF_PIXEL_DEPTH_10 = 0x02,
+    AVTP_RVF_PIXEL_DEPTH_12 = 0x03,
+    AVTP_RVF_PIXEL_DEPTH_16 = 0x04,
+    AVTP_RVF_PIXEL_DEPTH_USER = 0x0F
 } Avtp_RvfPixelDepth_t;
 
 typedef enum Avtp_RvfPixelFormat {
-    AVTP_RVF_PIXEL_FORMAT_MONO          = 0x00,
-    AVTP_RVF_PIXEL_FORMAT_411           = 0x01,
-    AVTP_RVF_PIXEL_FORMAT_420           = 0x02,
-    AVTP_RVF_PIXEL_FORMAT_422           = 0x03,
-    AVTP_RVF_PIXEL_FORMAT_444           = 0x04,
-    AVTP_RVF_PIXEL_FORMAT_4224          = 0x06,
-    AVTP_RVF_PIXEL_FORMAT_4444          = 0x07,
-    AVTP_RVF_PIXEL_FORMAT_BAYER_GRBG    = 0x08,
-    AVTP_RVF_PIXEL_FORMAT_BAYER_RGGB    = 0x09,
-    AVTP_RVF_PIXEL_FORMAT_BAYER_BGGR    = 0x0A,
-    AVTP_RVF_PIXEL_FORMAT_BAYER_GBRG    = 0x0B,
-    AVTP_RVF_PIXEL_FORMAT_USER          = 0x0F
+    AVTP_RVF_PIXEL_FORMAT_MONO = 0x00,
+    AVTP_RVF_PIXEL_FORMAT_411 = 0x01,
+    AVTP_RVF_PIXEL_FORMAT_420 = 0x02,
+    AVTP_RVF_PIXEL_FORMAT_422 = 0x03,
+    AVTP_RVF_PIXEL_FORMAT_444 = 0x04,
+    AVTP_RVF_PIXEL_FORMAT_4224 = 0x06,
+    AVTP_RVF_PIXEL_FORMAT_4444 = 0x07,
+    AVTP_RVF_PIXEL_FORMAT_BAYER_GRBG = 0x08,
+    AVTP_RVF_PIXEL_FORMAT_BAYER_RGGB = 0x09,
+    AVTP_RVF_PIXEL_FORMAT_BAYER_BGGR = 0x0A,
+    AVTP_RVF_PIXEL_FORMAT_BAYER_GBRG = 0x0B,
+    AVTP_RVF_PIXEL_FORMAT_USER = 0x0F
 } Avtp_RvfPixelFormat_t;
 
 typedef enum Avtp_RvfFrameRate {
-    AVTP_RVF_FRAME_RATE_1               = 0x01,
-    AVTP_RVF_FRAME_RATE_2               = 0x02,
-    AVTP_RVF_FRAME_RATE_5               = 0x03,
-    AVTP_RVF_FRAME_RATE_10              = 0x10,
-    AVTP_RVF_FRAME_RATE_15              = 0x11,
-    AVTP_RVF_FRAME_RATE_20              = 0x12,
-    AVTP_RVF_FRAME_RATE_24              = 0x13,
-    AVTP_RVF_FRAME_RATE_25              = 0x14,
-    AVTP_RVF_FRAME_RATE_30              = 0x15,
-    AVTP_RVF_FRAME_RATE_48              = 0x16,
-    AVTP_RVF_FRAME_RATE_50              = 0x17,
-    AVTP_RVF_FRAME_RATE_60              = 0x18,
-    AVTP_RVF_FRAME_RATE_72              = 0x19,
-    AVTP_RVF_FRAME_RATE_85              = 0x1A,
-    AVTP_RVF_FRAME_RATE_100             = 0x30,
-    AVTP_RVF_FRAME_RATE_120             = 0x31,
-    AVTP_RVF_FRAME_RATE_150             = 0x32,
-    AVTP_RVF_FRAME_RATE_200             = 0x33,
-    AVTP_RVF_FRAME_RATE_240             = 0x34,
-    AVTP_RVF_FRAME_RATE_300             = 0x35,
-    AVTP_RVF_FRAME_RATE_USER            = 0x0F
+    AVTP_RVF_FRAME_RATE_1 = 0x01,
+    AVTP_RVF_FRAME_RATE_2 = 0x02,
+    AVTP_RVF_FRAME_RATE_5 = 0x03,
+    AVTP_RVF_FRAME_RATE_10 = 0x10,
+    AVTP_RVF_FRAME_RATE_15 = 0x11,
+    AVTP_RVF_FRAME_RATE_20 = 0x12,
+    AVTP_RVF_FRAME_RATE_24 = 0x13,
+    AVTP_RVF_FRAME_RATE_25 = 0x14,
+    AVTP_RVF_FRAME_RATE_30 = 0x15,
+    AVTP_RVF_FRAME_RATE_48 = 0x16,
+    AVTP_RVF_FRAME_RATE_50 = 0x17,
+    AVTP_RVF_FRAME_RATE_60 = 0x18,
+    AVTP_RVF_FRAME_RATE_72 = 0x19,
+    AVTP_RVF_FRAME_RATE_85 = 0x1A,
+    AVTP_RVF_FRAME_RATE_100 = 0x30,
+    AVTP_RVF_FRAME_RATE_120 = 0x31,
+    AVTP_RVF_FRAME_RATE_150 = 0x32,
+    AVTP_RVF_FRAME_RATE_200 = 0x33,
+    AVTP_RVF_FRAME_RATE_240 = 0x34,
+    AVTP_RVF_FRAME_RATE_300 = 0x35,
+    AVTP_RVF_FRAME_RATE_USER = 0x0F
 } Avtp_RvfFrameRate_t;
 
 /* RVF 'colorspace' field values. */
 typedef enum Avtp_RvfColorspace {
-    AVTP_RVF_COLORSPACE_YCbCr           = 0x01,
-    AVTP_RVF_COLORSPACE_SRGB            = 0x02,
-    AVTP_RVF_COLORSPACE_YCgCo           = 0x03,
-    AVTP_RVF_COLORSPACE_GRAY            = 0x04,
-    AVTP_RVF_COLORSPACE_XYZ             = 0x05,
-    AVTP_RVF_COLORSPACE_YCM             = 0x06,
-    AVTP_RVF_COLORSPACE_BT_601          = 0x07,
-    AVTP_RVF_COLORSPACE_BT_709          = 0x08,
-    AVTP_RVF_COLORSPACE_ITU_BT          = 0x09,
-    AVTP_RVF_COLORSPACE_USER            = 0x0F
+    AVTP_RVF_COLORSPACE_YCbCr = 0x01,
+    AVTP_RVF_COLORSPACE_SRGB = 0x02,
+    AVTP_RVF_COLORSPACE_YCgCo = 0x03,
+    AVTP_RVF_COLORSPACE_GRAY = 0x04,
+    AVTP_RVF_COLORSPACE_XYZ = 0x05,
+    AVTP_RVF_COLORSPACE_YCM = 0x06,
+    AVTP_RVF_COLORSPACE_BT_601 = 0x07,
+    AVTP_RVF_COLORSPACE_BT_709 = 0x08,
+    AVTP_RVF_COLORSPACE_ITU_BT = 0x09,
+    AVTP_RVF_COLORSPACE_USER = 0x0F
 } Avtp_RvfColorspace_t;
 
-void Avtp_Rvf_Init(Avtp_Rvf_t* pdu);
+void Avtp_Rvf_Init(Avtp_Rvf_t *pdu);
 
-uint64_t Avtp_Rvf_GetField(const Avtp_Rvf_t* const pdu, Avtp_RvfField_t field);
+uint64_t Avtp_Rvf_GetField(const Avtp_Rvf_t *const pdu, Avtp_RvfField_t field);
 
-uint8_t Avtp_Rvf_GetSubtype(const Avtp_Rvf_t* const pdu);
-uint8_t Avtp_Rvf_GetSv(const Avtp_Rvf_t* const pdu);
-uint8_t Avtp_Rvf_GetVersion(const Avtp_Rvf_t* const pdu);
-uint8_t Avtp_Rvf_GetMr(const Avtp_Rvf_t* const pdu);
-uint8_t Avtp_Rvf_GetTv(const Avtp_Rvf_t* const pdu);
-uint8_t Avtp_Rvf_GetSequenceNum(const Avtp_Rvf_t* const pdu);
-uint8_t Avtp_Rvf_GetTu(const Avtp_Rvf_t* const pdu);
-uint64_t Avtp_Rvf_GetStreamId(const Avtp_Rvf_t* const pdu);
-uint32_t Avtp_Rvf_GetAvtpTimestamp(const Avtp_Rvf_t* const pdu);
-uint16_t Avtp_Rvf_GetActivePixels(const Avtp_Rvf_t* const pdu);
-uint16_t Avtp_Rvf_GetTotalLines(const Avtp_Rvf_t* const pdu);
-uint16_t Avtp_Rvf_GetStreamDataLength(const Avtp_Rvf_t* const pdu);
-uint8_t Avtp_Rvf_GetAp(const Avtp_Rvf_t* const pdu);
-uint8_t Avtp_Rvf_GetF(const Avtp_Rvf_t* const pdu);
-uint8_t Avtp_Rvf_GetEf(const Avtp_Rvf_t* const pdu);
-uint8_t Avtp_Rvf_GetEvt(const Avtp_Rvf_t* const pdu);
-uint8_t Avtp_Rvf_GetPd(const Avtp_Rvf_t* const pdu);
-uint8_t Avtp_Rvf_GetI(const Avtp_Rvf_t* const pdu);
-Avtp_RvfPixelDepth_t Avtp_Rvf_GetPixelDepth(const Avtp_Rvf_t* const pdu);
-Avtp_RvfPixelFormat_t Avtp_Rvf_GetPixelFormat(const Avtp_Rvf_t* const pdu);
-Avtp_RvfFrameRate_t Avtp_Rvf_GetFrameRate(const Avtp_Rvf_t* const pdu);
-Avtp_RvfColorspace_t Avtp_Rvf_GetColorspace(const Avtp_Rvf_t* const pdu);
-uint8_t Avtp_Rvf_GetNumLines(const Avtp_Rvf_t* const pdu);
-uint8_t Avtp_Rvf_GetISeqNum(const Avtp_Rvf_t* const pdu);
-uint16_t Avtp_Rvf_GetLineNumber(const Avtp_Rvf_t* const pdu);
+uint8_t Avtp_Rvf_GetSv(const Avtp_Rvf_t *const pdu);
+uint8_t Avtp_Rvf_GetVersion(const Avtp_Rvf_t *const pdu);
+uint8_t Avtp_Rvf_GetMr(const Avtp_Rvf_t *const pdu);
+uint8_t Avtp_Rvf_GetTv(const Avtp_Rvf_t *const pdu);
+uint8_t Avtp_Rvf_GetSequenceNum(const Avtp_Rvf_t *const pdu);
+uint8_t Avtp_Rvf_GetTu(const Avtp_Rvf_t *const pdu);
+uint64_t Avtp_Rvf_GetStreamId(const Avtp_Rvf_t *const pdu);
+uint32_t Avtp_Rvf_GetAvtpTimestamp(const Avtp_Rvf_t *const pdu);
+uint16_t Avtp_Rvf_GetActivePixels(const Avtp_Rvf_t *const pdu);
+uint16_t Avtp_Rvf_GetTotalLines(const Avtp_Rvf_t *const pdu);
+uint16_t Avtp_Rvf_GetStreamDataLength(const Avtp_Rvf_t *const pdu);
+uint8_t Avtp_Rvf_GetAp(const Avtp_Rvf_t *const pdu);
+uint8_t Avtp_Rvf_GetF(const Avtp_Rvf_t *const pdu);
+uint8_t Avtp_Rvf_GetEf(const Avtp_Rvf_t *const pdu);
+uint8_t Avtp_Rvf_GetEvt(const Avtp_Rvf_t *const pdu);
+uint8_t Avtp_Rvf_GetPd(const Avtp_Rvf_t *const pdu);
+uint8_t Avtp_Rvf_GetI(const Avtp_Rvf_t *const pdu);
+Avtp_RvfPixelDepth_t Avtp_Rvf_GetPixelDepth(const Avtp_Rvf_t *const pdu);
+Avtp_RvfPixelFormat_t Avtp_Rvf_GetPixelFormat(const Avtp_Rvf_t *const pdu);
+Avtp_RvfFrameRate_t Avtp_Rvf_GetFrameRate(const Avtp_Rvf_t *const pdu);
+Avtp_RvfColorspace_t Avtp_Rvf_GetColorspace(const Avtp_Rvf_t *const pdu);
+uint8_t Avtp_Rvf_GetNumLines(const Avtp_Rvf_t *const pdu);
+uint8_t Avtp_Rvf_GetISeqNum(const Avtp_Rvf_t *const pdu);
+uint16_t Avtp_Rvf_GetLineNumber(const Avtp_Rvf_t *const pdu);
 
-void Avtp_Rvf_SetField(Avtp_Rvf_t* pdu, Avtp_RvfField_t field, uint64_t value);
+void Avtp_Rvf_SetField(Avtp_Rvf_t *pdu, Avtp_RvfField_t field, uint64_t value);
 
-void Avtp_Rvf_SetSubtype(Avtp_Rvf_t* pdu, uint8_t value);
-void Avtp_Rvf_EnableSv(Avtp_Rvf_t* pdu);
-void Avtp_Rvf_DisableSv(Avtp_Rvf_t* pdu);
-void Avtp_Rvf_SetVersion(Avtp_Rvf_t* pdu, uint8_t value);
-void Avtp_Rvf_EnableMr(Avtp_Rvf_t* pdu);
-void Avtp_Rvf_DisableMr(Avtp_Rvf_t* pdu);
-void Avtp_Rvf_EnableTv(Avtp_Rvf_t* pdu);
-void Avtp_Rvf_DisableTv(Avtp_Rvf_t* pdu);
-void Avtp_Rvf_SetSequenceNum(Avtp_Rvf_t* pdu, uint8_t value);
-void Avtp_Rvf_EnableTu(Avtp_Rvf_t* pdu);
-void Avtp_Rvf_DisableTu(Avtp_Rvf_t* pdu);
-void Avtp_Rvf_SetStreamId(Avtp_Rvf_t* pdu, uint64_t value);
-void Avtp_Rvf_SetAvtpTimestamp(Avtp_Rvf_t* pdu, uint32_t value);
-void Avtp_Rvf_SetActivePixels(Avtp_Rvf_t* pdu, uint16_t value);
-void Avtp_Rvf_SetTotalLines(Avtp_Rvf_t* pdu, uint16_t value);
-void Avtp_Rvf_SetStreamDataLength(Avtp_Rvf_t* pdu, uint16_t value);
-void Avtp_Rvf_EnableAp(Avtp_Rvf_t* pdu);
-void Avtp_Rvf_DisableAp(Avtp_Rvf_t* pdu);
-void Avtp_Rvf_EnableF(Avtp_Rvf_t* pdu);
-void Avtp_Rvf_DisableF(Avtp_Rvf_t* pdu);
-void Avtp_Rvf_EnableEf(Avtp_Rvf_t* pdu);
-void Avtp_Rvf_DisableEf(Avtp_Rvf_t* pdu);
-void Avtp_Rvf_SetEvt(Avtp_Rvf_t* pdu, uint8_t value);
-void Avtp_Rvf_EnablePd(Avtp_Rvf_t* pdu);
-void Avtp_Rvf_DisablePd(Avtp_Rvf_t* pdu);
-void Avtp_Rvf_EnableI(Avtp_Rvf_t* pdu);
-void Avtp_Rvf_DisableI(Avtp_Rvf_t* pdu);
-void Avtp_Rvf_SetPixelDepth(Avtp_Rvf_t* pdu, Avtp_RvfPixelDepth_t value);
-void Avtp_Rvf_SetPixelFormat(Avtp_Rvf_t* pdu, Avtp_RvfPixelFormat_t value);
-void Avtp_Rvf_SetFrameRate(Avtp_Rvf_t* pdu, Avtp_RvfFrameRate_t value);
-void Avtp_Rvf_SetColorspace(Avtp_Rvf_t* pdu, Avtp_RvfColorspace_t value);
-void Avtp_Rvf_SetNumLines(Avtp_Rvf_t* pdu, uint8_t value);
-void Avtp_Rvf_SetISeqNum(Avtp_Rvf_t* pdu, uint8_t value);
-void Avtp_Rvf_SetLineNumber(Avtp_Rvf_t* pdu, uint16_t value);
+void Avtp_Rvf_EnableSv(Avtp_Rvf_t *pdu);
+void Avtp_Rvf_DisableSv(Avtp_Rvf_t *pdu);
+void Avtp_Rvf_SetVersion(Avtp_Rvf_t *pdu, uint8_t value);
+void Avtp_Rvf_EnableMr(Avtp_Rvf_t *pdu);
+void Avtp_Rvf_DisableMr(Avtp_Rvf_t *pdu);
+void Avtp_Rvf_EnableTv(Avtp_Rvf_t *pdu);
+void Avtp_Rvf_DisableTv(Avtp_Rvf_t *pdu);
+void Avtp_Rvf_SetSequenceNum(Avtp_Rvf_t *pdu, uint8_t value);
+void Avtp_Rvf_EnableTu(Avtp_Rvf_t *pdu);
+void Avtp_Rvf_DisableTu(Avtp_Rvf_t *pdu);
+void Avtp_Rvf_SetStreamId(Avtp_Rvf_t *pdu, uint64_t value);
+void Avtp_Rvf_SetAvtpTimestamp(Avtp_Rvf_t *pdu, uint32_t value);
+void Avtp_Rvf_SetActivePixels(Avtp_Rvf_t *pdu, uint16_t value);
+void Avtp_Rvf_SetTotalLines(Avtp_Rvf_t *pdu, uint16_t value);
+void Avtp_Rvf_SetStreamDataLength(Avtp_Rvf_t *pdu, uint16_t value);
+void Avtp_Rvf_EnableAp(Avtp_Rvf_t *pdu);
+void Avtp_Rvf_DisableAp(Avtp_Rvf_t *pdu);
+void Avtp_Rvf_EnableF(Avtp_Rvf_t *pdu);
+void Avtp_Rvf_DisableF(Avtp_Rvf_t *pdu);
+void Avtp_Rvf_EnableEf(Avtp_Rvf_t *pdu);
+void Avtp_Rvf_DisableEf(Avtp_Rvf_t *pdu);
+void Avtp_Rvf_SetEvt(Avtp_Rvf_t *pdu, uint8_t value);
+void Avtp_Rvf_EnablePd(Avtp_Rvf_t *pdu);
+void Avtp_Rvf_DisablePd(Avtp_Rvf_t *pdu);
+void Avtp_Rvf_EnableI(Avtp_Rvf_t *pdu);
+void Avtp_Rvf_DisableI(Avtp_Rvf_t *pdu);
+void Avtp_Rvf_SetPixelDepth(Avtp_Rvf_t *pdu, Avtp_RvfPixelDepth_t value);
+void Avtp_Rvf_SetPixelFormat(Avtp_Rvf_t *pdu, Avtp_RvfPixelFormat_t value);
+void Avtp_Rvf_SetFrameRate(Avtp_Rvf_t *pdu, Avtp_RvfFrameRate_t value);
+void Avtp_Rvf_SetColorspace(Avtp_Rvf_t *pdu, Avtp_RvfColorspace_t value);
+void Avtp_Rvf_SetNumLines(Avtp_Rvf_t *pdu, uint8_t value);
+void Avtp_Rvf_SetISeqNum(Avtp_Rvf_t *pdu, uint8_t value);
+void Avtp_Rvf_SetLineNumber(Avtp_Rvf_t *pdu, uint16_t value);
 
 /******************************************************************************
  * Legacy API (deprecated)
  *****************************************************************************/
 
-#define AVTP_RVF_FIELD_SEQ_NUM          (AVTP_RVF_FIELD_SEQUENCE_NUM)
-#define AVTP_RVF_FIELD_TIMESTAMP        (AVTP_RVF_FIELD_AVTP_TIMESTAMP)
-#define AVTP_RVF_FIELD_STREAM_DATA_LEN  (AVTP_RVF_FIELD_STREAM_DATA_LENGTH)
-#define AVTP_RVF_FIELD_RAW_PIXEL_DEPTH  (AVTP_RVF_FIELD_PIXEL_DEPTH)
+#define AVTP_RVF_FIELD_SEQ_NUM (AVTP_RVF_FIELD_SEQUENCE_NUM)
+#define AVTP_RVF_FIELD_TIMESTAMP (AVTP_RVF_FIELD_AVTP_TIMESTAMP)
+#define AVTP_RVF_FIELD_STREAM_DATA_LEN (AVTP_RVF_FIELD_STREAM_DATA_LENGTH)
+#define AVTP_RVF_FIELD_RAW_PIXEL_DEPTH (AVTP_RVF_FIELD_PIXEL_DEPTH)
 #define AVTP_RVF_FIELD_RAW_PIXEL_FORMAT (AVTP_RVF_FIELD_PIXEL_FORMAT)
-#define AVTP_RVF_FIELD_RAW_FRAME_RATE   (AVTP_RVF_FIELD_FRAME_RATE)
-#define AVTP_RVF_FIELD_RAW_COLORSPACE   (AVTP_RVF_FIELD_COLORSPACE)
-#define AVTP_RVF_FIELD_RAW_NUM_LINES    (AVTP_RVF_FIELD_NUM_LINES)
-#define AVTP_RVF_FIELD_RAW_I_SEQ_NUM    (AVTP_RVF_FIELD_I_SEQ_NUM)
-#define AVTP_RVF_FIELD_RAW_LINE_NUMBER  (AVTP_RVF_FIELD_LINE_NUMBER)
+#define AVTP_RVF_FIELD_RAW_FRAME_RATE (AVTP_RVF_FIELD_FRAME_RATE)
+#define AVTP_RVF_FIELD_RAW_COLORSPACE (AVTP_RVF_FIELD_COLORSPACE)
+#define AVTP_RVF_FIELD_RAW_NUM_LINES (AVTP_RVF_FIELD_NUM_LINES)
+#define AVTP_RVF_FIELD_RAW_I_SEQ_NUM (AVTP_RVF_FIELD_I_SEQ_NUM)
+#define AVTP_RVF_FIELD_RAW_LINE_NUMBER (AVTP_RVF_FIELD_LINE_NUMBER)
 
 struct avtp_rvf_payload {
     uint64_t raw_header;
@@ -242,7 +240,7 @@ struct avtp_rvf_payload {
  *    0: Success.
  *    -EINVAL: If any argument is invalid.
  */
-int avtp_rvf_pdu_get(const void* const pdu, Avtp_RvfField_t field, uint64_t* val);
+int avtp_rvf_pdu_get(const void *const pdu, Avtp_RvfField_t field, uint64_t *val);
 
 /**
  * @deprecated
@@ -255,7 +253,7 @@ int avtp_rvf_pdu_get(const void* const pdu, Avtp_RvfField_t field, uint64_t* val
  *    0: Success.
  *    -EINVAL: If any argument is invalid.
  */
-int avtp_rvf_pdu_set(void* pdu, Avtp_RvfField_t field, uint64_t val);
+int avtp_rvf_pdu_set(void *pdu, Avtp_RvfField_t field, uint64_t val);
 
 /**
  * @deprecated
@@ -268,7 +266,7 @@ int avtp_rvf_pdu_set(void* pdu, Avtp_RvfField_t field, uint64_t val);
  *    0: Success.
  *    -EINVAL: If any argument is invalid.
  */
-int avtp_rvf_pdu_init(void* pdu);
+int avtp_rvf_pdu_init(void *pdu);
 
 #ifdef __cplusplus
 }

--- a/include/avtp/Rvf.h
+++ b/include/avtp/Rvf.h
@@ -149,7 +149,6 @@ void Avtp_Rvf_Init(Avtp_Rvf_t *pdu);
 uint64_t Avtp_Rvf_GetField(const Avtp_Rvf_t *const pdu, Avtp_RvfField_t field);
 
 uint8_t Avtp_Rvf_GetSv(const Avtp_Rvf_t *const pdu);
-uint8_t Avtp_Rvf_GetVersion(const Avtp_Rvf_t *const pdu);
 uint8_t Avtp_Rvf_GetMr(const Avtp_Rvf_t *const pdu);
 uint8_t Avtp_Rvf_GetTv(const Avtp_Rvf_t *const pdu);
 uint8_t Avtp_Rvf_GetSequenceNum(const Avtp_Rvf_t *const pdu);
@@ -177,7 +176,6 @@ void Avtp_Rvf_SetField(Avtp_Rvf_t *pdu, Avtp_RvfField_t field, uint64_t value);
 
 void Avtp_Rvf_EnableSv(Avtp_Rvf_t *pdu);
 void Avtp_Rvf_DisableSv(Avtp_Rvf_t *pdu);
-void Avtp_Rvf_SetVersion(Avtp_Rvf_t *pdu, uint8_t value);
 void Avtp_Rvf_EnableMr(Avtp_Rvf_t *pdu);
 void Avtp_Rvf_DisableMr(Avtp_Rvf_t *pdu);
 void Avtp_Rvf_EnableTv(Avtp_Rvf_t *pdu);

--- a/include/avtp/aaf/Aaf.h
+++ b/include/avtp/aaf/Aaf.h
@@ -43,7 +43,7 @@
 extern "C" {
 #endif
 
-#define AVTP_AAF_HEADER_LEN              (6 * AVTP_QUADLET_SIZE)
+#define AVTP_AAF_HEADER_LEN (6 * AVTP_QUADLET_SIZE)
 
 typedef struct {
     uint8_t header[AVTP_AAF_HEADER_LEN];
@@ -71,29 +71,29 @@ typedef enum {
 } Avtp_AafFields_t;
 
 /**
- * Returns the value of an an AVTP AAF common stream field as specified in the IEEE 1722 Specification.
+ * Returns the value of an an AVTP AAF common stream field as specified in the IEEE 1722
+ * Specification.
  *
  * @param pdu Pointer to the first bit of an 1722 AVTP PDU.
  * @param field Specifies the position of the data field to be read
  * @param value Pointer to location to store the value.
  * @returns The PDU fieldvalue
  */
-uint64_t Avtp_Aaf_GetField(const Avtp_Aaf_t* const pdu, Avtp_AafFields_t field);
+uint64_t Avtp_Aaf_GetField(const Avtp_Aaf_t *const pdu, Avtp_AafFields_t field);
 
-uint8_t Avtp_Aaf_GetSubtype(const Avtp_Aaf_t* const pdu);
-uint8_t Avtp_Aaf_GetSv(const Avtp_Aaf_t* const pdu);
-uint8_t Avtp_Aaf_GetVersion(const Avtp_Aaf_t* const pdu);
-uint8_t Avtp_Aaf_GetMr(const Avtp_Aaf_t* const pdu);
-uint8_t Avtp_Aaf_GetTv(const Avtp_Aaf_t* const pdu);
-uint8_t Avtp_Aaf_GetSequenceNum(const Avtp_Aaf_t* const pdu);
-uint8_t Avtp_Aaf_GetTu(const Avtp_Aaf_t* const pdu);
-uint64_t Avtp_Aaf_GetStreamId(const Avtp_Aaf_t* const pdu);
-uint32_t Avtp_Aaf_GetAvtpTimestamp(const Avtp_Aaf_t* const pdu);
-uint8_t Avtp_Aaf_GetFormat(const Avtp_Aaf_t* const pdu);
-uint16_t Avtp_Aaf_GetStreamDataLength(const Avtp_Aaf_t* const pdu);
-uint8_t Avtp_Aaf_GetAfsd(const Avtp_Aaf_t* const pdu);
-uint8_t Avtp_Aaf_GetSp(const Avtp_Aaf_t* const pdu);
-uint8_t Avtp_Aaf_GetEvt(const Avtp_Aaf_t* const pdu);
+uint8_t Avtp_Aaf_GetSv(const Avtp_Aaf_t *const pdu);
+uint8_t Avtp_Aaf_GetVersion(const Avtp_Aaf_t *const pdu);
+uint8_t Avtp_Aaf_GetMr(const Avtp_Aaf_t *const pdu);
+uint8_t Avtp_Aaf_GetTv(const Avtp_Aaf_t *const pdu);
+uint8_t Avtp_Aaf_GetSequenceNum(const Avtp_Aaf_t *const pdu);
+uint8_t Avtp_Aaf_GetTu(const Avtp_Aaf_t *const pdu);
+uint64_t Avtp_Aaf_GetStreamId(const Avtp_Aaf_t *const pdu);
+uint32_t Avtp_Aaf_GetAvtpTimestamp(const Avtp_Aaf_t *const pdu);
+uint8_t Avtp_Aaf_GetFormat(const Avtp_Aaf_t *const pdu);
+uint16_t Avtp_Aaf_GetStreamDataLength(const Avtp_Aaf_t *const pdu);
+uint8_t Avtp_Aaf_GetAfsd(const Avtp_Aaf_t *const pdu);
+uint8_t Avtp_Aaf_GetSp(const Avtp_Aaf_t *const pdu);
+uint8_t Avtp_Aaf_GetEvt(const Avtp_Aaf_t *const pdu);
 
 /**
  * Sets the value of an an AVTP AAF common stream field as specified in the IEEE 1722 Specification.
@@ -102,27 +102,26 @@ uint8_t Avtp_Aaf_GetEvt(const Avtp_Aaf_t* const pdu);
  * @param field Specifies the position of the data field to be read
  * @param value Pointer to location to store the value.
  */
-void Avtp_Aaf_SetField(Avtp_Aaf_t* pdu, Avtp_AafFields_t field, uint64_t value);
+void Avtp_Aaf_SetField(Avtp_Aaf_t *pdu, Avtp_AafFields_t field, uint64_t value);
 
-void Avtp_Aaf_SetSubtype(Avtp_Aaf_t* pdu, uint8_t value);
-void Avtp_Aaf_EnableSv(Avtp_Aaf_t* pdu);
-void Avtp_Aaf_DisableSv(Avtp_Aaf_t* pdu);
-void Avtp_Aaf_SetVersion(Avtp_Aaf_t* pdu, uint8_t value);
-void Avtp_Aaf_EnableMr(Avtp_Aaf_t* pdu);
-void Avtp_Aaf_DisableMr(Avtp_Aaf_t* pdu);
-void Avtp_Aaf_EnableTv(Avtp_Aaf_t* pdu);
-void Avtp_Aaf_DisableTv(Avtp_Aaf_t* pdu);
-void Avtp_Aaf_SetSequenceNum(Avtp_Aaf_t* pdu, uint8_t value);
-void Avtp_Aaf_EnableTu(Avtp_Aaf_t* pdu);
-void Avtp_Aaf_DisableTu(Avtp_Aaf_t* pdu);
-void Avtp_Aaf_SetStreamId(Avtp_Aaf_t* pdu, uint64_t value);
-void Avtp_Aaf_SetAvtpTimestamp(Avtp_Aaf_t* pdu, uint32_t value);
-void Avtp_Aaf_SetFormat(Avtp_Aaf_t* pdu, uint8_t value);
-void Avtp_Aaf_SetStreamDataLength(Avtp_Aaf_t* pdu, uint16_t value);
-void Avtp_Aaf_SetAfsd(Avtp_Aaf_t* pdu, uint8_t value);
-void Avtp_Aaf_EnableSp(Avtp_Aaf_t* pdu);
-void Avtp_Aaf_DisableSp(Avtp_Aaf_t* pdu);
-void Avtp_Aaf_SetEvt(Avtp_Aaf_t* pdu, uint8_t value);
+void Avtp_Aaf_EnableSv(Avtp_Aaf_t *pdu);
+void Avtp_Aaf_DisableSv(Avtp_Aaf_t *pdu);
+void Avtp_Aaf_SetVersion(Avtp_Aaf_t *pdu, uint8_t value);
+void Avtp_Aaf_EnableMr(Avtp_Aaf_t *pdu);
+void Avtp_Aaf_DisableMr(Avtp_Aaf_t *pdu);
+void Avtp_Aaf_EnableTv(Avtp_Aaf_t *pdu);
+void Avtp_Aaf_DisableTv(Avtp_Aaf_t *pdu);
+void Avtp_Aaf_SetSequenceNum(Avtp_Aaf_t *pdu, uint8_t value);
+void Avtp_Aaf_EnableTu(Avtp_Aaf_t *pdu);
+void Avtp_Aaf_DisableTu(Avtp_Aaf_t *pdu);
+void Avtp_Aaf_SetStreamId(Avtp_Aaf_t *pdu, uint64_t value);
+void Avtp_Aaf_SetAvtpTimestamp(Avtp_Aaf_t *pdu, uint32_t value);
+void Avtp_Aaf_SetFormat(Avtp_Aaf_t *pdu, uint8_t value);
+void Avtp_Aaf_SetStreamDataLength(Avtp_Aaf_t *pdu, uint16_t value);
+void Avtp_Aaf_SetAfsd(Avtp_Aaf_t *pdu, uint8_t value);
+void Avtp_Aaf_EnableSp(Avtp_Aaf_t *pdu);
+void Avtp_Aaf_DisableSp(Avtp_Aaf_t *pdu);
+void Avtp_Aaf_SetEvt(Avtp_Aaf_t *pdu, uint8_t value);
 
 #ifdef __cplusplus
 }

--- a/include/avtp/aaf/Aaf.h
+++ b/include/avtp/aaf/Aaf.h
@@ -82,7 +82,6 @@ typedef enum {
 uint64_t Avtp_Aaf_GetField(const Avtp_Aaf_t *const pdu, Avtp_AafFields_t field);
 
 uint8_t Avtp_Aaf_GetSv(const Avtp_Aaf_t *const pdu);
-uint8_t Avtp_Aaf_GetVersion(const Avtp_Aaf_t *const pdu);
 uint8_t Avtp_Aaf_GetMr(const Avtp_Aaf_t *const pdu);
 uint8_t Avtp_Aaf_GetTv(const Avtp_Aaf_t *const pdu);
 uint8_t Avtp_Aaf_GetSequenceNum(const Avtp_Aaf_t *const pdu);
@@ -106,7 +105,6 @@ void Avtp_Aaf_SetField(Avtp_Aaf_t *pdu, Avtp_AafFields_t field, uint64_t value);
 
 void Avtp_Aaf_EnableSv(Avtp_Aaf_t *pdu);
 void Avtp_Aaf_DisableSv(Avtp_Aaf_t *pdu);
-void Avtp_Aaf_SetVersion(Avtp_Aaf_t *pdu, uint8_t value);
 void Avtp_Aaf_EnableMr(Avtp_Aaf_t *pdu);
 void Avtp_Aaf_DisableMr(Avtp_Aaf_t *pdu);
 void Avtp_Aaf_EnableTv(Avtp_Aaf_t *pdu);

--- a/include/avtp/aaf/Pcm.h
+++ b/include/avtp/aaf/Pcm.h
@@ -114,7 +114,6 @@ void Avtp_Pcm_Init(Avtp_Pcm_t *pdu);
 uint64_t Avtp_Pcm_GetField(const Avtp_Pcm_t *const pdu, Avtp_PcmFields_t field);
 
 uint8_t Avtp_Pcm_GetSv(const Avtp_Pcm_t *const pdu);
-uint8_t Avtp_Pcm_GetVersion(const Avtp_Pcm_t *const pdu);
 uint8_t Avtp_Pcm_GetMr(const Avtp_Pcm_t *const pdu);
 uint8_t Avtp_Pcm_GetTv(const Avtp_Pcm_t *const pdu);
 uint8_t Avtp_Pcm_GetSequenceNum(const Avtp_Pcm_t *const pdu);
@@ -142,7 +141,6 @@ void Avtp_Pcm_SetField(Avtp_Pcm_t *pdu, Avtp_PcmFields_t field, uint64_t value);
 
 void Avtp_Pcm_EnableSv(Avtp_Pcm_t *pdu);
 void Avtp_Pcm_DisableSv(Avtp_Pcm_t *pdu);
-void Avtp_Pcm_SetVersion(Avtp_Pcm_t *pdu, uint8_t value);
 void Avtp_Pcm_EnableMr(Avtp_Pcm_t *pdu);
 void Avtp_Pcm_DisableMr(Avtp_Pcm_t *pdu);
 void Avtp_Pcm_EnableTv(Avtp_Pcm_t *pdu);

--- a/include/avtp/aaf/Pcm.h
+++ b/include/avtp/aaf/Pcm.h
@@ -38,7 +38,7 @@
 extern "C" {
 #endif
 
-#define AVTP_PCM_HEADER_LEN              (6 * AVTP_QUADLET_SIZE)
+#define AVTP_PCM_HEADER_LEN (6 * AVTP_QUADLET_SIZE)
 
 typedef struct {
     uint8_t header[AVTP_PCM_HEADER_LEN];
@@ -100,7 +100,7 @@ typedef enum {
  *
  * @param pdu Pointer to the first bit of a 1722 PDU.
  */
-void Avtp_Pcm_Init(Avtp_Pcm_t* pdu);
+void Avtp_Pcm_Init(Avtp_Pcm_t *pdu);
 
 /**
  * Returns the value of an an AVTP AAF PCM stream field as specified in the IEEE 1722 Specification.
@@ -111,24 +111,23 @@ void Avtp_Pcm_Init(Avtp_Pcm_t* pdu);
  * @returns This function returns 0 if the data field was successfully read from
  * the 1722 AVTP PDU.
  */
-uint64_t Avtp_Pcm_GetField(const Avtp_Pcm_t* const pdu, Avtp_PcmFields_t field);
+uint64_t Avtp_Pcm_GetField(const Avtp_Pcm_t *const pdu, Avtp_PcmFields_t field);
 
-uint8_t Avtp_Pcm_GetSubtype(const Avtp_Pcm_t* const pdu);
-uint8_t Avtp_Pcm_GetSv(const Avtp_Pcm_t* const pdu);
-uint8_t Avtp_Pcm_GetVersion(const Avtp_Pcm_t* const pdu);
-uint8_t Avtp_Pcm_GetMr(const Avtp_Pcm_t* const pdu);
-uint8_t Avtp_Pcm_GetTv(const Avtp_Pcm_t* const pdu);
-uint8_t Avtp_Pcm_GetSequenceNum(const Avtp_Pcm_t* const pdu);
-uint8_t Avtp_Pcm_GetTu(const Avtp_Pcm_t* const pdu);
-uint64_t Avtp_Pcm_GetStreamId(const Avtp_Pcm_t* const pdu);
-uint32_t Avtp_Pcm_GetAvtpTimestamp(const Avtp_Pcm_t* const pdu);
-Avtp_AafFormat_t Avtp_Pcm_GetFormat(const Avtp_Pcm_t* const pdu);
-Avtp_AafNsr_t Avtp_Pcm_GetNsr(const Avtp_Pcm_t* const pdu);
-uint16_t Avtp_Pcm_GetChannelsPerFrame(const Avtp_Pcm_t* const pdu);
-uint8_t Avtp_Pcm_GetBitDepth(const Avtp_Pcm_t* const pdu);
-uint16_t Avtp_Pcm_GetStreamDataLength(const Avtp_Pcm_t* const pdu);
-Avtp_AafSp_t Avtp_Pcm_GetSp(const Avtp_Pcm_t* const pdu);
-uint8_t Avtp_Pcm_GetEvt(const Avtp_Pcm_t* const pdu);
+uint8_t Avtp_Pcm_GetSv(const Avtp_Pcm_t *const pdu);
+uint8_t Avtp_Pcm_GetVersion(const Avtp_Pcm_t *const pdu);
+uint8_t Avtp_Pcm_GetMr(const Avtp_Pcm_t *const pdu);
+uint8_t Avtp_Pcm_GetTv(const Avtp_Pcm_t *const pdu);
+uint8_t Avtp_Pcm_GetSequenceNum(const Avtp_Pcm_t *const pdu);
+uint8_t Avtp_Pcm_GetTu(const Avtp_Pcm_t *const pdu);
+uint64_t Avtp_Pcm_GetStreamId(const Avtp_Pcm_t *const pdu);
+uint32_t Avtp_Pcm_GetAvtpTimestamp(const Avtp_Pcm_t *const pdu);
+Avtp_AafFormat_t Avtp_Pcm_GetFormat(const Avtp_Pcm_t *const pdu);
+Avtp_AafNsr_t Avtp_Pcm_GetNsr(const Avtp_Pcm_t *const pdu);
+uint16_t Avtp_Pcm_GetChannelsPerFrame(const Avtp_Pcm_t *const pdu);
+uint8_t Avtp_Pcm_GetBitDepth(const Avtp_Pcm_t *const pdu);
+uint16_t Avtp_Pcm_GetStreamDataLength(const Avtp_Pcm_t *const pdu);
+Avtp_AafSp_t Avtp_Pcm_GetSp(const Avtp_Pcm_t *const pdu);
+uint8_t Avtp_Pcm_GetEvt(const Avtp_Pcm_t *const pdu);
 
 /**
  * Sets the value of an an AVTP AAF PCM stream field as specified in the IEEE 1722 Specification.
@@ -139,49 +138,48 @@ uint8_t Avtp_Pcm_GetEvt(const Avtp_Pcm_t* const pdu);
  * @returns This function returns 0 if the data field was successfully set in
  * the 1722 AVTP PDU.
  */
-void Avtp_Pcm_SetField(Avtp_Pcm_t* pdu, Avtp_PcmFields_t field, uint64_t value);
+void Avtp_Pcm_SetField(Avtp_Pcm_t *pdu, Avtp_PcmFields_t field, uint64_t value);
 
-void Avtp_Pcm_SetSubtype(Avtp_Pcm_t* pdu, uint8_t value);
-void Avtp_Pcm_EnableSv(Avtp_Pcm_t* pdu);
-void Avtp_Pcm_DisableSv(Avtp_Pcm_t* pdu);
-void Avtp_Pcm_SetVersion(Avtp_Pcm_t* pdu, uint8_t value);
-void Avtp_Pcm_EnableMr(Avtp_Pcm_t* pdu);
-void Avtp_Pcm_DisableMr(Avtp_Pcm_t* pdu);
-void Avtp_Pcm_EnableTv(Avtp_Pcm_t* pdu);
-void Avtp_Pcm_DisableTv(Avtp_Pcm_t* pdu);
-void Avtp_Pcm_SetSequenceNum(Avtp_Pcm_t* pdu, uint8_t value);
-void Avtp_Pcm_EnableTu(Avtp_Pcm_t* pdu);
-void Avtp_Pcm_DisableTu(Avtp_Pcm_t* pdu);
-void Avtp_Pcm_SetStreamId(Avtp_Pcm_t* pdu, uint64_t value);
-void Avtp_Pcm_SetAvtpTimestamp(Avtp_Pcm_t* pdu, uint32_t value);
-void Avtp_Pcm_SetFormat(Avtp_Pcm_t* pdu, Avtp_AafFormat_t value);
-void Avtp_Pcm_SetNsr(Avtp_Pcm_t* pdu, Avtp_AafNsr_t value);
-void Avtp_Pcm_SetChannelsPerFrame(Avtp_Pcm_t* pdu, uint16_t value);
-void Avtp_Pcm_SetBitDepth(Avtp_Pcm_t* pdu, uint8_t value);
-void Avtp_Pcm_SetStreamDataLength(Avtp_Pcm_t* pdu, uint16_t value);
-void Avtp_Pcm_EnableSp(Avtp_Pcm_t* pdu);
-void Avtp_Pcm_DisableSp(Avtp_Pcm_t* pdu);
-void Avtp_Pcm_SetEvt(Avtp_Pcm_t* pdu, uint8_t value);
+void Avtp_Pcm_EnableSv(Avtp_Pcm_t *pdu);
+void Avtp_Pcm_DisableSv(Avtp_Pcm_t *pdu);
+void Avtp_Pcm_SetVersion(Avtp_Pcm_t *pdu, uint8_t value);
+void Avtp_Pcm_EnableMr(Avtp_Pcm_t *pdu);
+void Avtp_Pcm_DisableMr(Avtp_Pcm_t *pdu);
+void Avtp_Pcm_EnableTv(Avtp_Pcm_t *pdu);
+void Avtp_Pcm_DisableTv(Avtp_Pcm_t *pdu);
+void Avtp_Pcm_SetSequenceNum(Avtp_Pcm_t *pdu, uint8_t value);
+void Avtp_Pcm_EnableTu(Avtp_Pcm_t *pdu);
+void Avtp_Pcm_DisableTu(Avtp_Pcm_t *pdu);
+void Avtp_Pcm_SetStreamId(Avtp_Pcm_t *pdu, uint64_t value);
+void Avtp_Pcm_SetAvtpTimestamp(Avtp_Pcm_t *pdu, uint32_t value);
+void Avtp_Pcm_SetFormat(Avtp_Pcm_t *pdu, Avtp_AafFormat_t value);
+void Avtp_Pcm_SetNsr(Avtp_Pcm_t *pdu, Avtp_AafNsr_t value);
+void Avtp_Pcm_SetChannelsPerFrame(Avtp_Pcm_t *pdu, uint16_t value);
+void Avtp_Pcm_SetBitDepth(Avtp_Pcm_t *pdu, uint8_t value);
+void Avtp_Pcm_SetStreamDataLength(Avtp_Pcm_t *pdu, uint16_t value);
+void Avtp_Pcm_EnableSp(Avtp_Pcm_t *pdu);
+void Avtp_Pcm_DisableSp(Avtp_Pcm_t *pdu);
+void Avtp_Pcm_SetEvt(Avtp_Pcm_t *pdu, uint8_t value);
 
 /******************************************************************************
  * Legacy API (deprecated)
  *****************************************************************************/
 
-#define AVTP_AAF_FIELD_SV               AVTP_PCM_FIELD_SV
-#define AVTP_AAF_FIELD_MR               AVTP_PCM_FIELD_MR
-#define AVTP_AAF_FIELD_TV               AVTP_PCM_FIELD_TV
-#define AVTP_AAF_FIELD_SEQ_NUM          AVTP_PCM_FIELD_SEQUENCE_NUM
-#define AVTP_AAF_FIELD_TU               AVTP_PCM_FIELD_TU
-#define AVTP_AAF_FIELD_STREAM_ID        AVTP_PCM_FIELD_STREAM_ID
-#define AVTP_AAF_FIELD_TIMESTAMP        AVTP_PCM_FIELD_AVTP_TIMESTAMP
-#define AVTP_AAF_FIELD_STREAM_DATA_LEN  AVTP_PCM_FIELD_STREAM_DATA_LENGTH
-#define AVTP_AAF_FIELD_FORMAT           AVTP_PCM_FIELD_FORMAT
-#define AVTP_AAF_FIELD_NSR              AVTP_PCM_FIELD_NSR
-#define AVTP_AAF_FIELD_CHAN_PER_FRAME   AVTP_PCM_FIELD_CHANNELS_PER_FRAME
-#define AVTP_AAF_FIELD_BIT_DEPTH        AVTP_PCM_FIELD_BIT_DEPTH
-#define AVTP_AAF_FIELD_SP               AVTP_PCM_FIELD_SP
-#define AVTP_AAF_FIELD_EVT              AVTP_PCM_FIELD_EVT
-#define AVTP_AAF_FIELD_MAX              AVTP_PCM_FIELD_MAX
+#define AVTP_AAF_FIELD_SV AVTP_PCM_FIELD_SV
+#define AVTP_AAF_FIELD_MR AVTP_PCM_FIELD_MR
+#define AVTP_AAF_FIELD_TV AVTP_PCM_FIELD_TV
+#define AVTP_AAF_FIELD_SEQ_NUM AVTP_PCM_FIELD_SEQUENCE_NUM
+#define AVTP_AAF_FIELD_TU AVTP_PCM_FIELD_TU
+#define AVTP_AAF_FIELD_STREAM_ID AVTP_PCM_FIELD_STREAM_ID
+#define AVTP_AAF_FIELD_TIMESTAMP AVTP_PCM_FIELD_AVTP_TIMESTAMP
+#define AVTP_AAF_FIELD_STREAM_DATA_LEN AVTP_PCM_FIELD_STREAM_DATA_LENGTH
+#define AVTP_AAF_FIELD_FORMAT AVTP_PCM_FIELD_FORMAT
+#define AVTP_AAF_FIELD_NSR AVTP_PCM_FIELD_NSR
+#define AVTP_AAF_FIELD_CHAN_PER_FRAME AVTP_PCM_FIELD_CHANNELS_PER_FRAME
+#define AVTP_AAF_FIELD_BIT_DEPTH AVTP_PCM_FIELD_BIT_DEPTH
+#define AVTP_AAF_FIELD_SP AVTP_PCM_FIELD_SP
+#define AVTP_AAF_FIELD_EVT AVTP_PCM_FIELD_EVT
+#define AVTP_AAF_FIELD_MAX AVTP_PCM_FIELD_MAX
 
 /**
  * @deprecated
@@ -194,8 +192,7 @@ void Avtp_Pcm_SetEvt(Avtp_Pcm_t* pdu, uint8_t value);
  *    0: Success.
  *    -EINVAL: If any argument is invalid.
  */
-int avtp_aaf_pdu_get(const void * const pdu,
-                Avtp_PcmFields_t field, uint64_t *val);
+int avtp_aaf_pdu_get(const void *const pdu, Avtp_PcmFields_t field, uint64_t *val);
 
 /**
  * @deprecated
@@ -208,8 +205,7 @@ int avtp_aaf_pdu_get(const void * const pdu,
  *    0: Success.
  *    -EINVAL: If any argument is invalid.
  */
-int avtp_aaf_pdu_set(void *pdu, Avtp_PcmFields_t field,
-                                uint64_t val);
+int avtp_aaf_pdu_set(void *pdu, Avtp_PcmFields_t field, uint64_t val);
 
 /**
  * @deprecated

--- a/include/avtp/acf/Ntscf.h
+++ b/include/avtp/acf/Ntscf.h
@@ -103,17 +103,6 @@ OPEN1722_INLINE bool Avtp_Ntscf_IsSv(const Avtp_Ntscf_t *const pdu)
 }
 
 /**
- * Return the value of an an NTSCF PDU version field as specified in the IEEE 1722 Specification.
- *
- * @param pdu Pointer to the first bit of an 1722 ACF Ntscf PDU.
- * @returns Value of the NTSCF PDU version field.
- */
-OPEN1722_INLINE uint8_t Avtp_Ntscf_GetVersion(const Avtp_Ntscf_t *const pdu)
-{
-    return (uint8_t)GET_NTSCF_FIELD(AVTP_NTSCF_FIELD_VERSION);
-}
-
-/**
  * Return the value of an an NTSCF PDU Ntscf Data Length field as specified in the IEEE 1722
  * Specification.
  *
@@ -157,17 +146,6 @@ OPEN1722_INLINE uint64_t Avtp_Ntscf_GetStreamId(const Avtp_Ntscf_t *const pdu)
 OPEN1722_INLINE void Avtp_Ntscf_SetSv(Avtp_Ntscf_t *pdu, bool sv)
 {
     SET_NTSCF_FIELD(AVTP_NTSCF_FIELD_SV, sv);
-}
-
-/**
- * Set the value of an an NTSCF PDU version field as specified in the IEEE 1722 Specification.
- *
- * @param pdu Pointer to the first bit of an 1722 ACF Ntscf PDU.
- * @param value Value to set the NTSCF PDU version field to.
- */
-OPEN1722_INLINE void Avtp_Ntscf_SetVersion(Avtp_Ntscf_t *pdu, uint8_t value)
-{
-    SET_NTSCF_FIELD(AVTP_NTSCF_FIELD_VERSION, value);
 }
 
 /**

--- a/include/avtp/acf/Ntscf.h
+++ b/include/avtp/acf/Ntscf.h
@@ -92,17 +92,6 @@ static const Avtp_FieldDescriptor_t Avtp_NtscfFieldDesc[AVTP_NTSCF_FIELD_MAX] = 
 };
 
 /**
- * Return the value of an an NTSCF PDU subtype field as specified in the IEEE 1722 Specification.
- *
- * @param pdu Pointer to the first bit of an 1722 ACF Ntscf PDU.
- * @returns Value of the NTSCF PDU subtype field.
- */
-OPEN1722_INLINE uint8_t Avtp_Ntscf_GetSubtype(const Avtp_Ntscf_t *const pdu)
-{
-    return (uint8_t)GET_NTSCF_FIELD(AVTP_NTSCF_FIELD_SUBTYPE);
-}
-
-/**
  * Return the value of an an NTSCF PDU SV field as specified in the IEEE 1722 Specification.
  *
  * @param pdu Pointer to the first bit of an 1722 ACF Ntscf PDU.
@@ -157,17 +146,6 @@ OPEN1722_INLINE uint8_t Avtp_Ntscf_GetSequenceNum(const Avtp_Ntscf_t *const pdu)
 OPEN1722_INLINE uint64_t Avtp_Ntscf_GetStreamId(const Avtp_Ntscf_t *const pdu)
 {
     return (uint64_t)GET_NTSCF_FIELD(AVTP_NTSCF_FIELD_STREAM_ID);
-}
-
-/**
- * Set the value of an an NTSCF PDU subtype field as specified in the IEEE 1722 Specification.
- *
- * @param pdu Pointer to the first bit of an 1722 ACF Ntscf PDU.
- * @param value Value to set the NTSCF PDU subtype field to.
- */
-OPEN1722_INLINE void Avtp_Ntscf_SetSubtype(Avtp_Ntscf_t *pdu, uint8_t value)
-{
-    SET_NTSCF_FIELD(AVTP_NTSCF_FIELD_SUBTYPE, value);
 }
 
 /**
@@ -245,7 +223,7 @@ OPEN1722_INLINE bool Avtp_Ntscf_IsValid(const Avtp_Ntscf_t *const pdu, size_t bu
         return false;
     }
 
-    if (Avtp_Ntscf_GetSubtype(pdu) != AVTP_SUBTYPE_NTSCF) {
+    if (Avtp_CommonHeader_GetSubtype((const Avtp_CommonHeader_t *)pdu) != AVTP_SUBTYPE_NTSCF) {
         return false;
     }
 
@@ -267,7 +245,7 @@ OPEN1722_INLINE void Avtp_Ntscf_Init(Avtp_Ntscf_t *pdu)
 {
     if (pdu != NULL) {
         memset(pdu, 0, sizeof(Avtp_Ntscf_t));
-        Avtp_Ntscf_SetSubtype(pdu, AVTP_SUBTYPE_NTSCF);
+        Avtp_CommonHeader_SetSubtype((Avtp_CommonHeader_t *)pdu, AVTP_SUBTYPE_NTSCF);
         Avtp_Ntscf_SetSv(pdu, true);
     }
 }

--- a/include/avtp/acf/Tscf.h
+++ b/include/avtp/acf/Tscf.h
@@ -110,17 +110,6 @@ static const Avtp_FieldDescriptor_t Avtp_TscfFieldDesc[AVTP_TSCF_FIELD_MAX] = {
 };
 
 /**
- * Return the value of an an TSCF PDU subtype field as specified in the IEEE 1722 Specification.
- *
- * @param pdu Pointer to the first bit of an 1722 ACF TSCF PDU.
- * @returns Value of the TSCF PDU subtype field.
- */
-OPEN1722_INLINE uint8_t Avtp_Tscf_GetSubtype(const Avtp_Tscf_t *const pdu)
-{
-    return (uint8_t)GET_TSCF_FIELD(AVTP_TSCF_FIELD_SUBTYPE);
-}
-
-/**
  * Return the value of an an TSCF PDU SV field as specified in the IEEE 1722 Specification.
  *
  * @param pdu Pointer to the first bit of an 1722 ACF TSCF PDU.
@@ -220,17 +209,6 @@ OPEN1722_INLINE uint32_t Avtp_Tscf_GetAvtpTimestamp(const Avtp_Tscf_t *const pdu
 OPEN1722_INLINE uint16_t Avtp_Tscf_GetStreamDataLength(const Avtp_Tscf_t *const pdu)
 {
     return (uint16_t)GET_TSCF_FIELD(AVTP_TSCF_FIELD_STREAM_DATA_LENGTH);
-}
-
-/**
- * Set the value of an an TSCF PDU subtype field as specified in the IEEE 1722 Specification.
- *
- * @param pdu Pointer to the first bit of an 1722 ACF TSCF PDU.
- * @param value Value to set the TSCF PDU subtype field to.
- */
-OPEN1722_INLINE void Avtp_Tscf_SetSubtype(Avtp_Tscf_t *pdu, uint8_t value)
-{
-    SET_TSCF_FIELD(AVTP_TSCF_FIELD_SUBTYPE, value);
 }
 
 /**
@@ -352,7 +330,7 @@ OPEN1722_INLINE bool Avtp_Tscf_IsValid(const Avtp_Tscf_t *const pdu, size_t buff
         return false;
     }
 
-    if (Avtp_Tscf_GetSubtype(pdu) != AVTP_SUBTYPE_TSCF) {
+    if (Avtp_CommonHeader_GetSubtype((const Avtp_CommonHeader_t *)pdu) != AVTP_SUBTYPE_TSCF) {
         return false;
     }
 
@@ -374,7 +352,7 @@ OPEN1722_INLINE void Avtp_Tscf_Init(Avtp_Tscf_t *pdu)
 {
     if (pdu != NULL) {
         memset(pdu, 0, sizeof(Avtp_Tscf_t));
-        Avtp_Tscf_SetSubtype(pdu, AVTP_SUBTYPE_TSCF);
+        Avtp_CommonHeader_SetSubtype((Avtp_CommonHeader_t *)pdu, AVTP_SUBTYPE_TSCF);
         Avtp_Tscf_SetSv(pdu, true);
     }
 }

--- a/include/avtp/acf/Tscf.h
+++ b/include/avtp/acf/Tscf.h
@@ -121,17 +121,6 @@ OPEN1722_INLINE bool Avtp_Tscf_IsSv(const Avtp_Tscf_t *const pdu)
 }
 
 /**
- * Return the value of an an TSCF PDU version field as specified in the IEEE 1722 Specification.
- *
- * @param pdu Pointer to the first bit of an 1722 ACF TSCF PDU.
- * @returns Value of the TSCF PDU version field.
- */
-OPEN1722_INLINE uint8_t Avtp_Tscf_GetVersion(const Avtp_Tscf_t *const pdu)
-{
-    return (uint8_t)GET_TSCF_FIELD(AVTP_TSCF_FIELD_VERSION);
-}
-
-/**
  * Return the value of an an TSCF PDU MR field as specified in the IEEE 1722 Specification.
  *
  * @param pdu Pointer to the first bit of an 1722 ACF TSCF PDU.
@@ -220,17 +209,6 @@ OPEN1722_INLINE uint16_t Avtp_Tscf_GetStreamDataLength(const Avtp_Tscf_t *const 
 OPEN1722_INLINE void Avtp_Tscf_SetSv(Avtp_Tscf_t *pdu, bool sv)
 {
     SET_TSCF_FIELD(AVTP_TSCF_FIELD_SV, sv);
-}
-
-/**
- * Set the value of an an TSCF PDU version field as specified in the IEEE 1722 Specification.
- *
- * @param pdu Pointer to the first bit of an 1722 ACF TSCF PDU.
- * @param value Value to set the TSCF PDU version field to.
- */
-OPEN1722_INLINE void Avtp_Tscf_SetVersion(Avtp_Tscf_t *pdu, uint8_t value)
-{
-    SET_TSCF_FIELD(AVTP_TSCF_FIELD_VERSION, value);
 }
 
 /**

--- a/include/avtp/cvf/Cvf.h
+++ b/include/avtp/cvf/Cvf.h
@@ -70,59 +70,55 @@ typedef enum Avtp_CvfField {
     AVTP_CVF_FIELD_MAX
 } Avtp_CvfField_t;
 
-typedef enum Avtp_CvfFormat {
-    AVTP_CVF_FORMAT_RFC                 = 0x2
-} Avtp_CvfFormat_t;
+typedef enum Avtp_CvfFormat { AVTP_CVF_FORMAT_RFC = 0x2 } Avtp_CvfFormat_t;
 
 typedef enum Avtp_CvfFormatSubtype {
-    AVTP_CVF_FORMAT_SUBTYPE_MJPEG       = 0x0,
-    AVTP_CVF_FORMAT_SUBTYPE_H264        = 0x1,
-    AVTP_CVF_FORMAT_SUBTYPE_JPEG2000    = 0x2
+    AVTP_CVF_FORMAT_SUBTYPE_MJPEG = 0x0,
+    AVTP_CVF_FORMAT_SUBTYPE_H264 = 0x1,
+    AVTP_CVF_FORMAT_SUBTYPE_JPEG2000 = 0x2
 } Avtp_CvfFormatSubtype_t;
 
-void Avtp_Cvf_Init(Avtp_Cvf_t* pdu);
+void Avtp_Cvf_Init(Avtp_Cvf_t *pdu);
 
-uint64_t Avtp_Cvf_GetField(const Avtp_Cvf_t* const pdu, Avtp_CvfField_t field);
+uint64_t Avtp_Cvf_GetField(const Avtp_Cvf_t *const pdu, Avtp_CvfField_t field);
 
-uint8_t Avtp_Cvf_GetSubtype(const Avtp_Cvf_t* const pdu);
-uint8_t Avtp_Cvf_GetSv(const Avtp_Cvf_t* const pdu);
-uint8_t Avtp_Cvf_GetVersion(const Avtp_Cvf_t* const pdu);
-uint8_t Avtp_Cvf_GetMr(const Avtp_Cvf_t* const pdu);
-uint8_t Avtp_Cvf_GetTv(const Avtp_Cvf_t* const pdu);
-uint8_t Avtp_Cvf_GetSequenceNum(const Avtp_Cvf_t* const pdu);
-uint8_t Avtp_Cvf_GetTu(const Avtp_Cvf_t* const pdu);
-uint64_t Avtp_Cvf_GetStreamId(const Avtp_Cvf_t* const pdu);
-uint32_t Avtp_Cvf_GetAvtpTimestamp(const Avtp_Cvf_t* const pdu);
-Avtp_CvfFormat_t Avtp_Cvf_GetFormat(const Avtp_Cvf_t* const pdu);
-Avtp_CvfFormatSubtype_t Avtp_Cvf_GetFormatSubtype(const Avtp_Cvf_t* const pdu);
-uint16_t Avtp_Cvf_GetStreamDataLength(const Avtp_Cvf_t* const pdu);
-uint8_t Avtp_Cvf_GetPtv(const Avtp_Cvf_t* const pdu);
-uint8_t Avtp_Cvf_GetM(const Avtp_Cvf_t* const pdu);
-uint8_t Avtp_Cvf_GetEvt(const Avtp_Cvf_t* const pdu);
+uint8_t Avtp_Cvf_GetSv(const Avtp_Cvf_t *const pdu);
+uint8_t Avtp_Cvf_GetVersion(const Avtp_Cvf_t *const pdu);
+uint8_t Avtp_Cvf_GetMr(const Avtp_Cvf_t *const pdu);
+uint8_t Avtp_Cvf_GetTv(const Avtp_Cvf_t *const pdu);
+uint8_t Avtp_Cvf_GetSequenceNum(const Avtp_Cvf_t *const pdu);
+uint8_t Avtp_Cvf_GetTu(const Avtp_Cvf_t *const pdu);
+uint64_t Avtp_Cvf_GetStreamId(const Avtp_Cvf_t *const pdu);
+uint32_t Avtp_Cvf_GetAvtpTimestamp(const Avtp_Cvf_t *const pdu);
+Avtp_CvfFormat_t Avtp_Cvf_GetFormat(const Avtp_Cvf_t *const pdu);
+Avtp_CvfFormatSubtype_t Avtp_Cvf_GetFormatSubtype(const Avtp_Cvf_t *const pdu);
+uint16_t Avtp_Cvf_GetStreamDataLength(const Avtp_Cvf_t *const pdu);
+uint8_t Avtp_Cvf_GetPtv(const Avtp_Cvf_t *const pdu);
+uint8_t Avtp_Cvf_GetM(const Avtp_Cvf_t *const pdu);
+uint8_t Avtp_Cvf_GetEvt(const Avtp_Cvf_t *const pdu);
 
-void Avtp_Cvf_SetField(Avtp_Cvf_t* pdu, Avtp_CvfField_t field, uint64_t value);
+void Avtp_Cvf_SetField(Avtp_Cvf_t *pdu, Avtp_CvfField_t field, uint64_t value);
 
-void Avtp_Cvf_SetSubtype(Avtp_Cvf_t* pdu, uint8_t value);
-void Avtp_Cvf_EnableSv(Avtp_Cvf_t* pdu);
-void Avtp_Cvf_DisableSv(Avtp_Cvf_t* pdu);
-void Avtp_Cvf_SetVersion(Avtp_Cvf_t* pdu, uint8_t value);
-void Avtp_Cvf_EnableMr(Avtp_Cvf_t* pdu);
-void Avtp_Cvf_DisableMr(Avtp_Cvf_t* pdu);
-void Avtp_Cvf_EnableTv(Avtp_Cvf_t* pdu);
-void Avtp_Cvf_DisableTv(Avtp_Cvf_t* pdu);
-void Avtp_Cvf_SetSequenceNum(Avtp_Cvf_t* pdu, uint8_t value);
-void Avtp_Cvf_EnableTu(Avtp_Cvf_t* pdu);
-void Avtp_Cvf_DisableTu(Avtp_Cvf_t* pdu);
-void Avtp_Cvf_SetStreamId(Avtp_Cvf_t* pdu, uint64_t value);
-void Avtp_Cvf_SetAvtpTimestamp(Avtp_Cvf_t* pdu, uint32_t value);
-void Avtp_Cvf_SetFormat(Avtp_Cvf_t* pdu, Avtp_CvfFormat_t value);
-void Avtp_Cvf_SetFormatSubtype(Avtp_Cvf_t* pdu, Avtp_CvfFormatSubtype_t value);
-void Avtp_Cvf_SetStreamDataLength(Avtp_Cvf_t* pdu, uint16_t value);
-void Avtp_Cvf_EnablePtv(Avtp_Cvf_t* pdu);
-void Avtp_Cvf_DisablePtv(Avtp_Cvf_t* pdu);
-void Avtp_Cvf_EnableM(Avtp_Cvf_t* pdu);
-void Avtp_Cvf_DisableM(Avtp_Cvf_t* pdu);
-void Avtp_Cvf_SetEvt(Avtp_Cvf_t* pdu, uint8_t value);
+void Avtp_Cvf_EnableSv(Avtp_Cvf_t *pdu);
+void Avtp_Cvf_DisableSv(Avtp_Cvf_t *pdu);
+void Avtp_Cvf_SetVersion(Avtp_Cvf_t *pdu, uint8_t value);
+void Avtp_Cvf_EnableMr(Avtp_Cvf_t *pdu);
+void Avtp_Cvf_DisableMr(Avtp_Cvf_t *pdu);
+void Avtp_Cvf_EnableTv(Avtp_Cvf_t *pdu);
+void Avtp_Cvf_DisableTv(Avtp_Cvf_t *pdu);
+void Avtp_Cvf_SetSequenceNum(Avtp_Cvf_t *pdu, uint8_t value);
+void Avtp_Cvf_EnableTu(Avtp_Cvf_t *pdu);
+void Avtp_Cvf_DisableTu(Avtp_Cvf_t *pdu);
+void Avtp_Cvf_SetStreamId(Avtp_Cvf_t *pdu, uint64_t value);
+void Avtp_Cvf_SetAvtpTimestamp(Avtp_Cvf_t *pdu, uint32_t value);
+void Avtp_Cvf_SetFormat(Avtp_Cvf_t *pdu, Avtp_CvfFormat_t value);
+void Avtp_Cvf_SetFormatSubtype(Avtp_Cvf_t *pdu, Avtp_CvfFormatSubtype_t value);
+void Avtp_Cvf_SetStreamDataLength(Avtp_Cvf_t *pdu, uint16_t value);
+void Avtp_Cvf_EnablePtv(Avtp_Cvf_t *pdu);
+void Avtp_Cvf_DisablePtv(Avtp_Cvf_t *pdu);
+void Avtp_Cvf_EnableM(Avtp_Cvf_t *pdu);
+void Avtp_Cvf_DisableM(Avtp_Cvf_t *pdu);
+void Avtp_Cvf_SetEvt(Avtp_Cvf_t *pdu, uint8_t value);
 
 /******************************************************************************
  * Legacy API (deprecated)
@@ -131,17 +127,17 @@ void Avtp_Cvf_SetEvt(Avtp_Cvf_t* pdu, uint8_t value);
 /**
  * @deprecated
  */
-int avtp_cvf_pdu_get(const void* const pdu, Avtp_CvfField_t field, uint64_t *val);
+int avtp_cvf_pdu_get(const void *const pdu, Avtp_CvfField_t field, uint64_t *val);
 
 /**
  * @deprecated
  */
-int avtp_cvf_pdu_set(void* pdu, Avtp_CvfField_t field, uint64_t val);
+int avtp_cvf_pdu_set(void *pdu, Avtp_CvfField_t field, uint64_t val);
 
 /**
  * @deprecated
  */
-int avtp_cvf_pdu_init(void* pdu, uint8_t format_subtype);
+int avtp_cvf_pdu_init(void *pdu, uint8_t format_subtype);
 
 #ifdef __cplusplus
 }

--- a/include/avtp/cvf/Cvf.h
+++ b/include/avtp/cvf/Cvf.h
@@ -83,7 +83,6 @@ void Avtp_Cvf_Init(Avtp_Cvf_t *pdu);
 uint64_t Avtp_Cvf_GetField(const Avtp_Cvf_t *const pdu, Avtp_CvfField_t field);
 
 uint8_t Avtp_Cvf_GetSv(const Avtp_Cvf_t *const pdu);
-uint8_t Avtp_Cvf_GetVersion(const Avtp_Cvf_t *const pdu);
 uint8_t Avtp_Cvf_GetMr(const Avtp_Cvf_t *const pdu);
 uint8_t Avtp_Cvf_GetTv(const Avtp_Cvf_t *const pdu);
 uint8_t Avtp_Cvf_GetSequenceNum(const Avtp_Cvf_t *const pdu);
@@ -101,7 +100,6 @@ void Avtp_Cvf_SetField(Avtp_Cvf_t *pdu, Avtp_CvfField_t field, uint64_t value);
 
 void Avtp_Cvf_EnableSv(Avtp_Cvf_t *pdu);
 void Avtp_Cvf_DisableSv(Avtp_Cvf_t *pdu);
-void Avtp_Cvf_SetVersion(Avtp_Cvf_t *pdu, uint8_t value);
 void Avtp_Cvf_EnableMr(Avtp_Cvf_t *pdu);
 void Avtp_Cvf_DisableMr(Avtp_Cvf_t *pdu);
 void Avtp_Cvf_EnableTv(Avtp_Cvf_t *pdu);

--- a/src/avtp/Crf.c
+++ b/src/avtp/Crf.c
@@ -65,7 +65,7 @@ void Avtp_Crf_Init(Avtp_Crf_t *pdu)
 {
     if (pdu != NULL) {
         memset(pdu, 0, sizeof(Avtp_Crf_t));
-        Avtp_Crf_SetField(pdu, AVTP_CRF_FIELD_SUBTYPE, AVTP_SUBTYPE_CRF);
+        Avtp_CommonHeader_SetSubtype((Avtp_CommonHeader_t *)pdu, AVTP_SUBTYPE_CRF);
         Avtp_Crf_SetField(pdu, AVTP_CRF_FIELD_SV, 1);
     }
 }
@@ -73,11 +73,6 @@ void Avtp_Crf_Init(Avtp_Crf_t *pdu)
 uint64_t Avtp_Crf_GetField(const Avtp_Crf_t *const pdu, Avtp_CrfField_t field)
 {
     return GET_FIELD(field);
-}
-
-uint8_t Avtp_Crf_GetSubtype(const Avtp_Crf_t *const pdu)
-{
-    return (uint8_t)GET_FIELD(AVTP_CRF_FIELD_SUBTYPE);
 }
 
 uint8_t Avtp_Crf_GetSv(const Avtp_Crf_t *const pdu)
@@ -143,11 +138,6 @@ uint16_t Avtp_Crf_GetTimestampInterval(const Avtp_Crf_t *const pdu)
 void Avtp_Crf_SetField(Avtp_Crf_t *pdu, Avtp_CrfField_t field, uint64_t value)
 {
     SET_FIELD(field, value);
-}
-
-void Avtp_Crf_SetSubtype(Avtp_Crf_t *pdu, uint8_t value)
-{
-    SET_FIELD(AVTP_CRF_FIELD_SUBTYPE, value);
 }
 
 void Avtp_Crf_EnableSv(Avtp_Crf_t *pdu)

--- a/src/avtp/Crf.c
+++ b/src/avtp/Crf.c
@@ -80,11 +80,6 @@ uint8_t Avtp_Crf_GetSv(const Avtp_Crf_t *const pdu)
     return (uint8_t)GET_FIELD(AVTP_CRF_FIELD_SV);
 }
 
-uint8_t Avtp_Crf_GetVersion(const Avtp_Crf_t *const pdu)
-{
-    return (uint8_t)GET_FIELD(AVTP_CRF_FIELD_VERSION);
-}
-
 uint8_t Avtp_Crf_GetMr(const Avtp_Crf_t *const pdu)
 {
     return (uint8_t)GET_FIELD(AVTP_CRF_FIELD_MR);
@@ -148,11 +143,6 @@ void Avtp_Crf_EnableSv(Avtp_Crf_t *pdu)
 void Avtp_Crf_DisableSv(Avtp_Crf_t *pdu)
 {
     SET_FIELD(AVTP_CRF_FIELD_SV, 0);
-}
-
-void Avtp_Crf_SetVersion(Avtp_Crf_t *pdu, uint8_t value)
-{
-    SET_FIELD(AVTP_CRF_FIELD_VERSION, value);
 }
 
 void Avtp_Crf_EnableMr(Avtp_Crf_t *pdu)

--- a/src/avtp/Rvf.c
+++ b/src/avtp/Rvf.c
@@ -83,7 +83,7 @@ void Avtp_Rvf_Init(Avtp_Rvf_t *pdu)
 {
     if (pdu != NULL) {
         memset(pdu, 0, sizeof(Avtp_Rvf_t));
-        Avtp_Rvf_SetField(pdu, AVTP_RVF_FIELD_SUBTYPE, AVTP_SUBTYPE_RVF);
+        Avtp_CommonHeader_SetSubtype((Avtp_CommonHeader_t *)pdu, AVTP_SUBTYPE_RVF);
         Avtp_Rvf_SetField(pdu, AVTP_RVF_FIELD_SV, 1);
     }
 }
@@ -91,11 +91,6 @@ void Avtp_Rvf_Init(Avtp_Rvf_t *pdu)
 uint64_t Avtp_Rvf_GetField(const Avtp_Rvf_t *const pdu, Avtp_RvfField_t field)
 {
     return GET_FIELD(field);
-}
-
-uint8_t Avtp_Rvf_GetSubtype(const Avtp_Rvf_t *const pdu)
-{
-    return (uint8_t)GET_FIELD(AVTP_RVF_FIELD_SUBTYPE);
 }
 
 uint8_t Avtp_Rvf_GetSv(const Avtp_Rvf_t *const pdu)
@@ -221,11 +216,6 @@ uint16_t Avtp_Rvf_GetLineNumber(const Avtp_Rvf_t *const pdu)
 void Avtp_Rvf_SetField(Avtp_Rvf_t *pdu, Avtp_RvfField_t field, uint64_t value)
 {
     SET_FIELD(field, value);
-}
-
-void Avtp_Rvf_SetSubtype(Avtp_Rvf_t *pdu, uint8_t value)
-{
-    SET_FIELD(AVTP_RVF_FIELD_SUBTYPE, value);
 }
 
 void Avtp_Rvf_EnableSv(Avtp_Rvf_t *pdu)

--- a/src/avtp/Rvf.c
+++ b/src/avtp/Rvf.c
@@ -98,11 +98,6 @@ uint8_t Avtp_Rvf_GetSv(const Avtp_Rvf_t *const pdu)
     return (uint8_t)GET_FIELD(AVTP_RVF_FIELD_SV);
 }
 
-uint8_t Avtp_Rvf_GetVersion(const Avtp_Rvf_t *const pdu)
-{
-    return (uint8_t)GET_FIELD(AVTP_RVF_FIELD_VERSION);
-}
-
 uint8_t Avtp_Rvf_GetMr(const Avtp_Rvf_t *const pdu)
 {
     return (uint8_t)GET_FIELD(AVTP_RVF_FIELD_MR);
@@ -226,11 +221,6 @@ void Avtp_Rvf_EnableSv(Avtp_Rvf_t *pdu)
 void Avtp_Rvf_DisableSv(Avtp_Rvf_t *pdu)
 {
     SET_FIELD(AVTP_RVF_FIELD_SV, 0);
-}
-
-void Avtp_Rvf_SetVersion(Avtp_Rvf_t *pdu, uint8_t value)
-{
-    SET_FIELD(AVTP_RVF_FIELD_VERSION, value);
 }
 
 void Avtp_Rvf_EnableMr(Avtp_Rvf_t *pdu)

--- a/src/avtp/aaf/Aaf.c
+++ b/src/avtp/aaf/Aaf.c
@@ -63,11 +63,6 @@ uint64_t Avtp_Aaf_GetField(const Avtp_Aaf_t *const pdu, Avtp_AafFields_t field)
                          (uint8_t)field);
 }
 
-uint8_t Avtp_Aaf_GetSubtype(const Avtp_Aaf_t *const pdu)
-{
-    return (uint8_t)GET_FIELD(AVTP_AAF_FIELD_SUBTYPE);
-}
-
 uint8_t Avtp_Aaf_GetSv(const Avtp_Aaf_t *const pdu)
 {
     return (uint8_t)GET_FIELD(AVTP_AAF_FIELD_SV);
@@ -136,11 +131,6 @@ uint8_t Avtp_Aaf_GetEvt(const Avtp_Aaf_t *const pdu)
 void Avtp_Aaf_SetField(Avtp_Aaf_t *pdu, Avtp_AafFields_t field, uint64_t value)
 {
     Avtp_SetField(Avtp_AafFieldDesc, AVTP_AAF_FIELD_MAX, (uint8_t *)pdu, (uint8_t)field, value);
-}
-
-void Avtp_Aaf_SetSubtype(Avtp_Aaf_t *pdu, uint8_t value)
-{
-    SET_FIELD(AVTP_AAF_FIELD_SUBTYPE, value);
 }
 
 void Avtp_Aaf_EnableSv(Avtp_Aaf_t *pdu)

--- a/src/avtp/aaf/Aaf.c
+++ b/src/avtp/aaf/Aaf.c
@@ -68,11 +68,6 @@ uint8_t Avtp_Aaf_GetSv(const Avtp_Aaf_t *const pdu)
     return (uint8_t)GET_FIELD(AVTP_AAF_FIELD_SV);
 }
 
-uint8_t Avtp_Aaf_GetVersion(const Avtp_Aaf_t *const pdu)
-{
-    return (uint8_t)GET_FIELD(AVTP_AAF_FIELD_VERSION);
-}
-
 uint8_t Avtp_Aaf_GetMr(const Avtp_Aaf_t *const pdu)
 {
     return (uint8_t)GET_FIELD(AVTP_AAF_FIELD_MR);
@@ -141,11 +136,6 @@ void Avtp_Aaf_EnableSv(Avtp_Aaf_t *pdu)
 void Avtp_Aaf_DisableSv(Avtp_Aaf_t *pdu)
 {
     SET_FIELD(AVTP_AAF_FIELD_SV, 0);
-}
-
-void Avtp_Aaf_SetVersion(Avtp_Aaf_t *pdu, uint8_t value)
-{
-    SET_FIELD(AVTP_AAF_FIELD_VERSION, value);
 }
 
 void Avtp_Aaf_EnableMr(Avtp_Aaf_t *pdu)

--- a/src/avtp/aaf/Pcm.c
+++ b/src/avtp/aaf/Pcm.c
@@ -63,7 +63,7 @@ void Avtp_Pcm_Init(Avtp_Pcm_t *pdu)
 {
     if (pdu != NULL) {
         memset(pdu, 0, sizeof(Avtp_Pcm_t));
-        Avtp_Pcm_SetField(pdu, AVTP_PCM_FIELD_SUBTYPE, AVTP_SUBTYPE_AAF);
+        Avtp_CommonHeader_SetSubtype((Avtp_CommonHeader_t *)pdu, AVTP_SUBTYPE_AAF);
         Avtp_Pcm_SetField(pdu, AVTP_PCM_FIELD_SV, 1);
     }
 }
@@ -71,11 +71,6 @@ void Avtp_Pcm_Init(Avtp_Pcm_t *pdu)
 uint64_t Avtp_Pcm_GetField(const Avtp_Pcm_t *const pdu, Avtp_PcmFields_t field)
 {
     return GET_FIELD(field);
-}
-
-uint8_t Avtp_Pcm_GetSubtype(const Avtp_Pcm_t *const pdu)
-{
-    return (uint8_t)GET_FIELD(AVTP_PCM_FIELD_SUBTYPE);
 }
 
 uint8_t Avtp_Pcm_GetSv(const Avtp_Pcm_t *const pdu)
@@ -156,11 +151,6 @@ uint8_t Avtp_Pcm_GetEvt(const Avtp_Pcm_t *const pdu)
 void Avtp_Pcm_SetField(Avtp_Pcm_t *pdu, Avtp_PcmFields_t field, uint64_t value)
 {
     SET_FIELD(field, value);
-}
-
-void Avtp_Pcm_SetSubtype(Avtp_Pcm_t *pdu, uint8_t value)
-{
-    SET_FIELD(AVTP_PCM_FIELD_SUBTYPE, value);
 }
 
 void Avtp_Pcm_EnableSv(Avtp_Pcm_t *pdu)

--- a/src/avtp/aaf/Pcm.c
+++ b/src/avtp/aaf/Pcm.c
@@ -78,11 +78,6 @@ uint8_t Avtp_Pcm_GetSv(const Avtp_Pcm_t *const pdu)
     return (uint8_t)GET_FIELD(AVTP_PCM_FIELD_SV);
 }
 
-uint8_t Avtp_Pcm_GetVersion(const Avtp_Pcm_t *const pdu)
-{
-    return (uint8_t)GET_FIELD(AVTP_PCM_FIELD_VERSION);
-}
-
 uint8_t Avtp_Pcm_GetMr(const Avtp_Pcm_t *const pdu)
 {
     return (uint8_t)GET_FIELD(AVTP_PCM_FIELD_MR);
@@ -161,11 +156,6 @@ void Avtp_Pcm_EnableSv(Avtp_Pcm_t *pdu)
 void Avtp_Pcm_DisableSv(Avtp_Pcm_t *pdu)
 {
     SET_FIELD(AVTP_PCM_FIELD_SV, 0);
-}
-
-void Avtp_Pcm_SetVersion(Avtp_Pcm_t *pdu, uint8_t value)
-{
-    SET_FIELD(AVTP_PCM_FIELD_VERSION, value);
 }
 
 void Avtp_Pcm_EnableMr(Avtp_Pcm_t *pdu)

--- a/src/avtp/cvf/Cvf.c
+++ b/src/avtp/cvf/Cvf.c
@@ -82,11 +82,6 @@ uint8_t Avtp_Cvf_GetSv(const Avtp_Cvf_t *const pdu)
     return (uint8_t)GET_FIELD(AVTP_CVF_FIELD_SV);
 }
 
-uint8_t Avtp_Cvf_GetVersion(const Avtp_Cvf_t *const pdu)
-{
-    return (uint8_t)GET_FIELD(AVTP_CVF_FIELD_VERSION);
-}
-
 uint8_t Avtp_Cvf_GetMr(const Avtp_Cvf_t *const pdu)
 {
     return (uint8_t)GET_FIELD(AVTP_CVF_FIELD_MR);
@@ -160,11 +155,6 @@ void Avtp_Cvf_EnableSv(Avtp_Cvf_t *pdu)
 void Avtp_Cvf_DisableSv(Avtp_Cvf_t *pdu)
 {
     SET_FIELD(AVTP_CVF_FIELD_SV, 0);
-}
-
-void Avtp_Cvf_SetVersion(Avtp_Cvf_t *pdu, uint8_t value)
-{
-    SET_FIELD(AVTP_CVF_FIELD_VERSION, value);
 }
 
 void Avtp_Cvf_EnableMr(Avtp_Cvf_t *pdu)

--- a/src/avtp/cvf/Cvf.c
+++ b/src/avtp/cvf/Cvf.c
@@ -66,7 +66,7 @@ void Avtp_Cvf_Init(Avtp_Cvf_t *pdu)
 {
     if (pdu != NULL) {
         memset(pdu, 0, sizeof(Avtp_Cvf_t));
-        Avtp_Cvf_SetField(pdu, AVTP_CVF_FIELD_SUBTYPE, AVTP_SUBTYPE_CVF);
+        Avtp_CommonHeader_SetSubtype((Avtp_CommonHeader_t *)pdu, AVTP_SUBTYPE_CVF);
         Avtp_Cvf_SetField(pdu, AVTP_CVF_FIELD_FORMAT, AVTP_CVF_FORMAT_RFC);
         Avtp_Cvf_EnableSv(pdu);
     }
@@ -75,11 +75,6 @@ void Avtp_Cvf_Init(Avtp_Cvf_t *pdu)
 uint64_t Avtp_Cvf_GetField(const Avtp_Cvf_t *const pdu, Avtp_CvfField_t field)
 {
     return GET_FIELD(field);
-}
-
-uint8_t Avtp_Cvf_GetSubtype(const Avtp_Cvf_t *const pdu)
-{
-    return (uint8_t)GET_FIELD(AVTP_CVF_FIELD_SUBTYPE);
 }
 
 uint8_t Avtp_Cvf_GetSv(const Avtp_Cvf_t *const pdu)
@@ -155,11 +150,6 @@ uint8_t Avtp_Cvf_GetEvt(const Avtp_Cvf_t *const pdu)
 void Avtp_Cvf_SetField(Avtp_Cvf_t *pdu, Avtp_CvfField_t field, uint64_t value)
 {
     SET_FIELD(field, value);
-}
-
-void Avtp_Cvf_SetSubtype(Avtp_Cvf_t *pdu, uint8_t value)
-{
-    SET_FIELD(AVTP_CVF_FIELD_SUBTYPE, value);
 }
 
 void Avtp_Cvf_EnableSv(Avtp_Cvf_t *pdu)


### PR DESCRIPTION
This fixes #183 

AVTP base frame defines subtype, h and version. So no need to duplicate code. 
H is special, as it is always in the same location but in common it is really a placeholder. The semantics can differ (e.g. becomes SV, stream valid in TSCF), so I kept the format specific accessors there

No test changes needed (granted outside ACF coverage is not too good), and it is a net-saving of code lines (even more then the diff implies, as some lines of docs have been added)