### PR TITLE
Update/harden CI

### DIFF
--- a/.github/workflows/build-all.yml
+++ b/.github/workflows/build-all.yml
@@ -7,11 +7,16 @@ on:
     branches: [main]
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   build:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v5
+      with:
+        persist-credentials: false
     - name: Install dependencies
       run: sudo apt update && sudo apt install -y meson libcmocka0 libcmocka-dev lcov
     - name: Run build_all.sh script

--- a/.github/workflows/build-linuxkernelmod.yml
+++ b/.github/workflows/build-linuxkernelmod.yml
@@ -7,14 +7,19 @@ on:
     branches: [main]
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   build:
     runs-on: ubuntu-latest
     env:
       CONFIG_ACF_CAN: m
-    
+
     steps:
     - uses: actions/checkout@v5
+      with:
+        persist-credentials: false
     - name: Install dependencies
       run: sudo apt update && sudo apt install -y meson libcmocka0 libcmocka-dev lcov
     - name: Patching license

--- a/.github/workflows/build-zephyr.yml
+++ b/.github/workflows/build-zephyr.yml
@@ -7,6 +7,9 @@ on:
     branches: [main]
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   acf-can-bridge:
     runs-on: ubuntu-latest
@@ -14,6 +17,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v5
+        with:
+          persist-credentials: false
 
       - name: Create West Workspace Directory
         run: mkdir west-ws && cp examples/acf-can/zephyr/west.yml west-ws/

--- a/.github/workflows/style.yml
+++ b/.github/workflows/style.yml
@@ -50,6 +50,6 @@ jobs:
         path: ~/.cache/pre-commit
         key: pre-commit-${{ runner.os }}-${{ hashFiles('.pre-commit-config.yaml') }}
     - name: Install pre-commit
-      run: python -m pip install pre-commit
+      run: python -m pip install pre-commit==4.6.2
     - name: Run pre-commit on changed files
       run: pre-commit run --show-diff-on-failure --color=always --from-ref origin/${{ github.base_ref }} --to-ref HEAD

--- a/.github/workflows/style.yml
+++ b/.github/workflows/style.yml
@@ -4,6 +4,9 @@ on:
   pull_request:
     branches: [main]
 
+permissions:
+  contents: read
+
 jobs:
   check-spdx-headers:
     name: Check SPDX headers
@@ -18,6 +21,7 @@ jobs:
       with:
         # required to grab the history of the PR
         fetch-depth: 0
+        persist-credentials: false
 
     - name: Get files changed in PR
       run: |
@@ -37,6 +41,7 @@ jobs:
     - uses: actions/checkout@v5
       with:
         fetch-depth: 0
+        persist-credentials: false
     - uses: actions/setup-python@v5
       with:
         python-version: '3.12'

--- a/.github/workflows/style.yml
+++ b/.github/workflows/style.yml
@@ -29,23 +29,22 @@ jobs:
         files: "${{ env.files }}"
         licenses: "${{ env.licenses }}"
 
-  format:
-    name: Check formatting
+  pre-commit:
+    name: Run pre-commit
 
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v5
       with:
         fetch-depth: 0
-    - name: Install clang-format
-      run: sudo apt update && sudo apt install -y clang-format
-    - name: Check formatting of changed C/H files
-      run: |
-        changed=$(git diff --name-only --diff-filter=d origin/${{ github.base_ref }}...HEAD \
-                  | grep -E '\.(c|h)$' || true)
-        if [ -n "$changed" ]; then
-          echo "Checking format for: $changed"
-          clang-format --dry-run --Werror $changed
-        else
-          echo "No C/H files changed — skipping format check"
-        fi
+    - uses: actions/setup-python@v5
+      with:
+        python-version: '3.12'
+    - uses: actions/cache@v4
+      with:
+        path: ~/.cache/pre-commit
+        key: pre-commit-${{ runner.os }}-${{ hashFiles('.pre-commit-config.yaml') }}
+    - name: Install pre-commit
+      run: python -m pip install pre-commit
+    - name: Run pre-commit on changed files
+      run: pre-commit run --show-diff-on-failure --color=always --from-ref origin/${{ github.base_ref }} --to-ref HEAD

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -29,8 +29,8 @@ This section includes general guidelines and recommendations for anyone interest
 
 Before committing, run the automatic style checks to make sure the code formatting matches
 what CI enforces. The repository provides a [pre-commit](https://pre-commit.com) configuration
-that uses a pinned version of clang-format (18.1.8) - the same version used by the CI style
-workflow (see `.github/workflows/style.yml`).
+that uses a pinned version of clang-format (18.1.8). CI runs the same pre-commit configuration
+on changed files (see `.github/workflows/style.yml`).
 
 To set it up once per clone:
 


### PR DESCRIPTION
CI improvements:

Run the same pre-commit hooks that run locally when installed them (that also replaces the "self-built" clang-format check as pre-commits deals with this)

Reduced the scope of the Github token, and do not persist it where not needed, to harden a bit against rogue actions/supply chain attacks